### PR TITLE
fix(app): render debt type card text on first mount

### DIFF
--- a/packages/app/src/account/component/account-dept-type-card/account-dept-type-card.tsx
+++ b/packages/app/src/account/component/account-dept-type-card/account-dept-type-card.tsx
@@ -43,7 +43,7 @@ export const AccountDeptTypeCard = ({ type, onSelect, isSelected, testID }: Prop
         <Card testID={testID} onPress={handleSelect} className={cardVariants({ isSelected })} size="md">
             <CircleIcon icon={ACCOUNT_DEBT_TYPE_ICON[type]} variant="ghost" border={false} size={40} iconSize={20} />
 
-            <View className="flex-1 items-center justify-center gap-y-xs self-stretch px-sm">
+            <View className="items-center justify-center gap-y-xs self-stretch px-sm">
                 <Text className="text-sm font-semibold text-primary text-center">{t(ACCOUNT_DEBT_TYPE[type])}</Text>
                 <Text className="text-sm text-secondary-foreground text-center">{t(ACCOUNT_DEBT_TYPE_DESCRIPTION[type])}</Text>
             </View>


### PR DESCRIPTION
Closes #429

## Summary

- The debt type cards on the Create Debt Account form rendered icon-only on first mount; only after toggling the selection did the title and description appear.
- Root cause: the inner text wrapper used `flex-1` inside a column-direction `Card` with no constrained height, so Yoga resolved it to `flex-basis:0` with no space to grow and clipped the `<Text>` children until a re-render refreshed the measurement cache.
- Fix removes the `flex-1` class — the texts have intrinsic height and the column lays out correctly without it. Regressed in `6d4faafbc`.

## Test plan

- [ ] Cold-launch app, open Create Debt Account, confirm both Lent and Borrowed cards show icon + title + description on the first frame
- [ ] Tap Borrowed, confirm both cards still render full content and the check pill moves
- [ ] Tap Lent, confirm both cards still render full content
- [ ] Open Update Debt Account on an existing debt account, confirm cards render correctly