### PR TITLE
fix(app): enable keyboard-aware scrolling in search lists

### DIFF
--- a/packages/app/src/@generic/component/animated-flat-list/animated-flat-list.tsx
+++ b/packages/app/src/@generic/component/animated-flat-list/animated-flat-list.tsx
@@ -29,6 +29,13 @@ export const AnimatedFlatList = <T,>({ data, keyExtractor, renderItem, ...rest }
     );
 
     return (
-        <FlatList data={data} keyExtractor={keyExtractor} renderItem={internalRenderItem} showsVerticalScrollIndicator={false} {...rest} />
+        <FlatList
+            data={data}
+            keyExtractor={keyExtractor}
+            renderItem={internalRenderItem}
+            showsVerticalScrollIndicator={false}
+            automaticallyAdjustKeyboardInsets
+            {...rest}
+        />
     );
 };


### PR DESCRIPTION
## Summary
- Add `automaticallyAdjustKeyboardInsets` prop to `AnimatedFlatList` component
- Fixes lists being hidden under the keyboard when search input is focused on search screens (tags, categories, etc.)

## Test plan
- [ ] Open Tags screen (Settings → Tags)
- [ ] Focus on the search input
- [ ] Verify the list scrolls properly and content is not hidden under the keyboard
- [ ] Repeat for Categories screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)