### PR TITLE
fix(app): fix keyboard dismissing on item tap in searchable lists

### DIFF
--- a/packages/app/src/@generic/component/animated-flat-list/animated-flat-list.tsx
+++ b/packages/app/src/@generic/component/animated-flat-list/animated-flat-list.tsx
@@ -35,6 +35,7 @@ export const AnimatedFlatList = <T,>({ data, keyExtractor, renderItem, ...rest }
             renderItem={internalRenderItem}
             showsVerticalScrollIndicator={false}
             automaticallyAdjustKeyboardInsets
+            keyboardShouldPersistTaps="handled"
             {...rest}
         />
     );


### PR DESCRIPTION
## Changes

Add `keyboardShouldPersistTaps="handled"` to `AnimatedFlatList` to ensure taps on list items are handled even when the keyboard is open.

## Problem

When searching in category/tags settings pages, tapping on an item while the keyboard is open would first dismiss the keyboard instead of selecting the item. Users had to tap twice - once to dismiss keyboard, once to select.

## Solution

Setting `keyboardShouldPersistTaps="handled"` allows the tap to be processed by the list item's press handler while still allowing the keyboard to dismiss when tapping outside of interactive elements.

Fixes #236