### PR TITLE
fix(app): default screenshot protection off

### DIFF
--- a/packages/app/drizzle/0022_default_screenshot_protection_off.sql
+++ b/packages/app/drizzle/0022_default_screenshot_protection_off.sql
@@ -1,0 +1,1 @@
+UPDATE `settings` SET `is_screenshot_protection_enabled` = 0;

--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
             "when": 1777597000000,
             "tag": "0021_add_updated_by",
             "breakpoints": true
+        },
+        {
+            "idx": 22,
+            "version": "6",
+            "when": 1779724800000,
+            "tag": "0022_default_screenshot_protection_off",
+            "breakpoints": true
         }
     ]
 }

--- a/packages/app/drizzle/migrations.js
+++ b/packages/app/drizzle/migrations.js
@@ -23,6 +23,7 @@ import m0018 from './0018_add_transaction_tags_is_primary.sql';
 import m0019 from './0019_add_consolidation_ledger.sql';
 import m0020 from './0020_add_rules.sql';
 import m0021 from './0021_add_updated_by.sql';
+import m0022 from './0022_default_screenshot_protection_off.sql';
 
 export default {
     journal,
@@ -48,6 +49,7 @@ export default {
         m0018,
         m0019,
         m0020,
-        m0021
+        m0021,
+        m0022
     }
 };


### PR DESCRIPTION
## Summary
- Adds migration `0022_default_screenshot_protection_off.sql` that runs `UPDATE settings SET is_screenshot_protection_enabled = 0` so the singleton settings row matches the contracts schema default for both fresh installs and existing users.
- Registers the migration in `drizzle/migrations.js` and `drizzle/meta/_journal.json`.

## Context
Migration `0000_normal_dragon_man.sql` created the column with `DEFAULT true` and the seed `INSERT INTO settings (...)` in the same migration does not list this column, so the singleton row picked up `true`. The contracts schema (`packages/contracts/src/settings/table/settings-entity.table.ts`) already declares `.default(false)` but no DB migration was ever generated to align with it.

## Test plan
- [ ] Fresh install: settings row has `is_screenshot_protection_enabled = 0`; ScreenshotProtectionController calls `allowScreenCaptureAsync`.
- [ ] Existing install: settings row flips from `1` to `0` after upgrade.
- [ ] Toggle in Settings still works (enable → relaunch → still enabled).
- [ ] `yarn ts` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)