### PR TITLE
fix(app): editing transactions creates duplicated entries

### DIFF
--- a/packages/app/src/transaction/service/transaction.service.ts
+++ b/packages/app/src/transaction/service/transaction.service.ts
@@ -103,6 +103,8 @@ class TransactionService {
 
             await this.upsertEntriesAndTags(id, input, tx);
 
+            await accountBalanceIncrementalService.updateAllBalances(true, tx);
+
             return transaction;
         });
     }
@@ -226,7 +228,8 @@ class TransactionService {
         await transactionEntryRepository.deleteByTransactionId(transactionId, tx);
 
         await transactionEntryRepository.bulkCreate(
-            input.entries.map(entry => ({ ...entry, amount: convertToMicroUnits(entry.amount), transactionId }), tx)
+            input.entries.map(entry => ({ ...entry, amount: convertToMicroUnits(entry.amount), transactionId })),
+            tx
         );
 
         await transactionTagsRepository.deleteByTransactionId(transactionId, tx);


### PR DESCRIPTION
## Summary
Fix a bug where editing transactions (e.g., adding tags) caused duplicate entries and incorrect balances.

## Problem
When updating a transaction, entries were being duplicated, causing balances to be incorrect.

## Root Cause
In `upsertEntriesAndTags`, the `tx` parameter was incorrectly passed as the second argument to `.map()` instead of to `.bulkCreate()`:

```typescript
// Before (bug)
await transactionEntryRepository.bulkCreate(
    input.entries.map(entry => ({ ...entry, transactionId }), tx)  // tx passed to .map()!
);

// After (fix)
await transactionEntryRepository.bulkCreate(
    input.entries.map(entry => ({ ...entry, transactionId })),
    tx  // tx correctly passed to .bulkCreate()
);
```

This caused entries to be created outside the database transaction, leading to duplicates when the delete was rolled back but the create wasn't.

Fixes #228