### PR TITLE
fix(ci): build workspace packages before eas update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
+      - name: Build internal workspace packages
+        run: yarn turbo build --filter=@budgie/contracts --filter=@budgie/ai --filter=@budgie/bank-sync
+
       - name: Publish update
         working-directory: packages/app
         run: |


### PR DESCRIPTION
## Summary
- The `EAS Update` job on `main.yml` ran `eas update` directly after `yarn install`, without compiling `@budgie/contracts`, `@budgie/ai`, and `@budgie/bank-sync`. Metro then resolved each package's `main` (`dist/esm/index.js`) and failed because `dist/` did not exist.
- Every push to `main` for the past 2+ weeks failed at this step (verified across the last 15 main runs).
- Mirrored the existing pattern from `.github/workflows/pr.yml`: insert one `yarn turbo build --filter=...` step between `Install dependencies` and `Publish update`.

## Test plan
- [ ] After merge, the next push to `main` should land EAS Update green.
- [ ] No effect on PR checks (PR workflow already had this step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)