### PR TITLE
fix(app): keep rule create pill pending

### DIFF
--- a/packages/app/src/rule/components/matching-rules-pill/matching-rules-pill.tsx
+++ b/packages/app/src/rule/components/matching-rules-pill/matching-rules-pill.tsx
@@ -31,10 +31,12 @@ export const MatchingRulesPill = ({ matchingRulesCount }: Props) => {
                 <HapticPressable
                     testID={MatchingRulesPillSelector.Pill}
                     onPress={handlePress}
-                    className="flex-row items-center gap-xs px-lg py-sm bg-ghost-background rounded-xl shadow-sm"
+                    className="flex-row items-center gap-xs rounded-full border border-secondary-corner bg-secondary-background px-md py-xs self-start max-w-[85%]"
                 >
                     <Icon icon={UserIconNameEnum.Workflow} size={14} className="text-secondary-foreground" />
-                    <Text className="text-xs text-secondary-foreground font-medium">{label}</Text>
+                    <Text className="text-xs text-secondary-foreground font-medium shrink" numberOfLines={1} ellipsizeMode="tail">
+                        {label}
+                    </Text>
                 </HapticPressable>
             </Animated.View>
         </View>

--- a/packages/app/src/rule/components/rule-suggestion-card/rule-suggestion-card.tsx
+++ b/packages/app/src/rule/components/rule-suggestion-card/rule-suggestion-card.tsx
@@ -173,6 +173,7 @@ export const RuleSuggestionCard = (props: Props) => {
             errorMessage={<Trans>Could not create rule</Trans>}
             cardTestID={RuleSuggestionCardSelector.Card}
             buttonTestID={RuleSuggestionCardSelector.CreateRuleButton}
+            layout="wide"
             onYes={handleYes}
             onComplete={onRuleCreated}
             onDismiss={onDismiss}

--- a/packages/app/src/rule/components/swipeable-rule-card-status/swipeable-rule-card-status.tsx
+++ b/packages/app/src/rule/components/swipeable-rule-card-status/swipeable-rule-card-status.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 export const SwipeableRuleCardStatus = ({ icon, iconClassName, textClassName, children }: Props) => (
     <Animated.View entering={FadeIn.duration(200)} exiting={FadeOut.duration(300)}>
-        <View className="flex-row items-center gap-xs px-lg py-sm bg-ghost-background rounded-xl shadow-sm">
+        <View className="flex-row items-center gap-xs rounded-full border border-secondary-corner bg-secondary-background px-md py-xs">
             <Icon icon={icon} size={STATUS_ICON_SIZE} className={iconClassName} />
             <Text className={textClassName}>{children}</Text>
         </View>

--- a/packages/app/src/rule/components/swipeable-rule-card/swipeable-rule-card.tsx
+++ b/packages/app/src/rule/components/swipeable-rule-card/swipeable-rule-card.tsx
@@ -29,7 +29,7 @@ const ERROR_AUTO_DISMISS_MS = 3000;
 type CardStatus = 'idle' | 'creating' | 'success' | 'error';
 type CardLayout = 'compact' | 'wide';
 
-const cardVariants = cva('flex-row items-center gap-sm px-lg py-sm bg-ghost-background rounded-xl shadow-sm', {
+const cardVariants = cva('flex-row items-center gap-xs rounded-full border border-secondary-corner bg-secondary-background px-md py-xs', {
     variants: {
         layout: {
             compact: 'self-start',

--- a/packages/app/src/rule/hooks/use-suggest-rule-detection.hook.ts
+++ b/packages/app/src/rule/hooks/use-suggest-rule-detection.hook.ts
@@ -36,7 +36,7 @@ const dismissedSuggestions = new Set<string>();
 
 // eslint-disable-next-line max-statements -- Detection hook with multiple derived values and dismiss tracking
 export const useSuggestRuleDetection = ({ transaction, control }: UseSuggestRuleDetectionParamsType): UseSuggestRuleDetectionResultType => {
-    const [ruleCreated, setRuleCreated] = useState(false);
+    const [isRuleCreationStarted, setIsRuleCreationStarted] = useState(false);
     const [isDismissed, setIsDismissed] = useState(false);
     const [isCreating, setIsCreating] = useState(false);
     const entries = useWatch({ control, name: 'entries' });
@@ -84,7 +84,7 @@ export const useSuggestRuleDetection = ({ transaction, control }: UseSuggestRule
 
     const mode = computeDetectionMode({
         hasChanges,
-        ruleCreated,
+        isRuleCreationStarted,
         isCreating,
         isDismissed: isDismissed || wasPreviouslyDismissed,
         matchingRulesCount,
@@ -92,13 +92,13 @@ export const useSuggestRuleDetection = ({ transaction, control }: UseSuggestRule
     });
 
     const singleMatchingRule = matchingRulesCount === 1 ? matchingRules[0] : null;
+    const canUpdateRule = !isCreating && !isRuleCreationStarted;
 
-    const updateRuleData: UpdateRuleDataInterface | null = isDefined(singleMatchingRule)
-        ? { ruleId: singleMatchingRule.id, categoryId, tagIds }
-        : null;
+    const updateRuleData: UpdateRuleDataInterface | null =
+        canUpdateRule && isDefined(singleMatchingRule) ? { ruleId: singleMatchingRule.id, categoryId, tagIds } : null;
 
     const onRuleCreated = () => {
-        setRuleCreated(true);
+        setIsRuleCreationStarted(true);
         setIsCreating(false);
     };
 
@@ -109,6 +109,10 @@ export const useSuggestRuleDetection = ({ transaction, control }: UseSuggestRule
     };
 
     const onCreatingChange = (next: boolean) => {
+        if (next) {
+            setIsRuleCreationStarted(true);
+        }
+
         setIsCreating(next);
     };
 

--- a/packages/app/src/rule/interface/detection-mode-params.interface.ts
+++ b/packages/app/src/rule/interface/detection-mode-params.interface.ts
@@ -1,6 +1,6 @@
 export interface DetectionModeParamsInterface {
     readonly hasChanges: boolean;
-    readonly ruleCreated: boolean;
+    readonly isRuleCreationStarted: boolean;
     readonly isCreating: boolean;
     readonly isDismissed: boolean;
     readonly matchingRulesCount: number;

--- a/packages/app/src/rule/util/compute-detection-mode.util.ts
+++ b/packages/app/src/rule/util/compute-detection-mode.util.ts
@@ -5,8 +5,8 @@ import { RuleDetectionModeEnum } from '../enum/rule-detection-mode.enum';
 import type { DetectionModeParamsInterface } from '../interface/detection-mode-params.interface';
 
 export const computeDetectionMode = (params: DetectionModeParamsInterface): RuleDetectionModeEnum => {
-    const { hasChanges, ruleCreated, isCreating, isDismissed, matchingRulesCount, hasConflictWithMatchingRules } = params;
-    const canSuggest = hasChanges && !ruleCreated && !isDismissed;
+    const { hasChanges, isRuleCreationStarted, isCreating, isDismissed, matchingRulesCount, hasConflictWithMatchingRules } = params;
+    const canSuggest = hasChanges && !isRuleCreationStarted && !isDismissed;
 
     if (isCreating) {
         return RuleDetectionModeEnum.SUGGEST;

--- a/packages/app/src/transaction/components/quick-form-bottom-overlay/quick-form-bottom-overlay.tsx
+++ b/packages/app/src/transaction/components/quick-form-bottom-overlay/quick-form-bottom-overlay.tsx
@@ -2,12 +2,9 @@ import { TransactionTypeEnum } from '@budgie/contracts';
 import { View } from 'react-native';
 
 import { MccInfoRow } from '../mcc-info-row/mcc-info-row';
-import { RulePillSlot } from '../rule-pill-slot/rule-pill-slot';
 import { SuggestionsContainer } from '../suggestions-container/suggestions-container';
 
-import type { RulePillSlotPropsInterface } from '../../interface/rule-pill-slot-props.interface';
-
-interface Props extends RulePillSlotPropsInterface {
+interface Props {
     readonly transactionTitle: string;
     readonly mccCategoryId: number | null;
     readonly isNewTransaction: boolean;
@@ -41,51 +38,29 @@ export const QuickFormBottomOverlay = (props: Props) => {
         onSelectCategory,
         onSelectTag,
         onSelectComment,
-        onFillPatternAmount,
-        ruleDetectionMode,
-        suggestRuleData,
-        updateRuleData,
-        matchingRulesCount,
-        onRuleCreated,
-        onDismiss,
-        onCreatingChange
+        onFillPatternAmount
     } = props;
 
     return (
         <View className="absolute bottom-0 left-0 right-0 gap-md">
             <MccInfoRow transactionTitle={transactionTitle} mccCategoryId={mccCategoryId} />
-            <View className="flex-row items-center gap-sm">
-                <View className="shrink">
-                    <RulePillSlot
-                        ruleDetectionMode={ruleDetectionMode}
-                        suggestRuleData={suggestRuleData}
-                        updateRuleData={updateRuleData}
-                        matchingRulesCount={matchingRulesCount}
-                        onRuleCreated={onRuleCreated}
-                        onDismiss={onDismiss}
-                        onCreatingChange={onCreatingChange}
-                    />
-                </View>
-                <View className="flex-1">
-                    <SuggestionsContainer
-                        isNewTransaction={isNewTransaction}
-                        isSplitActive={isSplitActive}
-                        transactionType={transactionType}
-                        transactionTitle={transactionTitle}
-                        categoryId={categoryId}
-                        mccCategoryId={mccCategoryId}
-                        comment={comment}
-                        aiContext={aiContext}
-                        accountId={accountId}
-                        amount={amount}
-                        hasTagsSelected={hasTagsSelected}
-                        onSelectCategory={onSelectCategory}
-                        onSelectTag={onSelectTag}
-                        onSelectComment={onSelectComment}
-                        onFillPatternAmount={onFillPatternAmount}
-                    />
-                </View>
-            </View>
+            <SuggestionsContainer
+                isNewTransaction={isNewTransaction}
+                isSplitActive={isSplitActive}
+                transactionType={transactionType}
+                transactionTitle={transactionTitle}
+                categoryId={categoryId}
+                mccCategoryId={mccCategoryId}
+                comment={comment}
+                aiContext={aiContext}
+                accountId={accountId}
+                amount={amount}
+                hasTagsSelected={hasTagsSelected}
+                onSelectCategory={onSelectCategory}
+                onSelectTag={onSelectTag}
+                onSelectComment={onSelectComment}
+                onFillPatternAmount={onFillPatternAmount}
+            />
         </View>
     );
 };

--- a/packages/app/src/transaction/components/simple-quick-form/simple-quick-form.tsx
+++ b/packages/app/src/transaction/components/simple-quick-form/simple-quick-form.tsx
@@ -18,6 +18,7 @@ import { useQuickFormModals } from '../../hook/use-quick-form-modals.hook';
 import { useQuickFormValidation } from '../../hook/use-quick-form-validation.hook';
 import { sumEntryAmounts } from '../../utils/sum-entry-amounts.util';
 import { QuickFormBottomOverlay } from '../quick-form-bottom-overlay/quick-form-bottom-overlay';
+import { RulePillSlot } from '../rule-pill-slot/rule-pill-slot';
 import { TransactionAccountRow, TransactionAccountRowRef } from '../transaction-account-row/transaction-account-row';
 import { TransactionAmountDisplay, TransactionAmountDisplayRef } from '../transaction-amount-display/transaction-amount-display';
 import { TransactionFieldIcons } from '../transaction-field-icons/transaction-field-icons';
@@ -212,6 +213,20 @@ export const SimpleQuickForm = (props: Props) => {
 
     const handleSplitIconPress = () => void handleSplitPress();
     const handleConfirm = isSplitActive ? handleSplitConfirm : handleNormalConfirm;
+    const amountTopStack = (
+        <View className="h-[76px] items-center justify-end gap-xs">
+            <RulePillSlot
+                ruleDetectionMode={ruleDetectionMode}
+                suggestRuleData={suggestRuleData}
+                updateRuleData={updateRuleData}
+                matchingRulesCount={matchingRulesCount}
+                onRuleCreated={onRuleCreated}
+                onDismiss={onDismiss}
+                onCreatingChange={onCreatingChange}
+            />
+            {amountTopContent}
+        </View>
+    );
 
     return (
         <View className="flex-1">
@@ -221,7 +236,7 @@ export const SimpleQuickForm = (props: Props) => {
                     amount={displayValue}
                     currencySymbol={currencySymbol}
                     variant={variant}
-                    topContent={amountTopContent}
+                    topContent={amountTopStack}
                     testID={SimpleQuickFormSelector.AmountInput}
                 />
                 <QuickFormBottomOverlay
@@ -240,13 +255,6 @@ export const SimpleQuickForm = (props: Props) => {
                     onSelectTag={handleSelectTag}
                     onSelectComment={handleSelectComment}
                     onFillPatternAmount={handleFillPatternAmount}
-                    ruleDetectionMode={ruleDetectionMode}
-                    suggestRuleData={suggestRuleData}
-                    updateRuleData={updateRuleData}
-                    matchingRulesCount={matchingRulesCount}
-                    onRuleCreated={onRuleCreated}
-                    onDismiss={onDismiss}
-                    onCreatingChange={onCreatingChange}
                 />
             </View>
 

--- a/tests/app-tests/flows/26.rules-application.flow.yaml
+++ b/tests/app-tests/flows/26.rules-application.flow.yaml
@@ -868,6 +868,10 @@ env:
     id: 'SuggestRule.CreateRuleButton'
 
 - extendedWaitUntil:
+    visible: 'Rule created'
+    timeout: 10000
+
+- extendedWaitUntil:
     notVisible:
       id: 'SuggestRule.Card'
     timeout: 10000
@@ -933,6 +937,10 @@ env:
 
 - tapOn:
     id: 'SuggestRule.CreateRuleButton'
+
+- extendedWaitUntil:
+    visible: 'Rule created'
+    timeout: 10000
 
 - extendedWaitUntil:
     notVisible:


### PR DESCRIPTION
## Summary

- Stop the transaction-page quick-rule flow from becoming eligible for update suggestions once create has started.
- Keep the quick-rule pill width aligned with the wider rule-related pills to reduce layout jumping and keep text on one line.
- Extend the existing rules Maestro flow to require the `Rule created` success state after quick-rule creation.

## Root Cause

After tapping the transaction-page quick-rule pill, the enabled-rules query can refresh as soon as the new rule is inserted. That gives the detection hook one matching rule before the create card has completed its success state, so the old derived state could briefly switch to `UPDATE` and show `Update rule?`.

## Review Notes

I removed the earlier over-modeled `CREATING` enum and pass-through pending prop. The hook now uses a single `isRuleCreationStarted` guard, which keeps the existing create card mounted during its own loading/success lifecycle and prevents update-rule data from being exposed for that transaction page session.

## Validation

- `yarn ts`
- `yarn format && yarn ts && yarn lint && yarn deadcode && yarn cpd`
- Local iOS E2E build: `APP_VARIANT=e2e npx expo prebuild -p ios --clean`, `pod install`, `xcodebuild build ... -configuration Release -sdk iphonesimulator`
- Focused local Maestro flow on rebuilt app: category + tag selection from transaction page, tap quick-rule create, assert `Update rule?` is not visible, assert `Rule created` is visible. Result: passed in 75s.
- Full existing `26.rules-application.flow.yaml` was also attempted, but it stalled before this PR’s scenario in an earlier manual rule-form section with the iOS keyboard still open after entering `Netflix`; I stopped that unrelated run and used the focused flow for this bug path.