### PR TITLE
fix(app): reset tab stack navigator when switching tabs

### DIFF
--- a/packages/app/src/app/(tabs)/_layout.tsx
+++ b/packages/app/src/app/(tabs)/_layout.tsx
@@ -49,19 +49,19 @@ export default function TabsLayout() {
             <View className="absolute inset-x-0 bottom-0" pointerEvents="box-none">
                 <View className="flex-row items-center justify-between px-lg pb-lg pt-md" style={containerStyle}>
                     <View className="flex-row items-center gap-sm bg-secondary rounded-full px-md py-sm shadow-lg shadow-black/20">
-                        <TabTrigger name="home" asChild>
+                        <TabTrigger name="home" asChild reset="always">
                             <TabButton icon={UserIconNameEnum.Home} />
                         </TabTrigger>
 
-                        <TabTrigger name="transactions" asChild>
+                        <TabTrigger name="transactions" asChild reset="always">
                             <TabButton icon={UserIconNameEnum.Receipt} />
                         </TabTrigger>
 
-                        <TabTrigger name="analytics" asChild>
+                        <TabTrigger name="analytics" asChild reset="always">
                             <TabButton icon={UserIconNameEnum.ChartNoAxesColumn} />
                         </TabTrigger>
 
-                        <TabTrigger name="settings" asChild>
+                        <TabTrigger name="settings" asChild reset="always">
                             <TabButton icon={UserIconNameEnum.Settings} />
                         </TabTrigger>
                     </View>


### PR DESCRIPTION
## Summary
When navigating deep into a tab with a nested stack navigator (e.g., Settings > Categories), switching to another tab and back would preserve the stack state, returning to the previously selected screen instead of the tab's index.

## Changes
- Added `reset="always"` prop to all `TabTrigger` components in the tabs layout
- This ensures nested stack navigators return to their index route when switching between tabs

## Testing
1. Go to Settings > Categories
2. Tap Home tab
3. Tap Settings tab
4. Should show Settings index, not Categories