### PR TITLE
chore(landing): add missing translations

### DIFF
--- a/packages/landing/src/i18n/locales/de/messages.po
+++ b/packages/landing/src/i18n/locales/de/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "'Yes! You can sync your data across devices using your own cloud storage (iCloud, Google Drive, Dropbox). Your data remains encrypted and private—we never see it during the sync process."
 msgstr "Ja! Sie können Ihre Daten über Ihren eigenen Cloud-Speicher (iCloud, Google Drive, Dropbox) auf mehreren Geräten synchronisieren. Ihre Daten bleiben verschlüsselt und privat – wir sehen sie während des Synchronisierungsprozesses niemals."
 
-#: src/generic/component/hero-section/hero-section-header.tsx:78
+#: src/generic/component/hero-section/hero-section-header.tsx:84
 msgid "(Beta testers)"
 msgstr "(Beta-Tester)"
 
@@ -230,7 +230,7 @@ msgid "Blazing Fast"
 msgstr "Blitzschnell"
 
 #: src/generic/component/footer/footer.tsx:112
-#: src/generic/component/header/header.tsx:69
+#: src/generic/component/header/header.tsx:74
 #: src/generic/component/mobile-menu/mobile-menu.tsx:33
 msgid "Blog"
 msgstr "Blog"
@@ -243,7 +243,7 @@ msgstr "Blog & Einblicke"
 #: src/app/[lang]/layout.tsx:83
 #: src/generic/component/comparison-section/comparison-table-header.tsx:12
 #: src/generic/component/footer/footer.tsx:27
-#: src/generic/component/header/header.tsx:46
+#: src/generic/component/header/header.tsx:49
 #: src/generic/component/open-source-section/open-source-visual-header.tsx:12
 msgid "Budgie"
 msgstr "Budgie"
@@ -481,10 +481,6 @@ msgstr "Herunterladen"
 msgid "Download & Install"
 msgstr "Herunterladen & Installieren"
 
-#: src/generic/component/header/header.tsx:92
-msgid "Download App"
-msgstr "App herunterladen"
-
 #: src/generic/component/trust-banner/trust-banner.tsx:36
 msgid "Downloads"
 msgstr "Downloads"
@@ -501,7 +497,7 @@ msgstr "Fällig 30. Jan. 2025"
 msgid "Early Access"
 msgstr "Early Access"
 
-#: src/generic/component/waitlist-form/waitlist-success.tsx:55
+#: src/generic/component/waitlist-form/waitlist-success.tsx:59
 msgid "Early access members get 50% off lifetime"
 msgstr "Early-Access-Mitglieder erhalten 50% Rabatt lebenslang"
 
@@ -550,7 +546,7 @@ msgid "expense tracker, budget app, bank sync, crypto tracking, privacy, offline
 msgstr "Ausgaben-Tracker, Budget-App, Banksynchronisation, Krypto-Tracking, Datenschutz, Offline-First, Multi-Währung, Schuldenverfolgung, Finanzverwaltung"
 
 #: src/generic/component/faq-section/faq-section.tsx:27
-#: src/generic/component/header/header.tsx:83
+#: src/generic/component/header/header.tsx:90
 #: src/generic/component/mobile-menu/mobile-menu.tsx:41
 msgid "FAQ"
 msgstr "FAQ"
@@ -560,7 +556,7 @@ msgid "Feature"
 msgstr "Funktion"
 
 #: src/generic/component/footer/footer.tsx:80
-#: src/generic/component/header/header.tsx:55
+#: src/generic/component/header/header.tsx:59
 #: src/generic/component/mobile-menu/mobile-menu.tsx:25
 msgid "Features"
 msgstr "Funktionen"
@@ -706,7 +702,7 @@ msgstr "Integrationen"
 msgid "Investment Portfolio"
 msgstr "Investmentportfolio"
 
-#: src/generic/component/hero-section/hero-section-header.tsx:88
+#: src/generic/component/hero-section/hero-section-header.tsx:94
 msgid "iOS & Android"
 msgstr "iOS & Android"
 
@@ -738,6 +734,7 @@ msgstr "Treten Sie der Budgie-Warteliste bei und gehören Sie zu den Ersten, die
 msgid "Join the Whitelist & Save 25%"
 msgstr "Treten Sie der Whitelist bei & sparen Sie 25%"
 
+#: src/generic/component/header/header.tsx:100
 #: src/generic/component/waitlist-form/waitlist-form.tsx:116
 msgid "Join Waitlist"
 msgstr "Warteliste beitreten"
@@ -1132,10 +1129,6 @@ msgstr "Sterne"
 msgid "Start Free Trial"
 msgstr "Kostenlose Testversion starten"
 
-#: src/generic/component/hero-section/hero-section-header.tsx:45
-msgid "Start Keeping It."
-msgstr "Fangen Sie an, es zu behalten."
-
 #: src/generic/component/how-it-works-section/how-it-works-section.tsx:32
 msgid "Start Tracking in Minutes"
 msgstr "Beginnen Sie in Minuten mit dem Tracking"
@@ -1143,10 +1136,6 @@ msgstr "Beginnen Sie in Minuten mit dem Tracking"
 #: src/app/[lang]/blog/page.tsx:50
 msgid "Stay informed about financial privacy, security best practices, and the latest features in Budgie."
 msgstr "Bleiben Sie über finanzielle Privatsphäre, Sicherheits-Best-Practices und die neuesten Funktionen in Budgie informiert."
-
-#: src/generic/component/hero-section/hero-section-header.tsx:39
-msgid "Stop Leaking Money."
-msgstr "Stopfen Sie die Geldlecks."
 
 #: src/generic/component/features-section/features-section-header.tsx:30
 msgid "Stop switching between apps. Budgie tracks your bank accounts, credit cards, cash, crypto, and investments together—so you finally see the complete picture of your finances."
@@ -1181,7 +1170,7 @@ msgstr "Synchronisiert mit 1000+ Banken und Finanzinstituten"
 msgid "Terms of Service"
 msgstr "Nutzungsbedingungen"
 
-#: src/generic/component/header/header.tsx:62
+#: src/generic/component/header/header.tsx:67
 #: src/generic/component/mobile-menu/mobile-menu.tsx:29
 msgid "Testimonials"
 msgstr "Erfahrungsberichte"
@@ -1189,10 +1178,6 @@ msgstr "Erfahrungsberichte"
 #: src/generic/component/analytics-section/analytics-section-content.tsx:26
 msgid "That daily coffee? $150/month. Forgotten subscriptions? $80/month. Budgie exposes every spending leak so you can finally plug them and keep more money in your pocket."
 msgstr "Der tägliche Kaffee? $150/Monat. Vergessene Abonnements? $80/Monat. Budgie deckt jedes Ausgabenleck auf, damit Sie es endlich stopfen und mehr Geld in der Tasche behalten können."
-
-#: src/generic/component/hero-section/hero-section-header.tsx:50
-msgid "The average person overspends $400/month without realizing it. Budgie tracks every dollar offline, encrypted with your fingerprint—so you finally see where your money really goes."
-msgstr "Der Durchschnittsmensch gibt $400/Monat zu viel aus, ohne es zu merken. Budgie verfolgt jeden Euro offline, verschlüsselt mit Ihrem Fingerabdruck – so sehen Sie endlich, wohin Ihr Geld wirklich geht."
 
 #: src/generic/component/testimonials-section/testimonials-slider.tsx:28
 msgid "The debt tracking feature helped me pay off my student loans 6 months early. Watching that progress bar fill up kept me motivated every single day."
@@ -1222,7 +1207,7 @@ msgstr "Dritte sehen Ihre Daten"
 msgid "This Month's Reality Check"
 msgstr "Der Realitätscheck dieses Monats"
 
-#: src/generic/component/header/header.tsx:100
+#: src/generic/component/header/header.tsx:109
 msgid "Toggle menu"
 msgstr "Menü umschalten"
 
@@ -1339,7 +1324,7 @@ msgstr "Alle Integrationen anzeigen"
 msgid "View on GitHub"
 msgstr "Auf GitHub ansehen"
 
-#: src/generic/component/hero-section/hero-section-header.tsx:61
+#: src/generic/component/hero-section/hero-section-header.tsx:67
 msgid "View Source Code"
 msgstr "Quellcode anzeigen"
 
@@ -1384,7 +1369,7 @@ msgid "What Makes Us Different"
 msgstr "Was uns unterscheidet"
 
 #: src/generic/component/footer/footer.tsx:88
-#: src/generic/component/header/header.tsx:76
+#: src/generic/component/header/header.tsx:82
 #: src/generic/component/mobile-menu/mobile-menu.tsx:37
 msgid "Whitelist"
 msgstr "Whitelist"
@@ -1430,7 +1415,7 @@ msgid "Works Offline"
 msgstr "Funktioniert offline"
 
 #: src/generic/component/comparison-section/comparison-table-body.tsx:12
-#: src/generic/component/hero-section/hero-section-header.tsx:108
+#: src/generic/component/hero-section/hero-section-header.tsx:114
 msgid "Works without internet"
 msgstr "Funktioniert ohne Internet"
 
@@ -1446,13 +1431,17 @@ msgstr "Ja, zeige mir die Details"
 msgid "You owe Sarah"
 msgstr "Sie schulden Sarah"
 
-#: src/generic/component/waitlist-form/waitlist-success.tsx:47
-msgid "You're #{position} on the waitlist. We'll notify you when Budgie launches!"
-msgstr "Sie sind #{position} auf der Warteliste. Wir benachrichtigen Sie, wenn Budgie startet!"
+#: src/generic/component/waitlist-form/waitlist-success.tsx:51
+msgid "You're #{displayPosition} on the waitlist. We'll notify you when Budgie launches!"
+msgstr "Sie sind #{displayPosition} auf der Warteliste. Wir benachrichtigen Sie, wenn Budgie startet!"
 
-#: src/generic/component/waitlist-form/waitlist-success.tsx:41
+#: src/generic/component/waitlist-form/waitlist-success.tsx:45
 msgid "You're in!"
 msgstr "Sie sind dabei!"
+
+#: src/generic/component/hero-section/hero-section-header.tsx:56
+msgid "Your bank knows everything. Mint sold your data. YNAB stores it on their servers. Budgie keeps your finances on your device—encrypted, offline, and yours alone."
+msgstr "Ihre Bank weiß alles. Mint hat Ihre Daten verkauft. YNAB speichert sie auf deren Servern. Budgie bewahrt Ihre Finanzen auf Ihrem Gerät – verschlüsselt, offline und nur Ihnen gehörend."
 
 #: src/generic/component/usp-pillars-section/usp-pillars-section.tsx:58
 msgid "Your data is encrypted using your Face ID or fingerprint. Only you can ever access it."
@@ -1475,6 +1464,10 @@ msgstr "Ihre Daten gehören Ihnen"
 msgid "Your data stored on their servers"
 msgstr "Ihre Daten auf deren Servern gespeichert"
 
+#: src/generic/component/hero-section/hero-section-header.tsx:45
+msgid "Your Device."
+msgstr "Ihr Gerät."
+
 #: src/generic/component/security-section/security-section-header.tsx:30
 msgid "Your financial data never leaves your device. No servers, no cloud, no tracking—just complete privacy with enterprise-grade security features."
 msgstr "Ihre Finanzdaten verlassen niemals Ihr Gerät. Keine Server, keine Cloud, kein Tracking – nur vollständige Privatsphäre mit Sicherheitsfunktionen auf Unternehmensniveau."
@@ -1482,6 +1475,14 @@ msgstr "Ihre Finanzdaten verlassen niemals Ihr Gerät. Keine Server, keine Cloud
 #: src/generic/component/usp-pillars-section/usp-pillars-section.tsx:41
 msgid "Your financial data never leaves your phone. No servers, no cloud, no risk of data breaches."
 msgstr "Ihre Finanzdaten verlassen niemals Ihr Telefon. Keine Server, keine Cloud, kein Risiko von Datenpannen."
+
+#: src/generic/component/hero-section/hero-section-header.tsx:39
+msgid "Your Financial Data."
+msgstr "Ihre Finanzdaten."
+
+#: src/generic/component/hero-section/hero-section-header.tsx:51
+msgid "Your Rules."
+msgstr "Ihre Regeln."
 
 #: src/generic/component/ai-section/ai-section.tsx:47
 msgid "Zero Cloud"
@@ -1491,7 +1492,7 @@ msgstr "Null Cloud"
 msgid "Zero Cloud Storage"
 msgstr "Null Cloud-Speicher"
 
-#: src/generic/component/hero-section/hero-section-header.tsx:98
+#: src/generic/component/hero-section/hero-section-header.tsx:104
 msgid "Zero data collection"
 msgstr "Keine Datensammlung"
 

--- a/packages/landing/src/i18n/locales/es/messages.po
+++ b/packages/landing/src/i18n/locales/es/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "'Yes! You can sync your data across devices using your own cloud storage (iCloud, Google Drive, Dropbox). Your data remains encrypted and private—we never see it during the sync process."
 msgstr "¡Sí! Puedes sincronizar tus datos en varios dispositivos usando tu propio almacenamiento en la nube (iCloud, Google Drive, Dropbox). Tus datos permanecen encriptados y privados; nunca los vemos durante el proceso de sincronización."
 
-#: src/generic/component/hero-section/hero-section-header.tsx:78
+#: src/generic/component/hero-section/hero-section-header.tsx:84
 msgid "(Beta testers)"
 msgstr "(Beta testers)"
 
@@ -230,7 +230,7 @@ msgid "Blazing Fast"
 msgstr "Ultrarrápido"
 
 #: src/generic/component/footer/footer.tsx:112
-#: src/generic/component/header/header.tsx:69
+#: src/generic/component/header/header.tsx:74
 #: src/generic/component/mobile-menu/mobile-menu.tsx:33
 msgid "Blog"
 msgstr "Blog"
@@ -243,7 +243,7 @@ msgstr "Blog y Perspectivas"
 #: src/app/[lang]/layout.tsx:83
 #: src/generic/component/comparison-section/comparison-table-header.tsx:12
 #: src/generic/component/footer/footer.tsx:27
-#: src/generic/component/header/header.tsx:46
+#: src/generic/component/header/header.tsx:49
 #: src/generic/component/open-source-section/open-source-visual-header.tsx:12
 msgid "Budgie"
 msgstr "Budgie"
@@ -481,10 +481,6 @@ msgstr "Descargar"
 msgid "Download & Install"
 msgstr "Descargar e Instalar"
 
-#: src/generic/component/header/header.tsx:92
-msgid "Download App"
-msgstr "Descargar App"
-
 #: src/generic/component/trust-banner/trust-banner.tsx:36
 msgid "Downloads"
 msgstr "Descargas"
@@ -501,7 +497,7 @@ msgstr "Vence 30 Ene, 2025"
 msgid "Early Access"
 msgstr "Acceso Anticipado"
 
-#: src/generic/component/waitlist-form/waitlist-success.tsx:55
+#: src/generic/component/waitlist-form/waitlist-success.tsx:59
 msgid "Early access members get 50% off lifetime"
 msgstr "Los miembros de acceso anticipado obtienen 50% de descuento de por vida"
 
@@ -550,7 +546,7 @@ msgid "expense tracker, budget app, bank sync, crypto tracking, privacy, offline
 msgstr "rastreador de gastos, app de presupuesto, sincronización bancaria, seguimiento de cripto, privacidad, sin conexión primero, multimoneda, seguimiento de deudas, gestión financiera"
 
 #: src/generic/component/faq-section/faq-section.tsx:27
-#: src/generic/component/header/header.tsx:83
+#: src/generic/component/header/header.tsx:90
 #: src/generic/component/mobile-menu/mobile-menu.tsx:41
 msgid "FAQ"
 msgstr "Preguntas Frecuentes"
@@ -560,7 +556,7 @@ msgid "Feature"
 msgstr "Característica"
 
 #: src/generic/component/footer/footer.tsx:80
-#: src/generic/component/header/header.tsx:55
+#: src/generic/component/header/header.tsx:59
 #: src/generic/component/mobile-menu/mobile-menu.tsx:25
 msgid "Features"
 msgstr "Características"
@@ -706,7 +702,7 @@ msgstr "Integraciones"
 msgid "Investment Portfolio"
 msgstr "Portafolio de Inversiones"
 
-#: src/generic/component/hero-section/hero-section-header.tsx:88
+#: src/generic/component/hero-section/hero-section-header.tsx:94
 msgid "iOS & Android"
 msgstr "iOS y Android"
 
@@ -738,6 +734,7 @@ msgstr "Únete a la lista de espera de Budgie y sé uno de los primeros en exper
 msgid "Join the Whitelist & Save 25%"
 msgstr "Únete a la Lista de Espera y Ahorra 25%"
 
+#: src/generic/component/header/header.tsx:100
 #: src/generic/component/waitlist-form/waitlist-form.tsx:116
 msgid "Join Waitlist"
 msgstr "Unirse a la Lista de Espera"
@@ -1132,10 +1129,6 @@ msgstr "Estrellas"
 msgid "Start Free Trial"
 msgstr "Iniciar Prueba Gratuita"
 
-#: src/generic/component/hero-section/hero-section-header.tsx:45
-msgid "Start Keeping It."
-msgstr "Empieza a Conservarlo."
-
 #: src/generic/component/how-it-works-section/how-it-works-section.tsx:32
 msgid "Start Tracking in Minutes"
 msgstr "Comienza a Rastrear en Minutos"
@@ -1143,10 +1136,6 @@ msgstr "Comienza a Rastrear en Minutos"
 #: src/app/[lang]/blog/page.tsx:50
 msgid "Stay informed about financial privacy, security best practices, and the latest features in Budgie."
 msgstr "Mantente informado sobre privacidad financiera, mejores prácticas de seguridad y las últimas funciones de Budgie."
-
-#: src/generic/component/hero-section/hero-section-header.tsx:39
-msgid "Stop Leaking Money."
-msgstr "Deja de Perder Dinero."
 
 #: src/generic/component/features-section/features-section-header.tsx:30
 msgid "Stop switching between apps. Budgie tracks your bank accounts, credit cards, cash, crypto, and investments together—so you finally see the complete picture of your finances."
@@ -1181,7 +1170,7 @@ msgstr "Sincroniza con más de 1000 bancos e instituciones financieras"
 msgid "Terms of Service"
 msgstr "Términos de Servicio"
 
-#: src/generic/component/header/header.tsx:62
+#: src/generic/component/header/header.tsx:67
 #: src/generic/component/mobile-menu/mobile-menu.tsx:29
 msgid "Testimonials"
 msgstr "Testimonios"
@@ -1189,10 +1178,6 @@ msgstr "Testimonios"
 #: src/generic/component/analytics-section/analytics-section-content.tsx:26
 msgid "That daily coffee? $150/month. Forgotten subscriptions? $80/month. Budgie exposes every spending leak so you can finally plug them and keep more money in your pocket."
 msgstr "¿Ese café diario? $150/mes. ¿Suscripciones olvidadas? $80/mes. Budgie expone cada fuga de gasto para que finalmente puedas taparlas y mantener más dinero en tu bolsillo."
-
-#: src/generic/component/hero-section/hero-section-header.tsx:50
-msgid "The average person overspends $400/month without realizing it. Budgie tracks every dollar offline, encrypted with your fingerprint—so you finally see where your money really goes."
-msgstr "La persona promedio gasta de más $400/mes sin darse cuenta. Budgie rastrea cada dólar sin conexión, encriptado con tu huella digital, para que finalmente veas a dónde realmente va tu dinero."
 
 #: src/generic/component/testimonials-section/testimonials-slider.tsx:28
 msgid "The debt tracking feature helped me pay off my student loans 6 months early. Watching that progress bar fill up kept me motivated every single day."
@@ -1222,7 +1207,7 @@ msgstr "Terceros ven tus datos"
 msgid "This Month's Reality Check"
 msgstr "El Chequeo de Realidad de Este Mes"
 
-#: src/generic/component/header/header.tsx:100
+#: src/generic/component/header/header.tsx:109
 msgid "Toggle menu"
 msgstr "Alternar menú"
 
@@ -1339,7 +1324,7 @@ msgstr "Ver Todas las Integraciones"
 msgid "View on GitHub"
 msgstr "Ver en GitHub"
 
-#: src/generic/component/hero-section/hero-section-header.tsx:61
+#: src/generic/component/hero-section/hero-section-header.tsx:67
 msgid "View Source Code"
 msgstr "Ver Código Fuente"
 
@@ -1384,7 +1369,7 @@ msgid "What Makes Us Different"
 msgstr "Qué Nos Hace Diferentes"
 
 #: src/generic/component/footer/footer.tsx:88
-#: src/generic/component/header/header.tsx:76
+#: src/generic/component/header/header.tsx:82
 #: src/generic/component/mobile-menu/mobile-menu.tsx:37
 msgid "Whitelist"
 msgstr "Lista de Espera"
@@ -1430,7 +1415,7 @@ msgid "Works Offline"
 msgstr "Funciona Sin Conexión"
 
 #: src/generic/component/comparison-section/comparison-table-body.tsx:12
-#: src/generic/component/hero-section/hero-section-header.tsx:108
+#: src/generic/component/hero-section/hero-section-header.tsx:114
 msgid "Works without internet"
 msgstr "Funciona sin internet"
 
@@ -1446,13 +1431,17 @@ msgstr "Sí, muéstrame los detalles"
 msgid "You owe Sarah"
 msgstr "Le debes a Sarah"
 
-#: src/generic/component/waitlist-form/waitlist-success.tsx:47
-msgid "You're #{position} on the waitlist. We'll notify you when Budgie launches!"
-msgstr "Eres el #{position} en la lista de espera. ¡Te notificaremos cuando Budgie se lance!"
+#: src/generic/component/waitlist-form/waitlist-success.tsx:51
+msgid "You're #{displayPosition} on the waitlist. We'll notify you when Budgie launches!"
+msgstr "Estás en el puesto #{displayPosition} de la lista de espera. ¡Te avisaremos cuando Budgie se lance!"
 
-#: src/generic/component/waitlist-form/waitlist-success.tsx:41
+#: src/generic/component/waitlist-form/waitlist-success.tsx:45
 msgid "You're in!"
 msgstr "¡Estás dentro!"
+
+#: src/generic/component/hero-section/hero-section-header.tsx:56
+msgid "Your bank knows everything. Mint sold your data. YNAB stores it on their servers. Budgie keeps your finances on your device—encrypted, offline, and yours alone."
+msgstr "Tu banco lo sabe todo. Mint vendió tus datos. YNAB los almacena en sus servidores. Budgie mantiene tus finanzas en tu dispositivo: cifradas, sin conexión y solo tuyas."
 
 #: src/generic/component/usp-pillars-section/usp-pillars-section.tsx:58
 msgid "Your data is encrypted using your Face ID or fingerprint. Only you can ever access it."
@@ -1475,6 +1464,10 @@ msgstr "Tus Datos Siguen Siendo Tuyos"
 msgid "Your data stored on their servers"
 msgstr "Tus datos almacenados en sus servidores"
 
+#: src/generic/component/hero-section/hero-section-header.tsx:45
+msgid "Your Device."
+msgstr "Tu Dispositivo."
+
 #: src/generic/component/security-section/security-section-header.tsx:30
 msgid "Your financial data never leaves your device. No servers, no cloud, no tracking—just complete privacy with enterprise-grade security features."
 msgstr "Tus datos financieros nunca salen de tu dispositivo. Sin servidores, sin nube, sin rastreo; solo privacidad completa con funciones de seguridad de nivel empresarial."
@@ -1482,6 +1475,14 @@ msgstr "Tus datos financieros nunca salen de tu dispositivo. Sin servidores, sin
 #: src/generic/component/usp-pillars-section/usp-pillars-section.tsx:41
 msgid "Your financial data never leaves your phone. No servers, no cloud, no risk of data breaches."
 msgstr "Tus datos financieros nunca salen de tu teléfono. Sin servidores, sin nube, sin riesgo de filtraciones de datos."
+
+#: src/generic/component/hero-section/hero-section-header.tsx:39
+msgid "Your Financial Data."
+msgstr "Tus Datos Financieros."
+
+#: src/generic/component/hero-section/hero-section-header.tsx:51
+msgid "Your Rules."
+msgstr "Tus Reglas."
 
 #: src/generic/component/ai-section/ai-section.tsx:47
 msgid "Zero Cloud"
@@ -1491,7 +1492,7 @@ msgstr "Cero Nube"
 msgid "Zero Cloud Storage"
 msgstr "Cero Almacenamiento en la Nube"
 
-#: src/generic/component/hero-section/hero-section-header.tsx:98
+#: src/generic/component/hero-section/hero-section-header.tsx:104
 msgid "Zero data collection"
 msgstr "Cero recolección de datos"
 

--- a/packages/landing/src/i18n/locales/fr/messages.po
+++ b/packages/landing/src/i18n/locales/fr/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "'Yes! You can sync your data across devices using your own cloud storage (iCloud, Google Drive, Dropbox). Your data remains encrypted and private—we never see it during the sync process."
 msgstr "'Oui ! Vous pouvez synchroniser vos données entre appareils en utilisant votre propre stockage cloud (iCloud, Google Drive, Dropbox). Vos données restent chiffrées et privées — nous ne les voyons jamais pendant le processus de synchronisation.'"
 
-#: src/generic/component/hero-section/hero-section-header.tsx:78
+#: src/generic/component/hero-section/hero-section-header.tsx:84
 msgid "(Beta testers)"
 msgstr "(Bêta-testeurs)"
 
@@ -230,7 +230,7 @@ msgid "Blazing Fast"
 msgstr "Ultra rapide"
 
 #: src/generic/component/footer/footer.tsx:112
-#: src/generic/component/header/header.tsx:69
+#: src/generic/component/header/header.tsx:74
 #: src/generic/component/mobile-menu/mobile-menu.tsx:33
 msgid "Blog"
 msgstr "Blog"
@@ -243,7 +243,7 @@ msgstr "Blog et Perspectives"
 #: src/app/[lang]/layout.tsx:83
 #: src/generic/component/comparison-section/comparison-table-header.tsx:12
 #: src/generic/component/footer/footer.tsx:27
-#: src/generic/component/header/header.tsx:46
+#: src/generic/component/header/header.tsx:49
 #: src/generic/component/open-source-section/open-source-visual-header.tsx:12
 msgid "Budgie"
 msgstr "Budgie"
@@ -481,10 +481,6 @@ msgstr "Télécharger"
 msgid "Download & Install"
 msgstr "Télécharger et installer"
 
-#: src/generic/component/header/header.tsx:92
-msgid "Download App"
-msgstr "Télécharger l'application"
-
 #: src/generic/component/trust-banner/trust-banner.tsx:36
 msgid "Downloads"
 msgstr "Téléchargements"
@@ -501,7 +497,7 @@ msgstr "Échéance 30 janv. 2025"
 msgid "Early Access"
 msgstr "Accès anticipé"
 
-#: src/generic/component/waitlist-form/waitlist-success.tsx:55
+#: src/generic/component/waitlist-form/waitlist-success.tsx:59
 msgid "Early access members get 50% off lifetime"
 msgstr "Les membres en accès anticipé bénéficient de 50 % de réduction à vie"
 
@@ -550,7 +546,7 @@ msgid "expense tracker, budget app, bank sync, crypto tracking, privacy, offline
 msgstr "gestionnaire de dépenses, application budget, synchronisation bancaire, suivi crypto, confidentialité, offline-first, multidevise, suivi des dettes, gestion financière"
 
 #: src/generic/component/faq-section/faq-section.tsx:27
-#: src/generic/component/header/header.tsx:83
+#: src/generic/component/header/header.tsx:90
 #: src/generic/component/mobile-menu/mobile-menu.tsx:41
 msgid "FAQ"
 msgstr "FAQ"
@@ -560,7 +556,7 @@ msgid "Feature"
 msgstr "Fonctionnalité"
 
 #: src/generic/component/footer/footer.tsx:80
-#: src/generic/component/header/header.tsx:55
+#: src/generic/component/header/header.tsx:59
 #: src/generic/component/mobile-menu/mobile-menu.tsx:25
 msgid "Features"
 msgstr "Fonctionnalités"
@@ -706,7 +702,7 @@ msgstr "Intégrations"
 msgid "Investment Portfolio"
 msgstr "Portefeuille d'investissement"
 
-#: src/generic/component/hero-section/hero-section-header.tsx:88
+#: src/generic/component/hero-section/hero-section-header.tsx:94
 msgid "iOS & Android"
 msgstr "iOS et Android"
 
@@ -738,6 +734,7 @@ msgstr "Rejoignez la liste d'attente Budgie et soyez parmi les premiers à déco
 msgid "Join the Whitelist & Save 25%"
 msgstr "Rejoignez la liste blanche et économisez 25 %"
 
+#: src/generic/component/header/header.tsx:100
 #: src/generic/component/waitlist-form/waitlist-form.tsx:116
 msgid "Join Waitlist"
 msgstr "Rejoindre la liste d'attente"
@@ -1132,10 +1129,6 @@ msgstr "Stars"
 msgid "Start Free Trial"
 msgstr "Commencer l'essai gratuit"
 
-#: src/generic/component/hero-section/hero-section-header.tsx:45
-msgid "Start Keeping It."
-msgstr "Commencez à le garder."
-
 #: src/generic/component/how-it-works-section/how-it-works-section.tsx:32
 msgid "Start Tracking in Minutes"
 msgstr "Commencez le suivi en quelques minutes"
@@ -1143,10 +1136,6 @@ msgstr "Commencez le suivi en quelques minutes"
 #: src/app/[lang]/blog/page.tsx:50
 msgid "Stay informed about financial privacy, security best practices, and the latest features in Budgie."
 msgstr "Restez informé de la confidentialité financière, des meilleures pratiques de sécurité et des dernières fonctionnalités de Budgie."
-
-#: src/generic/component/hero-section/hero-section-header.tsx:39
-msgid "Stop Leaking Money."
-msgstr "Arrêtez de perdre de l'argent."
 
 #: src/generic/component/features-section/features-section-header.tsx:30
 msgid "Stop switching between apps. Budgie tracks your bank accounts, credit cards, cash, crypto, and investments together—so you finally see the complete picture of your finances."
@@ -1181,7 +1170,7 @@ msgstr "Synchronisation avec plus de 1000 banques et institutions financières"
 msgid "Terms of Service"
 msgstr "Conditions d'utilisation"
 
-#: src/generic/component/header/header.tsx:62
+#: src/generic/component/header/header.tsx:67
 #: src/generic/component/mobile-menu/mobile-menu.tsx:29
 msgid "Testimonials"
 msgstr "Témoignages"
@@ -1189,10 +1178,6 @@ msgstr "Témoignages"
 #: src/generic/component/analytics-section/analytics-section-content.tsx:26
 msgid "That daily coffee? $150/month. Forgotten subscriptions? $80/month. Budgie exposes every spending leak so you can finally plug them and keep more money in your pocket."
 msgstr "Ce café quotidien ? 150 $/mois. Les abonnements oubliés ? 80 $/mois. Budgie expose chaque fuite de dépenses pour que vous puissiez enfin les colmater et garder plus d'argent dans votre poche."
-
-#: src/generic/component/hero-section/hero-section-header.tsx:50
-msgid "The average person overspends $400/month without realizing it. Budgie tracks every dollar offline, encrypted with your fingerprint—so you finally see where your money really goes."
-msgstr "La personne moyenne dépense 400 $/mois de trop sans s'en rendre compte. Budgie suit chaque euro hors ligne, chiffré avec votre empreinte digitale — pour enfin voir où va vraiment votre argent."
 
 #: src/generic/component/testimonials-section/testimonials-slider.tsx:28
 msgid "The debt tracking feature helped me pay off my student loans 6 months early. Watching that progress bar fill up kept me motivated every single day."
@@ -1222,7 +1207,7 @@ msgstr "Des tiers voient vos données"
 msgid "This Month's Reality Check"
 msgstr "Le bilan réaliste du mois"
 
-#: src/generic/component/header/header.tsx:100
+#: src/generic/component/header/header.tsx:109
 msgid "Toggle menu"
 msgstr "Basculer le menu"
 
@@ -1339,7 +1324,7 @@ msgstr "Voir toutes les intégrations"
 msgid "View on GitHub"
 msgstr "Voir sur GitHub"
 
-#: src/generic/component/hero-section/hero-section-header.tsx:61
+#: src/generic/component/hero-section/hero-section-header.tsx:67
 msgid "View Source Code"
 msgstr "Voir le code source"
 
@@ -1384,7 +1369,7 @@ msgid "What Makes Us Different"
 msgstr "Ce qui nous différencie"
 
 #: src/generic/component/footer/footer.tsx:88
-#: src/generic/component/header/header.tsx:76
+#: src/generic/component/header/header.tsx:82
 #: src/generic/component/mobile-menu/mobile-menu.tsx:37
 msgid "Whitelist"
 msgstr "Liste blanche"
@@ -1430,7 +1415,7 @@ msgid "Works Offline"
 msgstr "Fonctionne hors ligne"
 
 #: src/generic/component/comparison-section/comparison-table-body.tsx:12
-#: src/generic/component/hero-section/hero-section-header.tsx:108
+#: src/generic/component/hero-section/hero-section-header.tsx:114
 msgid "Works without internet"
 msgstr "Fonctionne sans Internet"
 
@@ -1446,13 +1431,17 @@ msgstr "Oui, montrez-moi les détails"
 msgid "You owe Sarah"
 msgstr "Vous devez à Sarah"
 
-#: src/generic/component/waitlist-form/waitlist-success.tsx:47
-msgid "You're #{position} on the waitlist. We'll notify you when Budgie launches!"
-msgstr "Vous êtes #{position} sur la liste d'attente. Nous vous informerons du lancement de Budgie !"
+#: src/generic/component/waitlist-form/waitlist-success.tsx:51
+msgid "You're #{displayPosition} on the waitlist. We'll notify you when Budgie launches!"
+msgstr "Vous êtes #{displayPosition} sur la liste d'attente. Nous vous avertirons quand Budgie sera lancé !"
 
-#: src/generic/component/waitlist-form/waitlist-success.tsx:41
+#: src/generic/component/waitlist-form/waitlist-success.tsx:45
 msgid "You're in!"
 msgstr "Vous êtes inscrit !"
+
+#: src/generic/component/hero-section/hero-section-header.tsx:56
+msgid "Your bank knows everything. Mint sold your data. YNAB stores it on their servers. Budgie keeps your finances on your device—encrypted, offline, and yours alone."
+msgstr "Votre banque sait tout. Mint a vendu vos données. YNAB les stocke sur leurs serveurs. Budgie garde vos finances sur votre appareil – chiffrées, hors ligne et rien qu'à vous."
 
 #: src/generic/component/usp-pillars-section/usp-pillars-section.tsx:58
 msgid "Your data is encrypted using your Face ID or fingerprint. Only you can ever access it."
@@ -1475,6 +1464,10 @@ msgstr "Vos données restent les vôtres"
 msgid "Your data stored on their servers"
 msgstr "Vos données stockées sur leurs serveurs"
 
+#: src/generic/component/hero-section/hero-section-header.tsx:45
+msgid "Your Device."
+msgstr "Votre Appareil."
+
 #: src/generic/component/security-section/security-section-header.tsx:30
 msgid "Your financial data never leaves your device. No servers, no cloud, no tracking—just complete privacy with enterprise-grade security features."
 msgstr "Vos données financières ne quittent jamais votre appareil. Pas de serveurs, pas de cloud, pas de tracking — juste une confidentialité totale avec des fonctionnalités de sécurité de niveau entreprise."
@@ -1482,6 +1475,14 @@ msgstr "Vos données financières ne quittent jamais votre appareil. Pas de serv
 #: src/generic/component/usp-pillars-section/usp-pillars-section.tsx:41
 msgid "Your financial data never leaves your phone. No servers, no cloud, no risk of data breaches."
 msgstr "Vos données financières ne quittent jamais votre téléphone. Pas de serveurs, pas de cloud, aucun risque de violation de données."
+
+#: src/generic/component/hero-section/hero-section-header.tsx:39
+msgid "Your Financial Data."
+msgstr "Vos Données Financières."
+
+#: src/generic/component/hero-section/hero-section-header.tsx:51
+msgid "Your Rules."
+msgstr "Vos Règles."
 
 #: src/generic/component/ai-section/ai-section.tsx:47
 msgid "Zero Cloud"
@@ -1491,7 +1492,7 @@ msgstr "Zéro cloud"
 msgid "Zero Cloud Storage"
 msgstr "Zéro stockage cloud"
 
-#: src/generic/component/hero-section/hero-section-header.tsx:98
+#: src/generic/component/hero-section/hero-section-header.tsx:104
 msgid "Zero data collection"
 msgstr "Zéro collecte de données"
 

--- a/packages/landing/src/i18n/locales/uk/messages.po
+++ b/packages/landing/src/i18n/locales/uk/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "'Yes! You can sync your data across devices using your own cloud storage (iCloud, Google Drive, Dropbox). Your data remains encrypted and private—we never see it during the sync process."
 msgstr "Так! Ви можете синхронізувати свої дані між пристроями, використовуючи власне хмарне сховище (iCloud, Google Drive, Dropbox). Ваші дані залишаються зашифрованими та приватними — ми ніколи не бачимо їх під час синхронізації."
 
-#: src/generic/component/hero-section/hero-section-header.tsx:78
+#: src/generic/component/hero-section/hero-section-header.tsx:84
 msgid "(Beta testers)"
 msgstr "(Бета-тестери)"
 
@@ -230,7 +230,7 @@ msgid "Blazing Fast"
 msgstr "Блискавична швидкість"
 
 #: src/generic/component/footer/footer.tsx:112
-#: src/generic/component/header/header.tsx:69
+#: src/generic/component/header/header.tsx:74
 #: src/generic/component/mobile-menu/mobile-menu.tsx:33
 msgid "Blog"
 msgstr "Блог"
@@ -243,7 +243,7 @@ msgstr "Блог та Аналітика"
 #: src/app/[lang]/layout.tsx:83
 #: src/generic/component/comparison-section/comparison-table-header.tsx:12
 #: src/generic/component/footer/footer.tsx:27
-#: src/generic/component/header/header.tsx:46
+#: src/generic/component/header/header.tsx:49
 #: src/generic/component/open-source-section/open-source-visual-header.tsx:12
 msgid "Budgie"
 msgstr "Budgie"
@@ -481,10 +481,6 @@ msgstr "Завантажити"
 msgid "Download & Install"
 msgstr "Завантажте та встановіть"
 
-#: src/generic/component/header/header.tsx:92
-msgid "Download App"
-msgstr "Завантажити додаток"
-
 #: src/generic/component/trust-banner/trust-banner.tsx:36
 msgid "Downloads"
 msgstr "Завантаження"
@@ -501,7 +497,7 @@ msgstr "До 30 січня 2025"
 msgid "Early Access"
 msgstr "Ранній доступ"
 
-#: src/generic/component/waitlist-form/waitlist-success.tsx:55
+#: src/generic/component/waitlist-form/waitlist-success.tsx:59
 msgid "Early access members get 50% off lifetime"
 msgstr "Учасники раннього доступу отримують 50% знижки назавжди"
 
@@ -550,7 +546,7 @@ msgid "expense tracker, budget app, bank sync, crypto tracking, privacy, offline
 msgstr "трекер витрат, бюджетний додаток, синхронізація з банком, облік криптовалюти, приватність, офлайн, мультивалюта, облік боргів, фінансовий менеджмент"
 
 #: src/generic/component/faq-section/faq-section.tsx:27
-#: src/generic/component/header/header.tsx:83
+#: src/generic/component/header/header.tsx:90
 #: src/generic/component/mobile-menu/mobile-menu.tsx:41
 msgid "FAQ"
 msgstr "Питання та відповіді"
@@ -560,7 +556,7 @@ msgid "Feature"
 msgstr "Функція"
 
 #: src/generic/component/footer/footer.tsx:80
-#: src/generic/component/header/header.tsx:55
+#: src/generic/component/header/header.tsx:59
 #: src/generic/component/mobile-menu/mobile-menu.tsx:25
 msgid "Features"
 msgstr "Можливості"
@@ -706,7 +702,7 @@ msgstr "Інтеграції"
 msgid "Investment Portfolio"
 msgstr "Інвестиційний портфель"
 
-#: src/generic/component/hero-section/hero-section-header.tsx:88
+#: src/generic/component/hero-section/hero-section-header.tsx:94
 msgid "iOS & Android"
 msgstr "iOS та Android"
 
@@ -738,6 +734,7 @@ msgstr "Приєднуйтесь до списку очікування Budgie �
 msgid "Join the Whitelist & Save 25%"
 msgstr "Приєднуйтесь до білого списку та заощаджуйте 25%"
 
+#: src/generic/component/header/header.tsx:100
 #: src/generic/component/waitlist-form/waitlist-form.tsx:116
 msgid "Join Waitlist"
 msgstr "Приєднатися до списку очікування"
@@ -1132,10 +1129,6 @@ msgstr "Зірки"
 msgid "Start Free Trial"
 msgstr "Почати безкоштовно"
 
-#: src/generic/component/hero-section/hero-section-header.tsx:45
-msgid "Start Keeping It."
-msgstr "Почніть зберігати."
-
 #: src/generic/component/how-it-works-section/how-it-works-section.tsx:32
 msgid "Start Tracking in Minutes"
 msgstr "Почніть облік за кілька хвилин"
@@ -1143,10 +1136,6 @@ msgstr "Почніть облік за кілька хвилин"
 #: src/app/[lang]/blog/page.tsx:50
 msgid "Stay informed about financial privacy, security best practices, and the latest features in Budgie."
 msgstr "Будьте в курсі фінансової конфіденційності, найкращих практик безпеки та останніх функцій Budgie."
-
-#: src/generic/component/hero-section/hero-section-header.tsx:39
-msgid "Stop Leaking Money."
-msgstr "Припиніть втрачати гроші."
 
 #: src/generic/component/features-section/features-section-header.tsx:30
 msgid "Stop switching between apps. Budgie tracks your bank accounts, credit cards, cash, crypto, and investments together—so you finally see the complete picture of your finances."
@@ -1181,7 +1170,7 @@ msgstr "Синхронізується з 1000+ банками та фінанс
 msgid "Terms of Service"
 msgstr "Умови користування"
 
-#: src/generic/component/header/header.tsx:62
+#: src/generic/component/header/header.tsx:67
 #: src/generic/component/mobile-menu/mobile-menu.tsx:29
 msgid "Testimonials"
 msgstr "Відгуки"
@@ -1189,10 +1178,6 @@ msgstr "Відгуки"
 #: src/generic/component/analytics-section/analytics-section-content.tsx:26
 msgid "That daily coffee? $150/month. Forgotten subscriptions? $80/month. Budgie exposes every spending leak so you can finally plug them and keep more money in your pocket."
 msgstr "Та щоденна кава? $150/місяць. Забуті підписки? $80/місяць. Budgie виявляє кожен витік грошей, щоб ви нарешті могли їх зупинити й тримати більше грошей у кишені."
-
-#: src/generic/component/hero-section/hero-section-header.tsx:50
-msgid "The average person overspends $400/month without realizing it. Budgie tracks every dollar offline, encrypted with your fingerprint—so you finally see where your money really goes."
-msgstr "Середня людина перевитрачає $400/місяць, не усвідомлюючи цього. Budgie відстежує кожну гривню офлайн, зашифровану вашим відбитком пальця — щоб ви нарешті побачили, куди насправді йдуть ваші гроші."
 
 #: src/generic/component/testimonials-section/testimonials-slider.tsx:28
 msgid "The debt tracking feature helped me pay off my student loans 6 months early. Watching that progress bar fill up kept me motivated every single day."
@@ -1222,7 +1207,7 @@ msgstr "Треті сторони бачать ваші дані"
 msgid "This Month's Reality Check"
 msgstr "Перевірка реальності цього місяця"
 
-#: src/generic/component/header/header.tsx:100
+#: src/generic/component/header/header.tsx:109
 msgid "Toggle menu"
 msgstr "Відкрити/закрити меню"
 
@@ -1339,7 +1324,7 @@ msgstr "Переглянути всі інтеграції"
 msgid "View on GitHub"
 msgstr "Переглянути на GitHub"
 
-#: src/generic/component/hero-section/hero-section-header.tsx:61
+#: src/generic/component/hero-section/hero-section-header.tsx:67
 msgid "View Source Code"
 msgstr "Переглянути вихідний код"
 
@@ -1384,7 +1369,7 @@ msgid "What Makes Us Different"
 msgstr "Що робить нас особливими"
 
 #: src/generic/component/footer/footer.tsx:88
-#: src/generic/component/header/header.tsx:76
+#: src/generic/component/header/header.tsx:82
 #: src/generic/component/mobile-menu/mobile-menu.tsx:37
 msgid "Whitelist"
 msgstr "Білий список"
@@ -1430,7 +1415,7 @@ msgid "Works Offline"
 msgstr "Працює офлайн"
 
 #: src/generic/component/comparison-section/comparison-table-body.tsx:12
-#: src/generic/component/hero-section/hero-section-header.tsx:108
+#: src/generic/component/hero-section/hero-section-header.tsx:114
 msgid "Works without internet"
 msgstr "Працює без інтернету"
 
@@ -1446,13 +1431,17 @@ msgstr "Так, покажи деталі"
 msgid "You owe Sarah"
 msgstr "Ви винні Сарі"
 
-#: src/generic/component/waitlist-form/waitlist-success.tsx:47
-msgid "You're #{position} on the waitlist. We'll notify you when Budgie launches!"
-msgstr "Ви #{position} у списку очікування. Ми повідомимо вас, коли Budgie запуститься!"
+#: src/generic/component/waitlist-form/waitlist-success.tsx:51
+msgid "You're #{displayPosition} on the waitlist. We'll notify you when Budgie launches!"
+msgstr "Ви #{displayPosition} у списку очікування. Ми повідомимо вас, коли Budgie запуститься!"
 
-#: src/generic/component/waitlist-form/waitlist-success.tsx:41
+#: src/generic/component/waitlist-form/waitlist-success.tsx:45
 msgid "You're in!"
 msgstr "Ви в списку!"
+
+#: src/generic/component/hero-section/hero-section-header.tsx:56
+msgid "Your bank knows everything. Mint sold your data. YNAB stores it on their servers. Budgie keeps your finances on your device—encrypted, offline, and yours alone."
+msgstr "Ваш банк знає все. Mint продав ваші дані. YNAB зберігає їх на своїх серверах. Budgie тримає ваші фінанси на вашому пристрої — зашифровані, офлайн і тільки ваші."
 
 #: src/generic/component/usp-pillars-section/usp-pillars-section.tsx:58
 msgid "Your data is encrypted using your Face ID or fingerprint. Only you can ever access it."
@@ -1475,6 +1464,10 @@ msgstr "Ваші дані залишаються вашими"
 msgid "Your data stored on their servers"
 msgstr "Ваші дані зберігаються на їхніх серверах"
 
+#: src/generic/component/hero-section/hero-section-header.tsx:45
+msgid "Your Device."
+msgstr "Ваш Пристрій."
+
 #: src/generic/component/security-section/security-section-header.tsx:30
 msgid "Your financial data never leaves your device. No servers, no cloud, no tracking—just complete privacy with enterprise-grade security features."
 msgstr "Ваші фінансові дані ніколи не залишають ваш пристрій. Без серверів, без хмари, без відстеження — лише повна приватність із функціями безпеки корпоративного рівня."
@@ -1482,6 +1475,14 @@ msgstr "Ваші фінансові дані ніколи не залишают�
 #: src/generic/component/usp-pillars-section/usp-pillars-section.tsx:41
 msgid "Your financial data never leaves your phone. No servers, no cloud, no risk of data breaches."
 msgstr "Ваші фінансові дані ніколи не залишають ваш телефон. Без серверів, без хмари, без ризику витоку даних."
+
+#: src/generic/component/hero-section/hero-section-header.tsx:39
+msgid "Your Financial Data."
+msgstr "Ваші Фінансові Дані."
+
+#: src/generic/component/hero-section/hero-section-header.tsx:51
+msgid "Your Rules."
+msgstr "Ваші Правила."
 
 #: src/generic/component/ai-section/ai-section.tsx:47
 msgid "Zero Cloud"
@@ -1491,7 +1492,7 @@ msgstr "Без хмари"
 msgid "Zero Cloud Storage"
 msgstr "Без хмарного сховища"
 
-#: src/generic/component/hero-section/hero-section-header.tsx:98
+#: src/generic/component/hero-section/hero-section-header.tsx:104
 msgid "Zero data collection"
 msgstr "Без збору даних"
 


### PR DESCRIPTION
## Summary
- Fill 5 missing translation strings across de/es/fr/uk locales for the landing page
- Strings: waitlist position, hero section headers (Your Financial Data, Your Device, Your Rules), and bank comparison paragraph

## Test plan
- [ ] Verify landing page renders correctly in all locales (de, es, fr, uk)

🤖 Generated with [Claude Code](https://claude.ai/code)