### PR TITLE
fix(app): replace undefined Tailwind tokens making AI status text invisible

### DIFF
--- a/packages/app/src/ai/component/ai-system-status-banner/ai-system-status-banner.tsx
+++ b/packages/app/src/ai/component/ai-system-status-banner/ai-system-status-banner.tsx
@@ -21,10 +21,10 @@ const BANNER_ICON: Record<AiSystemUmbrellaStateEnum, UserIconNameEnum | null> = 
 };
 
 const BANNER_COLOR: Record<AiSystemUmbrellaStateEnum, string> = {
-    [AiSystemUmbrellaStateEnum.DISABLED]: 'text-muted-foreground',
-    [AiSystemUmbrellaStateEnum.DOWNLOADING]: 'text-primary-foreground',
-    [AiSystemUmbrellaStateEnum.HEALTHY]: 'text-muted-foreground',
-    [AiSystemUmbrellaStateEnum.IDLE]: 'text-muted-foreground',
+    [AiSystemUmbrellaStateEnum.DISABLED]: 'text-secondary-foreground',
+    [AiSystemUmbrellaStateEnum.DOWNLOADING]: 'text-primary',
+    [AiSystemUmbrellaStateEnum.HEALTHY]: 'text-secondary-foreground',
+    [AiSystemUmbrellaStateEnum.IDLE]: 'text-secondary-foreground',
     [AiSystemUmbrellaStateEnum.INITIALIZING]: 'text-warning-foreground',
     [AiSystemUmbrellaStateEnum.MODEL_ERROR]: 'text-destructive-foreground',
     [AiSystemUmbrellaStateEnum.SUSPENDED]: 'text-warning-foreground'

--- a/packages/app/src/ai/constant/ai-subsystem-card-visuals.constant.ts
+++ b/packages/app/src/ai/constant/ai-subsystem-card-visuals.constant.ts
@@ -8,7 +8,7 @@ interface SubsystemCardVisualInterface {
 
 export const AI_SUBSYSTEM_CARD_VISUALS: Record<AiSubsystemCardStateEnum, SubsystemCardVisualInterface> = {
     [AiSubsystemCardStateEnum.HIDDEN]: {
-        colorClass: 'text-muted-foreground',
+        colorClass: 'text-secondary-foreground',
         pulsePeriodMs: null,
         glow: false
     },

--- a/packages/app/src/ai/constant/ai-system-state-visuals.constant.ts
+++ b/packages/app/src/ai/constant/ai-system-state-visuals.constant.ts
@@ -10,15 +10,15 @@ interface StateVisualInterface {
 
 export const AI_SYSTEM_STATE_VISUALS: Record<AiSystemStateEnum, StateVisualInterface> = {
     [AiSystemStateEnum.DISABLED]: {
-        colorClass: 'text-muted-foreground',
-        stripClass: 'bg-muted-foreground',
+        colorClass: 'text-secondary-foreground',
+        stripClass: 'bg-secondary-foreground',
         pulsePeriodMs: null,
         shakeOnEnter: false,
         glow: false
     },
     [AiSystemStateEnum.BOOTING]: {
-        colorClass: 'text-primary-foreground',
-        stripClass: 'bg-primary-foreground',
+        colorClass: 'text-primary',
+        stripClass: 'bg-primary',
         pulsePeriodMs: 1200,
         shakeOnEnter: false,
         glow: false
@@ -31,8 +31,8 @@ export const AI_SYSTEM_STATE_VISUALS: Record<AiSystemStateEnum, StateVisualInter
         glow: false
     },
     [AiSystemStateEnum.IDLE]: {
-        colorClass: 'text-muted-foreground',
-        stripClass: 'bg-muted-foreground',
+        colorClass: 'text-secondary-foreground',
+        stripClass: 'bg-secondary-foreground',
         pulsePeriodMs: null,
         shakeOnEnter: false,
         glow: false
@@ -45,8 +45,8 @@ export const AI_SYSTEM_STATE_VISUALS: Record<AiSystemStateEnum, StateVisualInter
         glow: false
     },
     [AiSystemStateEnum.INDEXING]: {
-        colorClass: 'text-primary-foreground',
-        stripClass: 'bg-primary-foreground',
+        colorClass: 'text-primary',
+        stripClass: 'bg-primary',
         pulsePeriodMs: 700,
         shakeOnEnter: false,
         glow: false

--- a/packages/app/src/sync/component/account-bank-sync-card/account-bank-sync-card.tsx
+++ b/packages/app/src/sync/component/account-bank-sync-card/account-bank-sync-card.tsx
@@ -75,7 +75,7 @@ export const AccountBankSyncCard = ({ accountId }: AccountBankSyncCardPropsInter
                         <SyncDataRow label={t`Errors`} value={String(bankSync.errorCount)} />
                         {isNotEmptyString(bankSync.lastError) && (
                             <View className="gap-y-xs">
-                                <Text className="text-primary text-xs text-muted-foreground">
+                                <Text className="text-xs text-secondary-foreground">
                                     <Trans>Last error</Trans>
                                 </Text>
                                 <Text className="text-secondary-foreground text-destructive text-xs" numberOfLines={2}>

--- a/packages/app/src/sync/component/account-selection-step/account-selection-step.tsx
+++ b/packages/app/src/sync/component/account-selection-step/account-selection-step.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 export const AccountSelectionStep = ({ accountPreviews, selectedAccounts, onToggle }: Props) => (
     <>
-        <Text className="text-primary text-muted-foreground text-sm px-md">
+        <Text className="text-secondary-foreground text-sm px-md">
             <Trans>Select accounts to sync:</Trans>
         </Text>
 

--- a/packages/app/src/sync/component/bank-account-preview-card/bank-account-preview-card.tsx
+++ b/packages/app/src/sync/component/bank-account-preview-card/bank-account-preview-card.tsx
@@ -25,7 +25,7 @@ export const BankAccountPreviewCard = ({ preview, isSelected, onToggle }: Props)
             <View className="flex-row items-center justify-between">
                 <View className="flex-1 mr-md">
                     <Text className="text-primary font-semibold text-base">{preview.title}</Text>
-                    <Text className="text-xs text-muted-foreground">
+                    <Text className="text-xs text-secondary-foreground">
                         {preview.currencyCode}
                         {isNotEmptyString(preview.iban) && ` • ${preview.iban}`}
                     </Text>

--- a/packages/app/src/sync/component/bank-sync-token-section/bank-sync-token-section.tsx
+++ b/packages/app/src/sync/component/bank-sync-token-section/bank-sync-token-section.tsx
@@ -60,7 +60,7 @@ export const BankSyncTokenSection = ({ accountId, token }: Props) => {
 
     return (
         <View className="gap-y-sm pt-md border-t border-secondary-corner mt-md">
-            <Text className="text-primary text-xs text-muted-foreground">{t`API Token`}</Text>
+            <Text className="text-xs text-secondary-foreground">{t`API Token`}</Text>
 
             {isEditing ? (
                 <View className="gap-y-sm">

--- a/packages/app/src/sync/component/sync-data-row/sync-data-row.tsx
+++ b/packages/app/src/sync/component/sync-data-row/sync-data-row.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export const SyncDataRow = ({ label, value, valueClass = 'text-primary' }: Props) => (
     <View className="flex-row justify-between">
-        <Text className="text-primary text-xs text-muted-foreground">{label}</Text>
+        <Text className="text-xs text-secondary-foreground">{label}</Text>
         <Text className={`text-xs ${valueClass}`}>{value}</Text>
     </View>
 );

--- a/packages/app/src/sync/component/token-input-step/token-input-step.tsx
+++ b/packages/app/src/sync/component/token-input-step/token-input-step.tsx
@@ -28,7 +28,7 @@ export const TokenInputStep = ({ token, onTokenChange }: Props) => {
             />
 
             <View className="gap-y-md">
-                <Text className="text-primary text-muted-foreground text-sm px-md">
+                <Text className="text-secondary-foreground text-sm px-md">
                     <Trans>Paste your API token below:</Trans>
                 </Text>
 


### PR DESCRIPTION
## Summary
- `text-muted-foreground`, `text-primary-foreground`, and the matching `bg-*` variants are not defined in `packages/app/src/global.css`. NativeWind emits no style for them, so the AI status banner (DOWNLOADING / IDLE / DISABLED states) and several Bank Sync labels render as invisible text on top of `bg-secondary-background`.
- Mapped every undefined token to the canonical equivalent that exists in the design system:
  - `text-muted-foreground` → `text-secondary-foreground`
  - `bg-muted-foreground` → `bg-secondary-foreground`
  - `text-primary-foreground` → `text-primary`
  - `bg-primary-foreground` → `bg-primary`
- Cleaned up sync labels that mixed `text-primary` with the dead `text-muted-foreground` token (the dead one silently won as the later class) so they now consistently use `text-secondary-foreground`.

Files touched:
- `ai/component/ai-system-status-banner/ai-system-status-banner.tsx`
- `ai/constant/ai-subsystem-card-visuals.constant.ts`
- `ai/constant/ai-system-state-visuals.constant.ts`
- `sync/component/{account-bank-sync-card,account-selection-step,bank-account-preview-card,bank-sync-token-section,sync-data-row,token-input-step}/*`

## Test plan
- [ ] Open Settings → AI section while models are downloading; verify "Downloading AI models…" label and percentage are visible in light + dark themes.
- [ ] Verify subsystem cards (Chat / Embedding / STT) progress label is visible while booting.
- [ ] Open Bank Sync flow: verify token-input hint, account-selection hint, account-preview subtitle (currency/IBAN), API token label, sync data rows, and "Last error" label all render with readable muted text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)