### PR TITLE
fix(app): fix tag/category form not receiving search input

### DIFF
--- a/packages/app/src/category/components/category-form/category-form.tsx
+++ b/packages/app/src/category/components/category-form/category-form.tsx
@@ -1,5 +1,6 @@
 import { CATEGORY_TITLE_MAX_LENGTH, CategoryCreateEntityInterface, CategoryEntityInterface, UserIconNameEnum } from '@budgie/contracts';
 import { Trans, useLingui } from '@lingui/react/macro';
+import { Controller, UseControllerReturn } from 'react-hook-form';
 import { TextInput, View } from 'react-native';
 
 import { isDefined } from '@rnw-community/shared';
@@ -30,12 +31,13 @@ interface Props {
     readonly onCancel: () => void;
 }
 
+ 
 export const CategoryForm = (props: Props) => {
     const { category, defaultTitle, onSuccess, onCancel } = props;
     const { t } = useLingui();
     const { backgroundColor } = useFormsheetListStyles();
     const { openCategorySelector } = useCategorySelectorModal();
-    const { handleSubmit, reset, register, control } = useCategoryForm(category ?? null, defaultTitle);
+    const { handleSubmit, reset, control } = useCategoryForm(category ?? null, defaultTitle);
 
     const isEditing = isDefined(category?.id);
     const containerStyle = { flex: 1, backgroundColor };
@@ -85,19 +87,24 @@ export const CategoryForm = (props: Props) => {
         onCancel();
     };
 
+    const renderTitleInput = ({ field: { value, onChange } }: UseControllerReturn<CategoryCreateEntityInterface, 'title'>) => (
+        <TextInput
+            className="h-[48px] px-lg bg-secondary-background rounded-xl border border-secondary-corner text-primary"
+            placeholder={t`e.g., Groceries, Salary, Rent`}
+            maxLength={CATEGORY_TITLE_MAX_LENGTH}
+            autoCapitalize="words"
+            autoCorrect={false}
+            value={value}
+            onChangeText={onChange}
+        />
+    );
+
     return (
         <View style={containerStyle}>
             <FormSheetHeader>{title}</FormSheetHeader>
             <View className="px-3xl gap-y-2xl">
                 <FormItem label={t`Category Name`}>
-                    <TextInput
-                        className="h-[48px] px-lg bg-secondary-background rounded-xl border border-secondary-corner text-primary"
-                        placeholder={t`e.g., Groceries, Salary, Rent`}
-                        maxLength={CATEGORY_TITLE_MAX_LENGTH}
-                        autoCapitalize="words"
-                        autoCorrect={false}
-                        {...register('title')}
-                    />
+                    <Controller name="title" control={control} render={renderTitleInput} />
                 </FormItem>
                 <CategoryFormIconField control={control} />
                 {isEditing ? (

--- a/packages/app/src/tag/components/tag-form/tag-form.tsx
+++ b/packages/app/src/tag/components/tag-form/tag-form.tsx
@@ -1,5 +1,6 @@
 import { TAG_TITLE_MAX_LENGTH, TagCreateEntityInterface, TagEntityInterface, UserIconNameEnum } from '@budgie/contracts';
 import { Trans, useLingui } from '@lingui/react/macro';
+import { Controller, UseControllerReturn } from 'react-hook-form';
 import { TextInput, View } from 'react-native';
 
 import { isDefined, isNotEmptyArray } from '@rnw-community/shared';
@@ -29,12 +30,13 @@ interface Props {
     readonly onCancel: () => void;
 }
 
+ 
 export const TagForm = (props: Props) => {
     const { tag, defaultTitle, onSuccess, onCancel } = props;
     const { t } = useLingui();
     const { backgroundColor } = useFormsheetListStyles();
     const { openTagsSelector } = useTagsSelectorModal();
-    const { handleSubmit, reset, register } = useTagForm(tag ?? (defaultTitle ? { title: defaultTitle } : null));
+    const { handleSubmit, reset, control } = useTagForm(tag ?? (defaultTitle ? { title: defaultTitle } : null));
 
     const isEditing = isDefined(tag?.id);
     const containerStyle = { flex: 1, backgroundColor };
@@ -84,19 +86,24 @@ export const TagForm = (props: Props) => {
         onCancel();
     };
 
+    const renderTitleInput = ({ field: { value, onChange } }: UseControllerReturn<TagCreateEntityInterface, 'title'>) => (
+        <TextInput
+            className="h-[48px] px-lg bg-secondary-background rounded-xl border border-secondary-corner text-primary"
+            placeholder={t`e.g., Business, Personal, Vacation`}
+            maxLength={TAG_TITLE_MAX_LENGTH}
+            autoCapitalize="words"
+            autoCorrect={false}
+            value={value}
+            onChangeText={onChange}
+        />
+    );
+
     return (
         <View style={containerStyle}>
             <FormSheetHeader>{title}</FormSheetHeader>
             <View className="px-3xl gap-y-2xl">
                 <FormItem label={t`Tag Name`}>
-                    <TextInput
-                        className="h-[48px] px-lg bg-secondary-background rounded-xl border border-secondary-corner text-primary"
-                        placeholder={t`e.g., Business, Personal, Vacation`}
-                        maxLength={TAG_TITLE_MAX_LENGTH}
-                        autoCapitalize="words"
-                        autoCorrect={false}
-                        {...register('title')}
-                    />
+                    <Controller name="title" control={control} render={renderTitleInput} />
                 </FormItem>
                 {isEditing ? (
                     <Button


### PR DESCRIPTION
## Summary
- Fixes tag and category creation forms not receiving the search input text when user clicks "Create" button
- Root cause: `react-hook-form`'s `register()` doesn't work with React Native `TextInput` because it expects DOM events (`onChange`) while RN uses `onChangeText(string)`
- Solution: Replace `{...register('title')}` with `Controller` component that properly wires `value` and `onChangeText`

## Test plan
- [ ] Open tags selector modal
- [ ] Type a search term (e.g., "Vacation")
- [ ] Click the "+" create button
- [ ] Verify the form's title input is pre-filled with "Vacation"
- [ ] Repeat for category selector

Closes #278

🤖 Generated with [Claude Code](https://claude.ai/code)