### PR TITLE
fix(contracts): bind since via aliased column in windowed canonical lookup

### DIFF
--- a/packages/contracts/src/transaction/repository/transaction.repository.ts
+++ b/packages/contracts/src/transaction/repository/transaction.repository.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines -- Transaction repository is the kitchen sink for tx queries + filter builders + bank-sync helpers */
 import { Log } from '@budgie/logger';
 import { SQL, and, count, eq, gte, inArray, isNotNull, isNull, lt, ne, or, sql } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/sqlite-core';
 
 import { getErrorMessage, isDefined, isEmptyArray, isNotEmptyArray, isPositiveNumber } from '@rnw-community/shared';
 
@@ -255,10 +256,12 @@ export class TransactionRepository extends BaseTransactionFilterRepository {
             return [];
         }
         const runner = tx ?? this.db;
+        const sourceTransaction = alias(TransactionEntityTable, 'source_tx');
         return await runner
             .selectDistinct({ id: TransactionEntityTable.id })
             .from(TransactionEntityTable)
             .innerJoin(TransactionEntryEntityTable, eq(TransactionEntryEntityTable.transactionId, TransactionEntityTable.id))
+            .innerJoin(sourceTransaction, eq(sourceTransaction.id, TransactionEntryEntityTable.originalTransactionId))
             .where(
                 and(
                     isNotNull(TransactionEntityTable.consolidationType),
@@ -266,10 +269,7 @@ export class TransactionRepository extends BaseTransactionFilterRepository {
                     inArray(TransactionEntryEntityTable.accountId, accountIds),
                     isNotNull(TransactionEntryEntityTable.originalTransactionId),
                     isNull(TransactionEntryEntityTable.deletedAt),
-                    gte(
-                        sql<Date>`(SELECT operated_at FROM ${TransactionEntityTable} WHERE id = ${TransactionEntryEntityTable.originalTransactionId})`,
-                        since
-                    )
+                    gte(sourceTransaction.operatedAt, since)
                 )
             );
     }


### PR DESCRIPTION
## Summary

Follow-up to PR #397. The new `transactionRepository.findActiveAutoConsolidatedByAccountIdsSince` query bound the \`since\` Date directly into a \`sql<Date>\` template, bypassing Drizzle's column-aware timestamp-mode mapper. On device this surfaced as \`InvalidConvertibleException: undefined reason\` from \`ExpoSQLite/SQLiteModule.swift:649\` whenever a user tapped a windowed re-sync option ("Last 7/30/90 days").

Fix: alias \`TransactionEntityTable\` as \`sourceTransaction\`, join on \`originalTransactionId\`, and compare \`gte(sourceTransaction.operatedAt, since)\` against a real column reference. Drizzle now serializes the Date through the column's \`mode: 'timestamp'\` mapper instead of binding the raw Date object.

## Test plan

- [x] \`yarn build\` green
- [x] \`yarn workspace @budgie-at/bank-sync-tests test\` — 22 tests passing
- [x] \`yarn cpd\` — 0 clones
- [ ] Manual: tap "Last 7 days" in the resync window picker on a Monobank account → no \`InvalidConvertibleException\`, sync runs, recent transactions land

🤖 Generated with [Claude Code](https://claude.com/claude-code)