### PR TITLE
feat(app): grow comment input vertically up to two lines

### DIFF
--- a/packages/app/src/@generic/component/textarea/constant/text-area-base-heights.constant.ts
+++ b/packages/app/src/@generic/component/textarea/constant/text-area-base-heights.constant.ts
@@ -1,0 +1,5 @@
+export const TEXT_AREA_BASE_HEIGHTS = {
+    sm: 36,
+    md: 44,
+    lg: 62
+} as const;

--- a/packages/app/src/@generic/component/textarea/constant/text-area-line-deltas.constant.ts
+++ b/packages/app/src/@generic/component/textarea/constant/text-area-line-deltas.constant.ts
@@ -1,0 +1,5 @@
+export const TEXT_AREA_LINE_DELTAS = {
+    sm: 20,
+    md: 22,
+    lg: 28
+} as const;

--- a/packages/app/src/@generic/component/textarea/interface/text-area-props.interface.ts
+++ b/packages/app/src/@generic/component/textarea/interface/text-area-props.interface.ts
@@ -1,0 +1,15 @@
+import type { FormFieldStatus } from '../../../type/form-field-status.type';
+import type { ComponentProps, RefObject } from 'react';
+import type { TextInput } from 'react-native';
+
+
+type BaseTextInputProps = Omit<ComponentProps<typeof TextInput>, 'multiline' | 'style' | 'ref'>;
+
+export interface TextAreaProps extends BaseTextInputProps {
+    readonly status?: FormFieldStatus;
+    readonly borderless?: boolean;
+    readonly size?: 'sm' | 'md' | 'lg';
+    readonly minLines?: 1 | 2;
+    readonly maxLines?: 2 | 3 | 4 | 5;
+    readonly ref?: RefObject<TextInput | null>;
+}

--- a/packages/app/src/@generic/component/textarea/text-area.tsx
+++ b/packages/app/src/@generic/component/textarea/text-area.tsx
@@ -1,0 +1,49 @@
+import { cva } from 'class-variance-authority';
+import { TextInput } from 'react-native';
+
+import { cn } from '../../utils/cn.util';
+
+import { TEXT_AREA_BASE_HEIGHTS } from './constant/text-area-base-heights.constant';
+import { TEXT_AREA_LINE_DELTAS } from './constant/text-area-line-deltas.constant';
+
+import type { TextAreaProps } from './interface/text-area-props.interface';
+
+const textAreaVariant = cva('text-primary placeholder-primary/50 rounded-2xl', {
+    variants: {
+        size: {
+            sm: 'px-xl py-md text-md',
+            md: 'px-xl py-md text-md',
+            lg: 'px-4xl py-lg text-lg'
+        },
+        status: {
+            error: 'border border-destructive-corner bg-destructive-background/5 text-destructive-foreground',
+            default: 'border border-secondary-corner'
+        },
+        borderless: {
+            true: 'border-0',
+            false: ''
+        }
+    }
+});
+
+export const TextArea = (props: TextAreaProps) => {
+    const { size = 'sm', status = 'default', borderless = false, minLines = 1, maxLines = 2, className, ref, ...rest } = props;
+
+    const baseHeight = TEXT_AREA_BASE_HEIGHTS[size];
+    const lineDelta = TEXT_AREA_LINE_DELTAS[size];
+    const minHeight = baseHeight + (minLines - 1) * lineDelta;
+    const maxHeight = baseHeight + (maxLines - 1) * lineDelta;
+    const containerStyle = { minHeight, maxHeight };
+
+    return (
+        <TextInput
+            {...rest}
+            ref={ref}
+            multiline
+            textAlignVertical="top"
+            scrollEnabled
+            style={containerStyle}
+            className={cn(textAreaVariant({ size, status, borderless }), className)}
+        />
+    );
+};

--- a/packages/app/src/app/note-input.tsx
+++ b/packages/app/src/app/note-input.tsx
@@ -1,11 +1,11 @@
-import { UserIconNameEnum } from '@budgie/contracts';
+import { TRANSACTION_COMMENT_MAX_LENGTH, UserIconNameEnum } from '@budgie/contracts';
 import { useLingui } from '@lingui/react/macro';
-import { useState } from 'react';
+import { useRef } from 'react';
 import { View } from 'react-native';
 
 import { HapticPressable } from '../@generic/component/haptic-pressable/haptic-pressable';
 import { Icon } from '../@generic/component/icon/icon';
-import { Input } from '../@generic/component/input/input';
+import { TextArea } from '../@generic/component/textarea/text-area';
 import { useFormsheetListStyles } from '../@generic/hook/use-formsheet-list-styles/use-formsheet-list-styles.hook';
 import { useNoteInputModal } from '../transaction/context/note-input-modal.context';
 
@@ -15,29 +15,36 @@ export default function NoteInputModal() {
     const { t } = useLingui();
     const [, resolveNoteInput, currentParams] = useNoteInputModal();
     const { backgroundColor } = useFormsheetListStyles();
-    const [value, setValue] = useState(currentParams?.initialValue ?? '');
+
+    const initialValue = currentParams?.initialValue ?? '';
+    const valueRef = useRef(initialValue);
 
     const containerStyle = { flex: 1, backgroundColor };
 
+    const handleChangeText = (text: string) => {
+        valueRef.current = text;
+    };
+
     const handleSubmit = () => {
-        resolveNoteInput(value);
+        resolveNoteInput(valueRef.current);
     };
 
     return (
         <View style={containerStyle} collapsable={false}>
-            <View collapsable={false} className="flex-row items-center gap-md px-xl py-lg">
+            <View collapsable={false} className="flex-row items-end gap-md px-xl py-lg">
                 <View className="flex-1">
-                    <Input
-                        value={value}
-                        onChangeText={setValue}
+                    <TextArea
+                        defaultValue={initialValue}
+                        onChangeText={handleChangeText}
                         placeholder={t`Add a note...`}
                         autoFocus
-                        returnKeyType="done"
-                        onSubmitEditing={handleSubmit}
                         borderless
                         autoCorrect={false}
                         spellCheck={false}
                         autoComplete="off"
+                        maxLength={TRANSACTION_COMMENT_MAX_LENGTH}
+                        minLines={1}
+                        maxLines={2}
                         testID={NoteInputModalSelector.Input}
                     />
                 </View>


### PR DESCRIPTION
## Summary

- Replaces the single-line, horizontally-scrolling comment field in the `/note-input` form sheet with a vertically-growing multi-line input capped at 2 lines.
- Adds a `TextArea` component (sibling of `Input`, not a `multiline` mode) with bounded `minHeight`/`maxHeight` derived from `TEXT_AREA_BASE_HEIGHTS` + `TEXT_AREA_LINE_DELTAS` constants.
- Switches the modal to an uncontrolled ref pattern (`useRef` + `defaultValue`) so typing no longer re-renders the route on every keystroke.
- Enforces `TRANSACTION_COMMENT_MAX_LENGTH` (255) at the input layer — defense in depth alongside the existing schema cap.

## Behavior

- Empty / short comment: 1 line, autofocus, keyboard up.
- Wraps to 2 lines as the field fills.
- Past 2 lines: vertical scroll inside the field; no horizontal scroll at any width.
- Return key inserts a newline; the Check button submits.
- testIDs (`NoteInput.Input`, `NoteInput.SubmitButton`) preserved.

## Design

Spec: `docs/superpowers/specs/2026-05-03-comment-bottomsheet-multiline-design.md` (local, gitignored).

Key SOTA principles applied:
1. Composition over boolean prop modes — `TextArea` is a sibling of `Input`, not a `multiline?: boolean` flag (`vercel-composition-patterns / architecture-avoid-boolean-props`).
2. Uncontrolled `TextInput` with ref-based value capture — eliminates per-keystroke re-renders (`react-native-best-practices / js-uncontrolled-components`, `vercel / rerender-use-ref-transient-values`).
3. React 19 ref-as-prop — no `forwardRef`.
4. Inline `style={{ minHeight, maxHeight }}` over arbitrary NativeWind classes for cross-platform multiline height stability.

## Files

| File | Change |
|---|---|
| `packages/app/src/@generic/component/textarea/text-area.tsx` | new — multi-line `TextInput` wrapper |
| `packages/app/src/@generic/component/textarea/interface/text-area-props.interface.ts` | new — props interface |
| `packages/app/src/@generic/component/textarea/constant/text-area-base-heights.constant.ts` | new — `{ sm: 36, md: 44, lg: 62 }` |
| `packages/app/src/@generic/component/textarea/constant/text-area-line-deltas.constant.ts` | new — `{ sm: 20, md: 22, lg: 28 }` |
| `packages/app/src/app/note-input.tsx` | modified — `Input` → `TextArea`, `useState` → `useRef`, `items-end`, `maxLength` |

## Validation

`yarn format && yarn ts && yarn lint && yarn deadcode && yarn cpd` — all pass. No new lint warnings; the 2 remaining warnings are pre-existing on `main`. `cpd` reports 0 clones.

## Test plan

- [ ] iOS physical device: open expense quick-form → tap comment → field opens 1 line.
- [ ] Type ~50 chars → field wraps to 2 lines; no horizontal scroll.
- [ ] Type ~200 chars → field stays at 2 lines; vertical scroll works inside the field.
- [ ] Type until 255 chars → 256th char blocked.
- [ ] Press Enter → newline inserted; field grows up to 2 lines, scrolls beyond.
- [ ] Tap Check → sheet dismisses; comment appears on the transaction card.
- [ ] Reopen sheet on an existing multi-line comment → loads with caret at end, both lines visible.
- [ ] Repeat on Android emulator (verifies `textAlignVertical="top"` keeps text top-aligned).
- [ ] If iOS line-height looks off, tweak `TEXT_AREA_LINE_DELTAS.sm` (currently 20px); if 1-line height looks off, tweak `TEXT_AREA_BASE_HEIGHTS.sm` (currently 36px).

🤖 Generated with [Claude Code](https://claude.com/claude-code)