### PR TITLE
fix(app): fix toggle switch colors in dark mode on iOS 26

### DIFF
--- a/packages/app/src/@generic/component/themed-switch/themed-switch.tsx
+++ b/packages/app/src/@generic/component/themed-switch/themed-switch.tsx
@@ -2,44 +2,23 @@ import { ComponentProps } from 'react';
 import { Switch } from 'react-native';
 
 import { useThemeContext } from '../../../theme/context/theme.context';
-import { PRIMARY_COLOR, PRIMARY_COLOR_REVERSE, SWITCH_TRACK_OFF_DARK, SWITCH_TRACK_OFF_LIGHT } from '../../constant/colors.constant';
-
-const LIGHT_THEME = {
-    thumbOn: PRIMARY_COLOR,
-    thumbOff: PRIMARY_COLOR,
-    trackOn: PRIMARY_COLOR_REVERSE,
-    trackOff: SWITCH_TRACK_OFF_LIGHT
-};
-
-const DARK_THEME = {
-    thumbOn: PRIMARY_COLOR_REVERSE,
-    thumbOff: PRIMARY_COLOR_REVERSE,
-    trackOn: PRIMARY_COLOR,
-    trackOff: SWITCH_TRACK_OFF_DARK
-};
-
-const getThumbColor = (isDarkTheme: boolean, value: boolean) => {
-    const theme = isDarkTheme ? DARK_THEME : LIGHT_THEME;
-
-    return value ? theme.thumbOn : theme.thumbOff;
-};
-
-const getTrackColor = (isDarkTheme: boolean, value: boolean) => {
-    const theme = isDarkTheme ? DARK_THEME : LIGHT_THEME;
-
-    return value ? theme.trackOn : theme.trackOff;
-};
+import { dark, light } from '../../../theme/provider/theme.provider';
 
 export const ThemedSwitch = (props: Omit<ComponentProps<typeof Switch>, 'thumbColor' | 'ios_backgroundColor' | 'trackColor'>) => {
     const { isDarkColorSchema } = useThemeContext();
 
-    const thumbColor = getThumbColor(isDarkColorSchema, props.value ?? false);
-    const iosBackgroundColor = getTrackColor(isDarkColorSchema, props.value ?? false);
-
+    const theme = isDarkColorSchema ? dark : light;
     const trackColor = {
-        true: getTrackColor(isDarkColorSchema, true),
-        false: getTrackColor(isDarkColorSchema, false)
+        true: theme['--color-secondary-foreground'],
+        false: theme['--color-secondary-corner']
     };
 
-    return <Switch {...props} trackColor={trackColor} thumbColor={thumbColor} ios_backgroundColor={iosBackgroundColor} />;
+    return (
+        <Switch
+            {...props}
+            trackColor={trackColor}
+            thumbColor={theme['--color-primary']}
+            ios_backgroundColor={theme['--color-secondary-corner']}
+        />
+    );
 };

--- a/packages/app/src/@generic/constant/colors.constant.ts
+++ b/packages/app/src/@generic/constant/colors.constant.ts
@@ -1,9 +1,0 @@
-export const PRIMARY_COLOR = '#ffffff';
-export const PRIMARY_COLOR_REVERSE = '#000000';
-
-export const SWITCH_TRACK_OFF_LIGHT = '#e5e5e5';
-export const SWITCH_TRACK_OFF_DARK = '#3a3a3c';
-
-export const DEFAULT_FOREGROUND_COLOR = 'rgba(43, 127, 255, 1)';
-export const DESTRUCTIVE_FOREGROUND_COLOR = 'rgba(239, 68, 68, 1)';
-export const SECONDARY_FOREGROUND_COLOR = 'rgba(115, 115, 115, 1)';

--- a/packages/app/src/ai/component/animated-record-button/animated-record-button.constant.ts
+++ b/packages/app/src/ai/component/animated-record-button/animated-record-button.constant.ts
@@ -1,17 +1,13 @@
-import {
-    DEFAULT_FOREGROUND_COLOR,
-    DESTRUCTIVE_FOREGROUND_COLOR,
-    SECONDARY_FOREGROUND_COLOR
-} from '../../../@generic/constant/colors.constant';
+import { light } from '../../../theme/provider/theme.provider';
 
 export const BUTTON_SIZE = 80;
 export const RING_SIZE = 120;
 export const STROKE_WIDTH = 3;
 
-export const ACCENT_COLOR = DEFAULT_FOREGROUND_COLOR;
-export const RECORDING_COLOR = DESTRUCTIVE_FOREGROUND_COLOR;
-export const THINKING_COLOR = DEFAULT_FOREGROUND_COLOR;
-export const LOADING_COLOR = SECONDARY_FOREGROUND_COLOR;
+export const ACCENT_COLOR = light['--color-default-foreground'];
+export const RECORDING_COLOR = light['--color-destructive-foreground'];
+export const THINKING_COLOR = light['--color-default-foreground'];
+export const LOADING_COLOR = light['--color-secondary-foreground'];
 
 export const RING_CENTER = RING_SIZE / 2;
 export const RING_RADIUS = (RING_SIZE - STROKE_WIDTH) / 2;

--- a/packages/app/src/theme/provider/theme.provider.tsx
+++ b/packages/app/src/theme/provider/theme.provider.tsx
@@ -10,7 +10,7 @@ import { ColorSchemaEnum } from '../enum/color-schema.enum';
 
 import type { ReactNode } from 'react';
 
-const light = {
+export const light = {
     '--color-primary': 'rgb(0, 0, 0)',
     '--color-primary-reverse': 'rgb(255, 255, 255)',
     '--color-secondary-foreground': 'rgba(115, 115, 115, 1)',
@@ -44,7 +44,7 @@ const light = {
     '--color-separator': 'linear-gradient(90deg, rgba(0, 0, 0, 0.40) 0%, rgba(255, 255, 255, 0.00) 100%)'
 };
 
-const dark = {
+export const dark = {
     '--color-primary': 'rgb(255, 255, 255)',
     '--color-primary-reverse': 'rgb(0, 0, 0)',
     '--color-secondary-foreground': 'rgba(136, 136, 136, 1)',


### PR DESCRIPTION
## Summary
Fixes toggle switch visibility issues in dark mode on iOS 26.

## Changes
- Updated `ThemedSwitch` to use theme colors from `theme.provider.tsx`
- Removed hardcoded `colors.constant.ts` file
- Updated `animated-record-button.constant.ts` to use theme colors
- Exported `light` and `dark` theme objects for reuse

## Details
The switch now uses:
- `--color-primary` for thumb color
- `--color-secondary-foreground` for track ON state
- `--color-secondary-corner` for track OFF state and iOS background

This ensures colors are defined in one place (theme provider) and properly adapt to both light and dark modes.