### PR TITLE
fix(app): prevent split modal double back

### DIFF
--- a/packages/app/src/app/split-entries.tsx
+++ b/packages/app/src/app/split-entries.tsx
@@ -2,6 +2,8 @@ import { Stack, useRouter } from 'expo-router';
 import { useEffect, useRef } from 'react';
 import { View } from 'react-native';
 
+import { isDefined } from '@rnw-community/shared';
+
 import { useFormsheetListStyles } from '../@generic/hook/use-formsheet-list-styles/use-formsheet-list-styles.hook';
 import { SplitEntriesModalContent } from '../transaction/components/split-entries-modal-content/split-entries-modal-content';
 import { useSplitEntriesModal } from '../transaction/context/split-entries-modal.context';
@@ -17,6 +19,7 @@ export default function SplitEntriesModal() {
     const containerStyle = { flex: 1, backgroundColor };
 
     const entriesRef = useRef<TransactionEntryCreateInputInterface[]>(currentParams?.entries ?? []);
+    const hadParamsRef = useRef(isDefined(currentParams));
 
     const handleEntriesChange = (entries: TransactionEntryCreateInputInterface[]) => {
         entriesRef.current = entries;
@@ -35,7 +38,13 @@ export default function SplitEntriesModal() {
     );
 
     useEffect(() => {
-        if (!currentParams) {
+        if (isDefined(currentParams)) {
+            hadParamsRef.current = true;
+
+            return;
+        }
+
+        if (!hadParamsRef.current) {
             router.back();
         }
     }, [currentParams, router]);


### PR DESCRIPTION
## Summary
- prevent the split entries route from issuing a second `router.back()` after a successful modal resolve
- preserve the fallback back navigation only for direct `/split-entries` opens without modal params

## Root Cause
Confirming the split modal resolves through the modal provider, which already navigates back. After that resolve, `currentParams` becomes `null`; the route-level guard also called `router.back()`, popping the underlying edit transaction screen.

## Validation
- Not run per request.