### PR TITLE
fix(contracts): trim account, category, tag title inputs via zod

### DIFF
--- a/packages/contracts/src/account/schema/account-entity.schema.ts
+++ b/packages/contracts/src/account/schema/account-entity.schema.ts
@@ -14,7 +14,7 @@ import { AccountEntityTable } from '../table/account-entity.table';
 export const AccountEntitySchema = createSelectSchema(AccountEntityTable, {
     ...BaseEntityFields,
     includeInNetWorth: schema => schema.default(true).describe('Determines whether the account should be included in net worth.'),
-    title: schema => schema.min(ACCOUNT_TITLE_MIN_LENGTH).max(ACCOUNT_TITLE_MAX_LENGTH).describe('The account title.'),
+    title: schema => schema.trim().min(ACCOUNT_TITLE_MIN_LENGTH).max(ACCOUNT_TITLE_MAX_LENGTH).describe('The account title.'),
     type: zodEnum(AccountTypeEnum).describe('The account type.'),
     debtType: zodEnum(AccountDebtTypeEnum).describe('The account debt type.'),
     order: schema => schema.nonnegative().default(0).describe('The account order.'),

--- a/packages/contracts/src/category/schema/category-entity.schema.ts
+++ b/packages/contracts/src/category/schema/category-entity.schema.ts
@@ -9,7 +9,7 @@ import { CategoryEntityTable } from '../table/category-entity.table';
 
 export const CategoryEntitySchema = createSelectSchema(CategoryEntityTable, {
     ...BaseEntityFields,
-    title: schema => schema.min(CATEGORY_TITLE_MIN_LENGTH).max(CATEGORY_TITLE_MAX_LENGTH).describe('The category title.'),
+    title: schema => schema.trim().min(CATEGORY_TITLE_MIN_LENGTH).max(CATEGORY_TITLE_MAX_LENGTH).describe('The category title.'),
     icon: zodEnum(UserIconNameEnum, {
         message: 'Invalid icon selected'
     }).describe('The category icon.'),

--- a/packages/contracts/src/tag/schema/tag-entity.schema.ts
+++ b/packages/contracts/src/tag/schema/tag-entity.schema.ts
@@ -7,5 +7,5 @@ import { TagEntityTable } from '../table/tag-entity.table';
 
 export const TagEntitySchema = createSelectSchema(TagEntityTable, {
     ...BaseEntityFields,
-    title: schema => schema.min(TAG_TITLE_MIN_LENGTH).max(TAG_TITLE_MAX_LENGTH).describe('The tag title.')
+    title: schema => schema.trim().min(TAG_TITLE_MIN_LENGTH).max(TAG_TITLE_MAX_LENGTH).describe('The tag title.')
 });


### PR DESCRIPTION
Adds .trim() transformation to the title field in entity schemas for
account, category, and tag. This ensures whitespace is trimmed before
validation when creating or updating these entities.

Closes #260