### PR TITLE
feat(app): vertically stack analytics overview tiles for long labels

### DIFF
--- a/packages/app/src/transaction/components/transaction-analytics-card/transaction-analytics-card.tsx
+++ b/packages/app/src/transaction/components/transaction-analytics-card/transaction-analytics-card.tsx
@@ -30,19 +30,23 @@ export const TransactionAnalyticsCard = ({ label, icon, variant, amount }: Props
     const heroAmount = isAbbreviated ? compactAmount : fullAmount;
 
     return (
-        <Card className="flex-1 gap-y-3xl p-3xl">
-            <View className="flex-row items-center gap-x-md">
-                <CircleIcon border={false} icon={icon} variant={variant} size={24} iconSize={12} radius={12} />
-                <Text className="uppercase tracking-wider text-secondary-foreground text-xxs">{label}</Text>
-            </View>
+        <Card className="flex-1 gap-y-lg p-3xl items-center">
+            <CircleIcon border={false} icon={icon} variant={variant} size={28} iconSize={14} radius={14} />
+            <Text
+                numberOfLines={1}
+                ellipsizeMode="tail"
+                className="uppercase tracking-wider text-secondary-foreground text-xxs text-center"
+            >
+                {label}
+            </Text>
 
-            <View className="gap-y-xxs">
+            <View className="gap-y-xxs items-center w-full">
                 <ProtectedText
                     adjustsFontSizeToFit
                     numberOfLines={1}
                     minimumFontScale={0.7}
                     style={TABULAR_NUMS_STYLE}
-                    className="text-primary text-2xl font-bold"
+                    className="text-primary text-2xl font-bold text-center"
                 >
                     {heroAmount}
                 </ProtectedText>


### PR DESCRIPTION
## Summary

The analytics overview tiles (Spent / Income / Balance) had the icon and label sitting in a horizontal row at the top of each card. With three tiles per row, each label only got ~80pt of horizontal space — fine for English (`Spent`, `Income`, `Balance`), but uppercase tracked labels like Ukrainian `ВИТРАЧЕНО`, German `AUSGEGEBEN`, Spanish `INGRESOS` overflowed and looked cramped.

This PR restructures the card to a centered vertical stack: **icon → label → amount**. The label now spans the full card width (~120pt instead of ~80pt) so all locales fit on one line, and the visual hierarchy reads more naturally. The icon was bumped from 24→28pt to feel like a focal point in the new layout.

Pattern matches modern fintech summary tiles (Revolut, Monzo, Lunch Money) which all use vertical-stack overview cards.

## Diff

Single component, `transaction-analytics-card.tsx`. 11 lines added, 7 removed.

## Test plan

- [ ] Open Analytics tab on iPhone 16 Pro sim
- [ ] Verify all three tiles render: icon centered at top, label centered below, big amount, optional small full amount
- [ ] Switch language uk → labels `ВИТРАЧЕНО / ДОХІД / БАЛАНС` all on one line
- [ ] Switch language de → labels `AUSGEGEBEN / EINKOMMEN / SALDO` all on one line
- [ ] Switch language es → labels `GASTADO / INGRESOS / SALDO` all on one line
- [ ] Switch language fr → labels `DÉPENSÉ / REVENU / SOLDE` all on one line
- [ ] Big amount still shrinks-to-fit when very large (existing `adjustsFontSizeToFit` preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)