### PR TITLE
fix(app): add useFocusKey hook to fix LegendList tab switching render issues

### DIFF
--- a/packages/app/src/@generic/hook/use-focus-key.hook.ts
+++ b/packages/app/src/@generic/hook/use-focus-key.hook.ts
@@ -1,0 +1,26 @@
+import { useFocusEffect } from 'expo-router';
+import { useRef, useState } from 'react';
+import { InteractionManager } from 'react-native';
+
+import { emptyFn } from '@rnw-community/shared';
+
+export const useFocusKey = (): number => {
+    const [focusKey, setFocusKey] = useState(0);
+    const isFirstFocus = useRef(true);
+
+    useFocusEffect(() => {
+        if (isFirstFocus.current) {
+            isFirstFocus.current = false;
+
+            return emptyFn;
+        }
+
+        const task = InteractionManager.runAfterInteractions(() => {
+            setFocusKey(prev => prev + 1);
+        });
+
+        return () => void task.cancel();
+    });
+
+    return focusKey;
+};

--- a/packages/app/src/app/(tabs)/analytics.tsx
+++ b/packages/app/src/app/(tabs)/analytics.tsx
@@ -33,9 +33,7 @@ export default function StatisticsPage() {
     const { incomeByTag } = useGetIncomeByTagQuery(filters);
     const { expenseByTag } = useGetExpenseByTagQuery(filters);
     const { expense, income } = useGetTotalIncomeAndExpensesQuery(filters);
-
     const netWorth = useNetWorthQuery();
-
     const hasFiltersSelected = checkIfFiltersSelected(null, filters);
 
     return (

--- a/packages/app/src/app/(tabs)/transactions.tsx
+++ b/packages/app/src/app/(tabs)/transactions.tsx
@@ -2,14 +2,16 @@ import { useLingui } from '@lingui/react/macro';
 
 import { Page } from '../../@generic/component/page/page';
 import { PageHeader } from '../../@generic/component/page-header/page-header';
+import { useFocusKey } from '../../@generic/hook/use-focus-key.hook';
 import { TransactionList } from '../../transaction/components/transaction-list/transaction-list';
 
 export default function TransactionsPage() {
     const { t } = useLingui();
+    const focusKey = useFocusKey();
 
     return (
         <Page header={<PageHeader className="border-b-0" size="md" title={t`Transactions`} />}>
-            <TransactionList accountId={null} />
+            <TransactionList focusKey={focusKey} accountId={null} />
         </Page>
     );
 }

--- a/packages/app/src/transaction/components/transaction-list/transaction-list.tsx
+++ b/packages/app/src/transaction/components/transaction-list/transaction-list.tsx
@@ -16,9 +16,16 @@ interface Props {
     readonly filters?: TransactionFilterInterface;
     readonly showFilters?: boolean;
     readonly footerSpacerMultiplier?: number;
+    readonly focusKey?: number;
 }
 
-export const TransactionList = ({ accountId = null, filters: externalFilters, showFilters = true, footerSpacerMultiplier }: Props) => {
+export const TransactionList = ({
+    accountId = null,
+    filters: externalFilters,
+    showFilters = true,
+    footerSpacerMultiplier,
+    focusKey
+}: Props) => {
     const { t } = useLingui();
 
     const [internalFilters, setInternalFilters] = useState<TransactionFilterInterface>(DEFAULT_TRANSACTION_FILTER);
@@ -67,6 +74,7 @@ export const TransactionList = ({ accountId = null, filters: externalFilters, sh
                 balanceAdjustmentLabel={balanceAdjustmentLabel}
                 categoriesLabel={categoriesLabel}
                 footerSpacerMultiplier={footerSpacerMultiplier}
+                focusKey={focusKey}
             />
         </View>
     );

--- a/packages/app/src/transaction/components/transaction-sections-list/transaction-sections-list.tsx
+++ b/packages/app/src/transaction/components/transaction-sections-list/transaction-sections-list.tsx
@@ -16,6 +16,7 @@ interface Props {
     readonly balanceAdjustmentLabel: string;
     readonly categoriesLabel: string;
     readonly footerSpacerMultiplier?: number;
+    readonly focusKey?: number;
 }
 
 const keyExtractor = (item: TransactionListItemType) => item.id;
@@ -43,7 +44,8 @@ export const TransactionSectionsList = ({
     listEmptyState,
     balanceAdjustmentLabel,
     categoriesLabel,
-    footerSpacerMultiplier
+    footerSpacerMultiplier,
+    focusKey
 }: Props) => {
     const { formatMonthAndDayWithTime } = useFormatDate();
 
@@ -67,6 +69,7 @@ export const TransactionSectionsList = ({
 
     return (
         <LegendList
+            key={focusKey}
             data={flatData}
             keyExtractor={keyExtractor}
             renderItem={renderItem}


### PR DESCRIPTION
## Summary
Fixes an issue where fast tab switching caused LegendList to render only partially (half-rendered screen).

## Changes
- Added `useFocusKey` hook that provides a key that changes when a tab gains focus
- Uses `InteractionManager.runAfterInteractions` to wait for navigation animations
- Skips the first focus event to avoid unnecessary initial re-render
- Applied to `TransactionList` via `TransactionSectionsList` to force LegendList re-mount on tab focus

## Implementation Details
The hook:
1. Tracks focus events using `useFocusEffect` from expo-router
2. Skips the initial focus (mount) to prevent redundant queries
3. Waits for animations to complete via InteractionManager
4. Returns a key that increments on subsequent tab focuses

This key is passed through to the LegendList component, forcing it to re-mount and properly render when switching back to the Transactions tab.