### PR TITLE
fix(app): resolve icon selection dismissing wrong bottom sheet

### DIFF
--- a/packages/app/src/@generic/component/icon-selector-bottom-sheet/icon-selector-bottom-sheet.tsx
+++ b/packages/app/src/@generic/component/icon-selector-bottom-sheet/icon-selector-bottom-sheet.tsx
@@ -1,7 +1,7 @@
 import { UserIconNameEnum } from '@budgie/contracts';
 import { useLingui } from '@lingui/react/macro';
 import { useState } from 'react';
-import { View } from 'react-native';
+import { InteractionManager, View } from 'react-native';
 
 import { USER_ICONS_LIST, UserIcon } from '../../constant/user-icons.constant';
 import { BottomSheetInterface } from '../../interface/bottom-sheet.interface';
@@ -39,8 +39,10 @@ export const IconSelectorBottomSheet = ({ ref, selectedIcon, variant, onSelect }
     const data = padFlatListData(showedIcons);
 
     const handleSelect = (icon: UserIconNameEnum) => {
-        void ref.current?.dismiss();
         onSelect(icon);
+        InteractionManager.runAfterInteractions(() => {
+            void ref.current?.dismiss();
+        });
     };
 
     const renderItem = ({ item }: { item: FlatListDataItem<UserIcon> }) =>


### PR DESCRIPTION
## Summary

Fixed a critical bug in the category creation flow where selecting an icon would either:
- Dismiss the parent category form bottom sheet instead of just the icon selector
- Cause the application to crash

## Root Cause

The issue was in the \`IconSelectorBottomSheet\` component's \`handleSelect\` callback. The dismiss operation was executed before the onSelect callback completed, creating a race condition.

**Before (buggy):**
\`\`\`typescript
const handleSelect = (icon: UserIconNameEnum) => {
    void ref.current?.dismiss();  // Dismiss FIRST
    onSelect(icon);               // Update form SECOND
};
\`\`\`

This created a race condition where:
1. The bottom sheet was dismissed before the form field update completed
2. The dismiss action could propagate to the parent bottom sheet
3. The form state update might occur on an unmounting component

**After (fixed):**
\`\`\`typescript
const handleSelect = (icon: UserIconNameEnum) => {
    onSelect(icon);  // Update form FIRST
    InteractionManager.runAfterInteractions(() => {
        void ref.current?.dismiss();  // Dismiss AFTER interactions complete
    });
};
\`\`\`

## Solution

The fix uses a two-step approach:
1. Call \`onSelect(icon)\` first to update the form field immediately
2. Use \`InteractionManager.runAfterInteractions()\` to defer the dismiss until after all pending interactions complete

This ensures:
- The form field update completes before any dismissal occurs
- The dismiss only affects the icon selector bottom sheet
- No race conditions between state updates and component lifecycle

## Changes

- Updated \`packages/app/src/@generic/component/icon-selector-bottom-sheet/icon-selector-bottom-sheet.tsx\`
- Added \`InteractionManager\` import from \`react-native\`
- Wrapped dismiss call in \`InteractionManager.runAfterInteractions()\`
- Ensured onSelect executes before dismiss is scheduled

## Test Plan

- [ ] Open category creation bottom sheet
- [ ] Tap on the icon field to open icon selector
- [ ] Select any icon from the grid
- [ ] Verify that only the icon selector bottom sheet closes
- [ ] Verify that the category form bottom sheet remains open with the selected icon displayed
- [ ] Verify that the app doesn't crash
- [ ] Complete the category creation successfully
- [ ] Test with multiple icon selections (change icon several times)

## Impact

- Fixes crashes during category creation
- Prevents accidental dismissal of the category form when selecting icons
- Improves user experience by maintaining proper bottom sheet state management
- Uses React Native's recommended pattern for deferring operations after interactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)