### PR TITLE
test(app): stabilize rules application e2e

### DIFF
--- a/packages/app/src/rule/service/rule-engine.service.ts
+++ b/packages/app/src/rule/service/rule-engine.service.ts
@@ -238,7 +238,7 @@ class RuleEngineService {
         }
 
         const ruleActionOutcomes = extractRuleActionOutcomes(matchingRules);
-        const {categoryId} = ruleActionOutcomes;
+        const { categoryId } = ruleActionOutcomes;
         const tagIds = [...new Set([...input.tagIds, ...ruleActionOutcomes.tagIds])];
         const hasCategoryAction = isDefined(categoryId);
         const hasTagAction = tagIds.length !== input.tagIds.length;

--- a/tests/app-tests/flows/26.rules-application.flow.yaml
+++ b/tests/app-tests/flows/26.rules-application.flow.yaml
@@ -868,10 +868,6 @@ env:
     id: 'SuggestRule.CreateRuleButton'
 
 - extendedWaitUntil:
-    visible: 'Rule created'
-    timeout: 10000
-
-- extendedWaitUntil:
     notVisible:
       id: 'SuggestRule.Card'
     timeout: 10000
@@ -937,10 +933,6 @@ env:
 
 - tapOn:
     id: 'SuggestRule.CreateRuleButton'
-
-- extendedWaitUntil:
-    visible: 'Rule created'
-    timeout: 10000
 
 - extendedWaitUntil:
     notVisible:


### PR DESCRIPTION
## Summary

- Remove transient `Rule created` toast assertions from the rules application Maestro flow.
- Keep the durable state assertions that the suggestion card disappears and the created rule appears on the Rules page.
- Include formatter cleanup in `rule-engine.service.ts` from the validation run.

## Root Cause

The app created the suggested rule successfully, but the E2E flow waited on a short-lived toast. Local verification showed the rule persisted in SQLite and the transaction form displayed `1 matching rule`, so the failure was the test contract, not app behavior.

## Validation

- `maestro test tests/app-tests/flows/26.rules-application.flow.yaml -e APP_ID=com.vitalyiegorov.budgie.e2e -e E2E_RUN_TOKEN=$(date +%s) -e RECURRING_EMPTY_DAY=21 -e E2E_CSV_FIXTURES_URI=file://.../Documents/E2ECsvFixtures --format junit --output tests/app-tests/artifacts/maestro-rules/report-26-toast-fix.xml --debug-output tests/app-tests/artifacts/maestro-rules --test-output-dir tests/app-tests/artifacts/maestro-rules`
- `PATH=/Users/vitalyiegorov/.nvm/versions/node/v22.22.0/bin:$PATH yarn format && PATH=/Users/vitalyiegorov/.nvm/versions/node/v22.22.0/bin:$PATH yarn ts && PATH=/Users/vitalyiegorov/.nvm/versions/node/v22.22.0/bin:$PATH yarn lint && PATH=/Users/vitalyiegorov/.nvm/versions/node/v22.22.0/bin:$PATH yarn deadcode && PATH=/Users/vitalyiegorov/.nvm/versions/node/v22.22.0/bin:$PATH yarn cpd`

Lint still reports the existing `packages/app/src/ai/hook/use-suggestion-base.hook.ts:101` exhaustive-deps warning; no errors.