### PR TITLE
fix(app): stabilize useLiveQuery deps in statistics transactions query

### DIFF
--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -458,6 +458,19 @@ const { data, error, updatedAt } = useLiveQuery(
 );
 ```
 
+**`useLiveQuery` deps must be primitive-stable.** Passing an object literal (e.g. a `filters` prop reconstructed each render) makes the dep change every render, which re-runs the query and returns a new `data` array reference each render. Downstream consumers like `LegendList` see a new `sections` reference every render and their internal reconciliation (`state.props.data`, `totalSize`, `isEndReached`) silently breaks — pages "load" but the scroll boundary doesn't grow.
+
+```typescript
+// Bad — filters is a fresh object each render → query re-runs every render
+useLiveQuery(repo.find(filters, limit), [limit, filters]);
+
+// Good — derive a stable key (string or primitive) from filters
+const filterKey = JSON.stringify(filters); // or a dedicated buildXxxFilterKey util
+useLiveQuery(repo.find(filters, limit), [limit, filterKey]);
+```
+
+If a filter shape exists in `@budgie/contracts` and is paginated, prefer adding a `buildXxxFilterKey` util alongside it (mirrors `buildTransactionFilterKey`) so callers can't forget.
+
 ### Drizzle ORM
 
 - **Prefer**: `db.query.[Entity].findMany/findFirst`

--- a/packages/app/src/app/(main)/analytics/transactions.tsx
+++ b/packages/app/src/app/(main)/analytics/transactions.tsx
@@ -114,7 +114,7 @@ export default function AnalyticsTransactionsPage() {
                 listEmptyState={listEmptyState}
                 balanceAdjustmentLabel={balanceAdjustmentLabel}
                 categoriesLabel={categoriesLabel}
-                footerSpacerMultiplier={2}
+                footerSpacerMultiplier={0}
             />
         </Page>
     );

--- a/packages/app/src/transaction/query/use-get-statistics-transactions.query.ts
+++ b/packages/app/src/transaction/query/use-get-statistics-transactions.query.ts
@@ -15,8 +15,9 @@ const DEFAULT_LIMIT = 20;
 export const useGetStatisticsTransactionsQuery = (filters: StatisticsFilterInterface) => {
     const { formatMonthAndYear } = useFormatDate();
     const [loadedCount, setLoadedCount] = useState(DEFAULT_LIMIT);
+    const filterKey = JSON.stringify(filters);
 
-    const { data, error, updatedAt } = useLiveQuery(statisticsRepository.getTransactions(filters, loadedCount + 1), [loadedCount, filters]);
+    const { data, error, updatedAt } = useLiveQuery(statisticsRepository.getTransactions(filters, loadedCount + 1), [loadedCount, filterKey]);
 
     const hasMore = data.length > loadedCount;
     const transactions = hasMore ? data.slice(0, -1) : data;


### PR DESCRIPTION
Fixes #395 — analytics transaction list "is not scrollable to the end" with many transactions.

## Root cause

`useGetStatisticsTransactionsQuery` passed the `filters` object directly as a `useLiveQuery` dependency:

```ts
useLiveQuery(statisticsRepository.getTransactions(filters, loadedCount + 1), [loadedCount, filters]);
```

The analytics drilldown builds `filters` via `buildFilters(params)` on every render, so it's a **fresh object reference every render**. `useLiveQuery` saw the dep change every render → re-ran the query → returned a new `data` array reference every render. `TransactionSectionsList` then computed a new `sections` array reference every render and handed it to `LegendList`.

`LegendList`'s internal reconciliation depends on `state.props.data` reference equality between renders for several paths:
- `totalSize` updates after pagination (`dataProp.length > state.props.data.length` check)
- `isEndReached` reset after data growth
- container recycling and item position calculations

When the array reference changes every render even though the actual contents didn't grow, those checks silently fail. Result: pagination kept firing and new items kept arriving at the data layer, but the scroll boundary stayed frozen at page 1's `contentSize` and items past it were unreachable. To the user: "list won't scroll to the end" / "next months don't load."

The same component (`TransactionSectionsList`) worked correctly when consumed via `TransactionList` (account-details, tabs/transactions) because that hook (`useGetTransactionsQuery`) already used a stable `filterKey` string built by `buildTransactionFilterKey`. The bug was scoped to the one screen that bypassed the stable-key pattern.

## Fix

Three lines in `useGetStatisticsTransactionsQuery`: derive a stable string key from `filters` (`JSON.stringify(filters)`) and use it as the `useLiveQuery` dep instead of the object itself. Mirrors how `useGetTransactionsQuery` already does it.

Also dropped `footerSpacerMultiplier={2}` to `0` on the analytics drilldown — it was a band-aid for the same scroll bug, adding 168px of dead space at the list bottom that's no longer needed (the page isn't under `(tabs)` and has no floating tab bar to clear).

Documented the rule in `packages/app/AGENTS.md` under **Data Layer → Live Queries** so the next paginated screen doesn't fall into the same trap.

## Validation

- Reproduced on iPhone 16 Pro sim with the analytics drilldown (Income → Uncategorized, ~300+ transactions). With the fix: `content` events fire on every page load, scroll boundary grows correctly past every section, list scrolls smoothly to the end.
- Account-details (`TransactionList` path) still works as before.
- `yarn ts && yarn lint` clean.

## Investigation history

This took an embarrassing number of dead-end attempts (slot wrappers, `getFixedItemSize`, manual `onScroll` triggers, removing/adding `<View flex-1>` layers, `recycleItems` toggling) all chasing the wrong tree because the symptom looked exactly like a `LegendList` bug. The branch was reset and rebuilt as a single clean commit once the actual cause — the unstable `useLiveQuery` dep — was identified. Lesson recorded in AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
