### PR TITLE
fix(app,contracts): improve transaction suggestion accuracy and ordering

### DIFF
--- a/packages/app/src/transaction/service/repeated-transaction.service.ts
+++ b/packages/app/src/transaction/service/repeated-transaction.service.ts
@@ -1,4 +1,4 @@
-import { RepeatedTransactionPatternInterface, TransactionTypeEnum } from '@budgie/contracts';
+import { PRECISION, RepeatedTransactionPatternInterface, TransactionTypeEnum } from '@budgie/contracts';
 
 import { isPositiveNumber } from '@rnw-community/shared';
 
@@ -55,9 +55,10 @@ class RepeatedTransactionService {
     }
 
     private filterByAmount(patterns: RepeatedTransactionPatternInterface[], targetAmount: number): RepeatedTransactionPatternInterface[] {
-        const tolerance = targetAmount * REPEATED_TRANSACTION_AMOUNT_TOLERANCE_PERCENT;
-        const minAmount = targetAmount - tolerance;
-        const maxAmount = targetAmount + tolerance;
+        const targetAmountMicrounits = targetAmount * PRECISION;
+        const tolerance = targetAmountMicrounits * REPEATED_TRANSACTION_AMOUNT_TOLERANCE_PERCENT;
+        const minAmount = targetAmountMicrounits - tolerance;
+        const maxAmount = targetAmountMicrounits + tolerance;
 
         return patterns.filter(pattern => pattern.averageAmount >= minAmount && pattern.averageAmount <= maxAmount);
     }

--- a/packages/contracts/src/transaction/repository/transaction-pattern.repository.ts
+++ b/packages/contracts/src/transaction/repository/transaction-pattern.repository.ts
@@ -96,7 +96,7 @@ export class TransactionPatternRepository {
             .where(and(...conditions))
             .groupBy(TransactionEntryEntityTable.categoryId, TransactionEntityTable.title)
             .having(sql`COUNT(DISTINCT ${TransactionEntityTable.id}) >= ${MIN_OCCURRENCES}`)
-            .orderBy(desc(sql`COUNT(DISTINCT ${TransactionEntityTable.id})`))
+            .orderBy(desc(sql`MAX(${TransactionEntityTable.operatedAt})`), desc(sql`COUNT(DISTINCT ${TransactionEntityTable.id})`))
             .limit(limit);
     }
 


### PR DESCRIPTION
## Summary
- Fix amount unit mismatch in `filterByAmount()` - convert targetAmount to microunits before comparing with pattern.averageAmount
- Change suggestion ordering to prioritize recency over frequency - most recent patterns appear first, then sorted by occurrence count

## Test plan
- [ ] Create several transactions with the same category/title on the same weekday and time
- [ ] Open new transaction form and verify suggestions show most recent patterns first
- [ ] Enter an amount and verify filtered suggestions match correctly (no weird amounts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)