### PR TITLE
fix(contracts): add Unicode-compatible search for categories, tags, accounts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,7 @@ entity-name/
 - **Schema Location:** `packages/app/src/@generic/drizzle/db/schema.ts`
 - **Migration Generation:** `yarn db:generate` in packages/app
 - **Pattern:** Repository pattern with expert OOP classes
+- **After table changes in contracts:** Always run `cd packages/app && yarn db:generate` to generate migrations
 
 ### Repository Pattern
 
@@ -307,7 +308,23 @@ app/(main)/
    }
    ```
 
-6. **Prefer explicit JSX over array mapping for fixed-size arrays** - When rendering a known, fixed number of elements, write explicit JSX instead of creating arrays and mapping
+7. **Avoid unnecessary variables** - Only create variables when they add semantic meaning or improve readability. Inline expressions when the logic is self-explanatory.
+   ```typescript
+   // Good - Inlined, logic is clear
+   .set({ ...input, ...(isDefined(input.title) && { titleSearch: input.title.toLowerCase() }) })
+
+   // Bad - Unnecessary variable for simple conditional
+   const titleFields = isDefined(input.title) ? { titleSearch: input.title.toLowerCase() } : {};
+   .set({ ...input, ...titleFields })
+
+   // Good - Variable adds semantic meaning for complex logic
+   const isTransferBetweenOwnAccounts =
+       transaction.type === TransactionTypeEnum.TRANSFER &&
+       syncedAccountIds.has(transaction.fromAccountId) &&
+       syncedAccountIds.has(transaction.toAccountId);
+   ```
+
+8. **Prefer explicit JSX over array mapping for fixed-size arrays** - When rendering a known, fixed number of elements, write explicit JSX instead of creating arrays and mapping
    ```tsx
    // Good - Explicit and clear
    return (

--- a/packages/app/drizzle/0005_omniscient_jasper_sitwell.sql
+++ b/packages/app/drizzle/0005_omniscient_jasper_sitwell.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `accounts` ADD `title_search` text DEFAULT '' NOT NULL;--> statement-breakpoint
+ALTER TABLE `categories` ADD `title_search` text DEFAULT '' NOT NULL;--> statement-breakpoint
+ALTER TABLE `tags` ADD `title_search` text DEFAULT '' NOT NULL;--> statement-breakpoint
+UPDATE `accounts` SET `title_search` = LOWER(`title`);--> statement-breakpoint
+UPDATE `categories` SET `title_search` = LOWER(`title`);--> statement-breakpoint
+UPDATE `tags` SET `title_search` = LOWER(`title`);

--- a/packages/app/drizzle/meta/0005_snapshot.json
+++ b/packages/app/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1336 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "fb1118be-ae84-4c64-ae25-3fb0fba6f043",
+  "prevId": "b0ff7bff-7111-471a-b54c-a192a7187ee2",
+  "tables": {
+    "account_balances": {
+      "name": "account_balances",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_balances_account_id_unique": {
+          "name": "account_balances_account_id_unique",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Home'"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "title_search": {
+          "name": "title_search",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'CASH'"
+        },
+        "nature": {
+          "name": "nature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'LIABILITY'"
+        },
+        "debt_type": {
+          "name": "debt_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'LENT'"
+        },
+        "instrument_id": {
+          "name": "instrument_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_balance": {
+          "name": "target_balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "iban": {
+          "name": "iban",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "include_in_net_worth": {
+          "name": "include_in_net_worth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_instrument_id_instruments_id_fk": {
+          "name": "accounts_instrument_id_instruments_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "instruments",
+          "columnsFrom": [
+            "instrument_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bank_syncs": {
+      "name": "bank_syncs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'BACKWARD'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'IDLE'"
+        },
+        "backward_synced_at": {
+          "name": "backward_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "backward_sync_from_at": {
+          "name": "backward_sync_from_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forward_synced_at": {
+          "name": "forward_synced_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forward_sync_from_at": {
+          "name": "forward_sync_from_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transaction_count": {
+          "name": "transaction_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "bank_syncs_account_id_unique": {
+          "name": "bank_syncs_account_id_unique",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "bank_syncs_account_id_accounts_id_fk": {
+          "name": "bank_syncs_account_id_accounts_id_fk",
+          "tableFrom": "bank_syncs",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "title_search": {
+          "name": "title_search",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_system_category": {
+          "name": "is_system_category",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exchange_rates": {
+      "name": "exchange_rates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_instrument_id": {
+          "name": "base_instrument_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quote_instrument_id": {
+          "name": "quote_instrument_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rate": {
+          "name": "rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "exchange_rates_base_instrument_id_quote_instrument_id_unique": {
+          "name": "exchange_rates_base_instrument_id_quote_instrument_id_unique",
+          "columns": [
+            "base_instrument_id",
+            "quote_instrument_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "instruments": {
+      "name": "instruments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcc_categories": {
+      "name": "mcc_categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcc": {
+          "name": "mcc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcc_group_id": {
+          "name": "mcc_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "short_description": {
+          "name": "short_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_description": {
+          "name": "full_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcc_categories_mcc_unique": {
+          "name": "mcc_categories_mcc_unique",
+          "columns": [
+            "mcc"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mcc_categories_mcc_group_id_mcc_groups_id_fk": {
+          "name": "mcc_categories_mcc_group_id_mcc_groups_id_fk",
+          "tableFrom": "mcc_categories",
+          "tableTo": "mcc_groups",
+          "columnsFrom": [
+            "mcc_group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcc_groups": {
+      "name": "mcc_groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcc_groups_type_unique": {
+          "name": "mcc_groups_type_unique",
+          "columns": [
+            "type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "default_account_id": {
+          "name": "default_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_instrument_id": {
+          "name": "default_instrument_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'SYSTEM'"
+        },
+        "is_pin_enabled": {
+          "name": "is_pin_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_biometric_enabled": {
+          "name": "is_biometric_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "show_cents": {
+          "name": "show_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "is_vibration_enabled": {
+          "name": "is_vibration_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "is_screenshot_protection_enabled": {
+          "name": "is_screenshot_protection_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_default_account_id_accounts_id_fk": {
+          "name": "settings_default_account_id_accounts_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "default_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "settings_default_instrument_id_instruments_id_fk": {
+          "name": "settings_default_instrument_id_instruments_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "instruments",
+          "columnsFrom": [
+            "default_instrument_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title_search": {
+          "name": "title_search",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transactions": {
+      "name": "transactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "operated_at": {
+          "name": "operated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "to_account_id": {
+          "name": "to_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "from_account_id": {
+          "name": "from_account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exchange_rate": {
+          "name": "exchange_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transactions_to_account_id_accounts_id_fk": {
+          "name": "transactions_to_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "to_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_from_account_id_accounts_id_fk": {
+          "name": "transactions_from_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "from_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transaction_entries": {
+      "name": "transaction_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mcc_category_id": {
+          "name": "mcc_category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transaction_entries_account_id_accounts_id_fk": {
+          "name": "transaction_entries_account_id_accounts_id_fk",
+          "tableFrom": "transaction_entries",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_entries_category_id_categories_id_fk": {
+          "name": "transaction_entries_category_id_categories_id_fk",
+          "tableFrom": "transaction_entries",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_entries_mcc_category_id_mcc_categories_id_fk": {
+          "name": "transaction_entries_mcc_category_id_mcc_categories_id_fk",
+          "tableFrom": "transaction_entries",
+          "tableTo": "mcc_categories",
+          "columnsFrom": [
+            "mcc_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "transaction_entries_transaction_id_transactions_id_fk": {
+          "name": "transaction_entries_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_entries",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transaction_tags": {
+      "name": "transaction_tags",
+      "columns": {
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transaction_tags_transaction_id_transactions_id_fk": {
+          "name": "transaction_tags_transaction_id_transactions_id_fk",
+          "tableFrom": "transaction_tags",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_tags_tag_id_tags_id_fk": {
+          "name": "transaction_tags_tag_id_tags_id_fk",
+          "tableFrom": "transaction_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transaction_tags_transaction_id_tag_id_pk": {
+          "columns": [
+            "transaction_id",
+            "tag_id"
+          ],
+          "name": "transaction_tags_transaction_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -1,41 +1,48 @@
 {
-    "version": "7",
-    "dialect": "sqlite",
-    "entries": [
-        {
-            "idx": 0,
-            "version": "6",
-            "when": 1766785704262,
-            "tag": "0000_normal_dragon_man",
-            "breakpoints": true
-        },
-        {
-            "idx": 1,
-            "version": "6",
-            "when": 1767193657976,
-            "tag": "0001_late_red_wolf",
-            "breakpoints": true
-        },
-        {
-            "idx": 2,
-            "version": "6",
-            "when": 1767283590405,
-            "tag": "0002_dark_prima",
-            "breakpoints": true
-        },
-        {
-            "idx": 3,
-            "version": "6",
-            "when": 1767359238587,
-            "tag": "0003_unusual_maestro",
-            "breakpoints": true
-        },
-        {
-            "idx": 4,
-            "version": "6",
-            "when": 1767360939861,
-            "tag": "0004_cloudy_juggernaut",
-            "breakpoints": true
-        }
-    ]
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1766785704262,
+      "tag": "0000_normal_dragon_man",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1767193657976,
+      "tag": "0001_late_red_wolf",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1767283590405,
+      "tag": "0002_dark_prima",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1767359238587,
+      "tag": "0003_unusual_maestro",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1767360939861,
+      "tag": "0004_cloudy_juggernaut",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1767472006304,
+      "tag": "0005_omniscient_jasper_sitwell",
+      "breakpoints": true
+    }
+  ]
 }

--- a/packages/app/drizzle/migrations.js
+++ b/packages/app/drizzle/migrations.js
@@ -1,17 +1,22 @@
+// This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
+
 import journal from './meta/_journal.json';
 import m0000 from './0000_normal_dragon_man.sql';
 import m0001 from './0001_late_red_wolf.sql';
 import m0002 from './0002_dark_prima.sql';
 import m0003 from './0003_unusual_maestro.sql';
 import m0004 from './0004_cloudy_juggernaut.sql';
+import m0005 from './0005_omniscient_jasper_sitwell.sql';
 
-export default {
+  export default {
     journal,
     migrations: {
-        m0000,
-        m0001,
-        m0002,
-        m0003,
-        m0004
+      m0000,
+m0001,
+m0002,
+m0003,
+m0004,
+m0005
     }
-};
+  }
+  

--- a/packages/contracts/src/account/repository/account.repository.ts
+++ b/packages/contracts/src/account/repository/account.repository.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, inArray, isNotNull, isNull, ne, notInArray, sql } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, isNotNull, isNull, like, ne, notInArray, sql } from 'drizzle-orm';
 
 import { isDefined, isNotEmptyArray } from '@rnw-community/shared';
 
@@ -25,7 +25,11 @@ export class AccountRepository {
     }
 
     async updateById(id: number, input: AccountUpdateEntityInterface, tx?: TX): Promise<AccountEntityInterface> {
-        const [account] = await (tx ?? this.db).update(AccountEntityTable).set(input).where(eq(AccountEntityTable.id, id)).returning();
+        const [account] = await (tx ?? this.db)
+            .update(AccountEntityTable)
+            .set({ ...input, ...(isDefined(input.title) && { titleSearch: input.title.toLowerCase() }) })
+            .where(eq(AccountEntityTable.id, id))
+            .returning();
 
         return account;
     }
@@ -100,7 +104,10 @@ export class AccountRepository {
     }
 
     async bulkCreate(inputs: AccountCreateEntityInterface[], tx?: TX): Promise<AccountEntityInterface[]> {
-        return await (tx ?? this.db).insert(AccountEntityTable).values(inputs).returning();
+        return await (tx ?? this.db)
+            .insert(AccountEntityTable)
+            .values(inputs.map(input => ({ ...input, titleSearch: input.title.toLowerCase() })))
+            .returning();
     }
 
     async truncate(tx?: TX): Promise<void> {
@@ -113,7 +120,7 @@ export class AccountRepository {
         return and(
             isNull(AccountEntityTable.parentId),
             isNull(AccountEntityTable.deletedAt),
-            sql`LOWER(${AccountEntityTable.title}) LIKE ${`%${search.toLowerCase()}%`}`,
+            like(AccountEntityTable.titleSearch, `%${search.toLowerCase()}%`),
             isNotEmptyArray(excludeTypes) ? notInArray(AccountEntityTable.type, excludeTypes) : sql`1=1`,
             isDefined(excludeAccountId) ? ne(AccountEntityTable.id, excludeAccountId) : sql`1=1`
         );

--- a/packages/contracts/src/account/schema/account-create-entity.schema.ts
+++ b/packages/contracts/src/account/schema/account-create-entity.schema.ts
@@ -2,15 +2,19 @@ import { convertToCreateEntitySchema } from '../../@generic/util/convert-to-crea
 
 import { AccountEntitySchema } from './account-entity.schema';
 
-export const AccountCreateEntitySchema = convertToCreateEntitySchema(AccountEntitySchema).partial({
-    iban: true,
-    debtType: true,
-    deadline: true,
-    parentId: true,
-    contactId: true,
-    externalId: true,
-    targetBalance: true,
-    externalSource: true,
-    includeInNetWorth: true,
-    isActive: true
-});
+export const AccountCreateEntitySchema = convertToCreateEntitySchema(AccountEntitySchema)
+    .omit({
+        titleSearch: true
+    })
+    .partial({
+        iban: true,
+        debtType: true,
+        deadline: true,
+        parentId: true,
+        contactId: true,
+        externalId: true,
+        targetBalance: true,
+        externalSource: true,
+        includeInNetWorth: true,
+        isActive: true
+    });

--- a/packages/contracts/src/account/schema/debt-account-create-input.schema.ts
+++ b/packages/contracts/src/account/schema/debt-account-create-input.schema.ts
@@ -12,7 +12,8 @@ export const DebtAccountCreateInputSchema = convertToCreateEntitySchema(AccountE
         externalId: true,
         targetBalance: true,
         externalSource: true,
-        includeInNetWorth: true
+        includeInNetWorth: true,
+        titleSearch: true
     })
     .required({
         contactId: true,

--- a/packages/contracts/src/account/schema/liability-account-create-input.schema.ts
+++ b/packages/contracts/src/account/schema/liability-account-create-input.schema.ts
@@ -14,7 +14,8 @@ export const LiabilityAccountCreateInputSchema = convertToCreateEntitySchema(Acc
         deadline: true,
         debtType: true,
         nature: true,
-        order: true
+        order: true,
+        titleSearch: true
     })
     .partial({
         includeInNetWorth: true,

--- a/packages/contracts/src/account/table/account-entity.table.ts
+++ b/packages/contracts/src/account/table/account-entity.table.ts
@@ -19,6 +19,7 @@ export const AccountEntityTable = sqliteTable(
         parentId: int('parent_id', { mode: 'number' }),
         order: int({ mode: 'number' }).default(0).notNull(),
         title: text().default('').notNull(),
+        titleSearch: text('title_search').default('').notNull(),
         type: text('type', { enum: convertEnumToDrizzleEnum(AccountTypeEnum) })
             .$type<AccountTypeEnum>()
             .default(AccountTypeEnum.CASH)

--- a/packages/contracts/src/category/repository/category.repository.ts
+++ b/packages/contracts/src/category/repository/category.repository.ts
@@ -1,4 +1,6 @@
-import { and, count, eq, getTableColumns, sql } from 'drizzle-orm';
+import { and, count, eq, getTableColumns, like, sql } from 'drizzle-orm';
+
+import { isDefined } from '@rnw-community/shared';
 
 import { TX } from '../../@generic/type/db.type';
 import { TransactionEntryEntityTable } from '../../transaction-entry/table/transaction-entry-entity.table';
@@ -18,7 +20,7 @@ export class CategoryRepository {
     }
 
     findBySearchQuery(search: string, includeDefault: boolean) {
-        const searchQuery = sql`LOWER (${CategoryEntityTable.title}) LIKE ${`%${search.toLowerCase()}%`}`;
+        const searchQuery = like(CategoryEntityTable.titleSearch, `%${search.toLowerCase()}%`);
 
         const whereConditions = includeDefault
             ? and(searchQuery, eq(CategoryEntityTable.isSystemCategory, false))
@@ -48,11 +50,18 @@ export class CategoryRepository {
     }
 
     async bulkCreate(inputs: CategoryCreateEntityInterface[], tx?: TX): Promise<CategoryEntityInterface[]> {
-        return await (tx ?? this.db).insert(CategoryEntityTable).values(inputs).returning();
+        return await (tx ?? this.db)
+            .insert(CategoryEntityTable)
+            .values(inputs.map(input => ({ ...input, titleSearch: input.title.toLowerCase() })))
+            .returning();
     }
 
     async updateById(id: number, input: CategoryUpdateEntityInterface): Promise<CategoryEntityInterface> {
-        const [category] = await this.db.update(CategoryEntityTable).set(input).where(eq(CategoryEntityTable.id, id)).returning();
+        const [category] = await this.db
+            .update(CategoryEntityTable)
+            .set({ ...input, ...(isDefined(input.title) && { titleSearch: input.title.toLowerCase() }) })
+            .where(eq(CategoryEntityTable.id, id))
+            .returning();
 
         return category;
     }

--- a/packages/contracts/src/category/schema/category-create-entity.schema.ts
+++ b/packages/contracts/src/category/schema/category-create-entity.schema.ts
@@ -5,7 +5,8 @@ import { CategoryEntitySchema } from './category-entity.schema';
 export const CategoryCreateEntitySchema = convertToCreateEntitySchema(CategoryEntitySchema)
     .omit({
         isDefault: true,
-        isSystemCategory: true
+        isSystemCategory: true,
+        titleSearch: true
     })
     .partial({
         parentId: true

--- a/packages/contracts/src/category/table/category-entity.table.ts
+++ b/packages/contracts/src/category/table/category-entity.table.ts
@@ -8,6 +8,7 @@ export const CategoryEntityTable = sqliteTable(
     'categories',
     withBaseEntityTableColumns({
         title: text().default('').notNull(),
+        titleSearch: text('title_search').default('').notNull(),
         icon: text({ enum: convertEnumToDrizzleEnum(UserIconNameEnum) })
             .$type<UserIconNameEnum>()
             .notNull(),

--- a/packages/contracts/src/tag/repository/tag.repository.ts
+++ b/packages/contracts/src/tag/repository/tag.repository.ts
@@ -1,4 +1,6 @@
-import { count, eq, inArray, sql } from 'drizzle-orm';
+import { count, eq, inArray, like } from 'drizzle-orm';
+
+import { isDefined } from '@rnw-community/shared';
 
 import { TX } from '../../@generic/type/db.type';
 import { TagCreateEntityInterface } from '../entity/tag-create-entity.interface';
@@ -20,7 +22,7 @@ export class TagRepository {
 
     findBySearchQuery(search: string) {
         return this.db.query.TagEntityTable.findMany({
-            where: sql`LOWER (${TagEntityTable.title}) LIKE ${`%${search.toLowerCase()}%`}`
+            where: like(TagEntityTable.titleSearch, `%${search.toLowerCase()}%`)
         });
     }
 
@@ -29,13 +31,20 @@ export class TagRepository {
     }
 
     async create(input: TagCreateEntityInterface): Promise<TagEntityInterface> {
-        const [tag] = await this.db.insert(TagEntityTable).values([input]).returning();
+        const [tag] = await this.db
+            .insert(TagEntityTable)
+            .values([{ ...input, titleSearch: input.title.toLowerCase() }])
+            .returning();
 
         return tag;
     }
 
     async updateById(id: number, input: TagUpdateEntityInterface): Promise<TagEntityInterface> {
-        const [tag] = await this.db.update(TagEntityTable).set(input).where(eq(TagEntityTable.id, id)).returning();
+        const [tag] = await this.db
+            .update(TagEntityTable)
+            .set({ ...input, ...(isDefined(input.title) && { titleSearch: input.title.toLowerCase() }) })
+            .where(eq(TagEntityTable.id, id))
+            .returning();
 
         return tag;
     }

--- a/packages/contracts/src/tag/table/tag-entity.table.ts
+++ b/packages/contracts/src/tag/table/tag-entity.table.ts
@@ -5,6 +5,7 @@ import { withBaseEntityTableColumns } from '../../@generic/util/with-base-entity
 export const TagEntityTable = sqliteTable(
     'tags',
     withBaseEntityTableColumns({
-        title: text().notNull()
+        title: text().notNull(),
+        titleSearch: text('title_search').default('').notNull()
     })
 );


### PR DESCRIPTION
## Summary
- SQLite's `LOWER()` function only handles ASCII, breaking search for Ukrainian and other non-ASCII text
- Add `titleSearch` column that stores JavaScript-lowercased titles for proper Unicode case-insensitive search
- Apply to categories, tags, and accounts entities

## Problem
When searching for categories/tags/accounts with Ukrainian titles (e.g., "Категорія"), the search fails because:
1. SQLite's `LOWER()` doesn't convert Cyrillic characters
2. `LIKE` comparison becomes case-sensitive for non-ASCII

## Solution
Store a pre-lowercased version of titles using JavaScript's `toLowerCase()` which handles Unicode correctly:

| Column | Purpose |
|--------|---------|
| `title` | Display value (original case) |
| `titleSearch` | Search index (lowercased via JS) |

## Files Changed

**Tables:**
- `category-entity.table.ts` - Added `titleSearch` column
- `tag-entity.table.ts` - Added `titleSearch` column  
- `account-entity.table.ts` - Added `titleSearch` column

**Repositories:**
- `category.repository.ts` - Populate `titleSearch` on create/update, search against it
- `tag.repository.ts` - Same
- `account.repository.ts` - Same

**Schemas:**
- Omit `titleSearch` from create input schemas (internal field)

**Migration:**
- `0005_omniscient_jasper_sitwell.sql` - Adds columns and populates existing data

**Docs:**
- `CLAUDE.md` - Added guidance for migrations after table changes

## Limitations
- Migration uses SQLite `LOWER()` for existing data (ASCII only)
- Full Unicode support applies to new/updated records
- Users can re-save existing Ukrainian categories/tags to enable search

## Test plan
- [ ] Create new category with Ukrainian title → search works
- [ ] Create new tag with Ukrainian title → search works
- [ ] Search existing ASCII categories → still works
- [ ] Update existing Ukrainian category → search now works

🤖 Generated with [Claude Code](https://claude.com/claude-code)