### PR TITLE
fix(app): gate consolidation source from/to override on transfer sourceType

### DIFF
--- a/packages/app/src/transaction/components/consolidation-source-row/consolidation-source-row.tsx
+++ b/packages/app/src/transaction/components/consolidation-source-row/consolidation-source-row.tsx
@@ -1,4 +1,4 @@
-import { TransactionEntryTypeEnum } from '@budgie/contracts';
+import { TransactionEntryTypeEnum, TransactionTypeEnum } from '@budgie/contracts';
 import { t } from '@lingui/core/macro';
 import { Text, View } from 'react-native';
 import Animated, { FadeIn, LinearTransition } from 'react-native-reanimated';
@@ -42,10 +42,13 @@ const buildAccountSummary = (source: ConsolidationSourceRowInterface, isDebit: b
     const toFallbackIcon = isDebit ? source.canonicalToAccountIcon : source.accountIcon;
     const toFallbackTitle = isDebit ? source.canonicalToAccountTitle : source.accountTitle;
 
-    const fromIcon = isDefined(source.sourceFromAccountIcon) ? source.sourceFromAccountIcon : fromFallbackIcon;
-    const fromTitle = isNotEmptyString(source.sourceFromAccountTitle) ? source.sourceFromAccountTitle : fromFallbackTitle;
-    const toIcon = isDefined(source.sourceToAccountIcon) ? source.sourceToAccountIcon : toFallbackIcon;
-    const toTitle = isNotEmptyString(source.sourceToAccountTitle) ? source.sourceToAccountTitle : toFallbackTitle;
+    const useSourceAccounts = source.sourceType === TransactionTypeEnum.TRANSFER;
+
+    const fromIcon = useSourceAccounts && isDefined(source.sourceFromAccountIcon) ? source.sourceFromAccountIcon : fromFallbackIcon;
+    const fromTitle =
+        useSourceAccounts && isNotEmptyString(source.sourceFromAccountTitle) ? source.sourceFromAccountTitle : fromFallbackTitle;
+    const toIcon = useSourceAccounts && isDefined(source.sourceToAccountIcon) ? source.sourceToAccountIcon : toFallbackIcon;
+    const toTitle = useSourceAccounts && isNotEmptyString(source.sourceToAccountTitle) ? source.sourceToAccountTitle : toFallbackTitle;
 
     return { fromIcon, fromTitle, toIcon, toTitle };
 };


### PR DESCRIPTION
## Summary
- Fix duplicated account names on `from`/`to` lines in the Source transactions modal for non-transfer sources.
- `buildAccountSummary` now only honors `sourceFromAccountTitle` / `sourceToAccountTitle` / icons when `source.sourceType === TransactionTypeEnum.TRANSFER`; otherwise falls back to canonical from/to + entry account (existing behavior for transfer sources unchanged).

Closes #431

## Test plan
- [ ] Open a consolidated transfer whose sources are EXPENSE + INCOME pair → modal shows distinct `from`/`to` accounts (entry account on its side, canonical counterpart on the other).
- [ ] Open a consolidated transfer whose sources are themselves TRANSFERs → modal still shows the source transfer's own `from`/`to` accounts.
- [ ] Open a transfer with mixed source types → each card resolves independently and correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)