### PR TITLE
fix(app): drop SQLiteProvider to eliminate dual-handle close race

### DIFF
--- a/packages/app/src/app/(tabs)/index.tsx
+++ b/packages/app/src/app/(tabs)/index.tsx
@@ -1,6 +1,5 @@
 import { AccountTypeEnum } from '@budgie/contracts';
 import { useDrizzleStudio } from 'expo-drizzle-studio-plugin';
-import { useSQLiteContext } from 'expo-sqlite';
 import { View } from 'react-native';
 import { useSharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -10,6 +9,7 @@ import { isNotEmptyArray } from '@rnw-community/shared';
 import { AnimatedSectionList } from '../../@generic/component/animated-section-list/animated-section-list';
 import { CollapsibleHeader } from '../../@generic/component/collapsible-header/collapsible-header';
 import { FLOATING_TAB_BAR_HEIGHT, FLOATING_TAB_BAR_MARGIN } from '../../@generic/constant/floating-tab-bar.constant';
+import { expoDb } from '../../@generic/drizzle/db/db';
 import { AccountGridItem } from '../../account/component/account-grid-item/account-grid-item';
 import { AccountSectionHeader } from '../../account/component/account-section-header/account-section-header';
 import { AccountsEmptyState } from '../../account/component/accounts-empty-state/accounts-empty-state';
@@ -39,8 +39,7 @@ export default function HomePage() {
     const { accounts } = useAccountsWithBankSyncQuery();
     const { bottom } = useSafeAreaInsets();
 
-    const db = useSQLiteContext();
-    useDrizzleStudio(db);
+    useDrizzleStudio(expoDb);
 
     const scrollY = useSharedValue(0);
 

--- a/packages/app/src/app/root-layout-content.tsx
+++ b/packages/app/src/app/root-layout-content.tsx
@@ -3,7 +3,6 @@ import { i18n } from '@lingui/core';
 import { useMigrations } from 'drizzle-orm/expo-sqlite/migrator';
 import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
-import { SQLiteProvider } from 'expo-sqlite';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { SafeAreaProvider, initialWindowMetrics } from 'react-native-safe-area-context';
@@ -34,7 +33,6 @@ import { DATE_FILTER_SHEET_OPTIONS, UNIFIED_FILTER_SHEET_OPTIONS } from '../@gen
 import { SELECTOR_MODAL_OPTIONS } from '../@generic/constant/selector-modal-options.constant';
 import { SPLIT_ENTRIES_MODAL_OPTIONS } from '../@generic/constant/split-entries-modal-options.constant';
 import { VOICE_REVIEW_MODAL_OPTIONS } from '../@generic/constant/voice-review-modal-options.constant';
-import { DB_NAME } from '../@generic/drizzle/constant/db-name.constant';
 import { db } from '../@generic/drizzle/db/db';
 import { useResetDb } from '../@generic/drizzle/hook/use-reset-db.hook';
 import { useAppInitialization } from '../@generic/hook/use-app-initialization.hook';
@@ -58,7 +56,6 @@ i18n.activate(i18nGetOSLocale());
 
 void SplashScreen.preventAutoHideAsync();
 
-const SQLOptions = { enableChangeListener: true };
 const handleAppStateChange = (isActive: boolean) => void (isActive && monobankSyncService.sync());
 
 // eslint-disable-next-line max-lines-per-function -- Layout component requires many lines
@@ -75,97 +72,92 @@ export const RootLayoutContent = () => {
 
     return (
         <SafeAreaProvider initialMetrics={initialWindowMetrics}>
-            <SQLiteProvider databaseName={DB_NAME} options={SQLOptions}>
-                <SettingsProvider>
-                    {__DEV__ && <DevMenuController />}
-                    <ScreenshotProtectionController />
-                    <I18nProvider>
-                        <KeyboardProvider>
-                            <ThemeProvider>
-                                <GestureHandlerRootView className="flex-1">
-                                    <AuthProvider>
-                                        <AuthGuard>
-                                            <CreateActionProvider>
-                                                <AiProvider>
-                                                    <ModalProvider>
-                                                        <VoiceInputProvider>
-                                                            <Stack screenOptions={DEFAULT_STACK_OPTIONS} screenLayout={ScreenLayout}>
-                                                                <Stack.Screen name="(tabs)" />
-                                                                <Stack.Screen name="(main)/pin" />
-                                                                <Stack.Screen name="(main)/create-account" />
-                                                                <Stack.Screen name="(main)/account/[id]/details" />
-                                                                <Stack.Screen name="(main)/account/[id]/update" />
-                                                                <Stack.Screen name="(main)/create-transaction/expense" />
-                                                                <Stack.Screen name="(main)/create-transaction/income" />
-                                                                <Stack.Screen name="(main)/create-transaction/transfer" />
-                                                                <Stack.Screen name="(main)/matching-rules" />
-                                                                <Stack.Screen name="(main)/transactions/[id]/expense" />
-                                                                <Stack.Screen name="(main)/transactions/[id]/income" />
-                                                                <Stack.Screen name="(main)/transactions/[id]/transfer" />
-                                                                <Stack.Screen name="(main)/analytics/transactions" />
-                                                                <Stack.Screen name="category-selector" options={SELECTOR_MODAL_OPTIONS} />
-                                                                <Stack.Screen name="account-selector" options={SELECTOR_MODAL_OPTIONS} />
-                                                                <Stack.Screen name="currency-selector" options={SELECTOR_MODAL_OPTIONS} />
-                                                                <Stack.Screen name="language-selector" options={SELECTOR_MODAL_OPTIONS} />
-                                                                <Stack.Screen
-                                                                    name="resync-window-picker"
-                                                                    options={SELECTOR_MODAL_OPTIONS}
-                                                                />
-                                                                <Stack.Screen name="contact-selector" options={SELECTOR_MODAL_OPTIONS} />
-                                                                <Stack.Screen name="tags-selector" options={SELECTOR_MODAL_OPTIONS} />
-                                                                <Stack.Screen name="voice-review" options={VOICE_REVIEW_MODAL_OPTIONS} />
-                                                                <Stack.Screen name="category-form" options={CATEGORY_EDIT_MODAL_OPTIONS} />
-                                                                <Stack.Screen name="tag-form" options={CATEGORY_EDIT_MODAL_OPTIONS} />
-                                                                <Stack.Screen name="date-picker" options={DATE_PICKER_MODAL_OPTIONS} />
-                                                                <Stack.Screen name="note-input" options={NOTE_INPUT_MODAL_OPTIONS} />
-                                                                <Stack.Screen
-                                                                    name="convert-to-transfer"
-                                                                    options={CONVERT_TO_TRANSFER_MODAL_OPTIONS}
-                                                                />
-                                                                <Stack.Screen name="icon-selector" options={ICON_SELECTOR_MODAL_OPTIONS} />
-                                                                <Stack.Screen name="split-entries" options={SPLIT_ENTRIES_MODAL_OPTIONS} />
-                                                                <Stack.Screen
-                                                                    name="consolidation-source"
-                                                                    options={CONSOLIDATION_SOURCE_MODAL_OPTIONS}
-                                                                />
-                                                                <Stack.Screen
-                                                                    name="import-column-mapper"
-                                                                    options={UNIFIED_FILTER_SHEET_OPTIONS}
-                                                                />
-                                                                <Stack.Screen
-                                                                    name="transaction-type-filter"
-                                                                    options={COMPACT_FILTER_SHEET_OPTIONS}
-                                                                />
-                                                                <Stack.Screen name="date-filter" options={DATE_FILTER_SHEET_OPTIONS} />
-                                                                <Stack.Screen
-                                                                    name="transaction-category-filter"
-                                                                    options={UNIFIED_FILTER_SHEET_OPTIONS}
-                                                                />
-                                                                <Stack.Screen
-                                                                    name="transaction-account-filter"
-                                                                    options={UNIFIED_FILTER_SHEET_OPTIONS}
-                                                                />
-                                                                <Stack.Screen
-                                                                    name="transaction-tag-filter"
-                                                                    options={UNIFIED_FILTER_SHEET_OPTIONS}
-                                                                />
-                                                                <Stack.Screen name="rule-form" options={RULE_FORM_MODAL_OPTIONS} />
-                                                                <Stack.Screen name="rule-selector" options={RULE_SELECTOR_MODAL_OPTIONS} />
-                                                                <Stack.Screen name="rule-mcc-selector" options={SELECTOR_MODAL_OPTIONS} />
-                                                            </Stack>
-                                                        </VoiceInputProvider>
-                                                    </ModalProvider>
-                                                    <Toast config={APP_TOAST_CONFIG} />
-                                                </AiProvider>
-                                            </CreateActionProvider>
-                                        </AuthGuard>
-                                    </AuthProvider>
-                                </GestureHandlerRootView>
-                            </ThemeProvider>
-                        </KeyboardProvider>
-                    </I18nProvider>
-                </SettingsProvider>
-            </SQLiteProvider>
+            <SettingsProvider>
+                {__DEV__ && <DevMenuController />}
+                <ScreenshotProtectionController />
+                <I18nProvider>
+                    <KeyboardProvider>
+                        <ThemeProvider>
+                            <GestureHandlerRootView className="flex-1">
+                                <AuthProvider>
+                                    <AuthGuard>
+                                        <CreateActionProvider>
+                                            <AiProvider>
+                                                <ModalProvider>
+                                                    <VoiceInputProvider>
+                                                        <Stack screenOptions={DEFAULT_STACK_OPTIONS} screenLayout={ScreenLayout}>
+                                                            <Stack.Screen name="(tabs)" />
+                                                            <Stack.Screen name="(main)/pin" />
+                                                            <Stack.Screen name="(main)/create-account" />
+                                                            <Stack.Screen name="(main)/account/[id]/details" />
+                                                            <Stack.Screen name="(main)/account/[id]/update" />
+                                                            <Stack.Screen name="(main)/create-transaction/expense" />
+                                                            <Stack.Screen name="(main)/create-transaction/income" />
+                                                            <Stack.Screen name="(main)/create-transaction/transfer" />
+                                                            <Stack.Screen name="(main)/matching-rules" />
+                                                            <Stack.Screen name="(main)/transactions/[id]/expense" />
+                                                            <Stack.Screen name="(main)/transactions/[id]/income" />
+                                                            <Stack.Screen name="(main)/transactions/[id]/transfer" />
+                                                            <Stack.Screen name="(main)/analytics/transactions" />
+                                                            <Stack.Screen name="category-selector" options={SELECTOR_MODAL_OPTIONS} />
+                                                            <Stack.Screen name="account-selector" options={SELECTOR_MODAL_OPTIONS} />
+                                                            <Stack.Screen name="currency-selector" options={SELECTOR_MODAL_OPTIONS} />
+                                                            <Stack.Screen name="language-selector" options={SELECTOR_MODAL_OPTIONS} />
+                                                            <Stack.Screen name="resync-window-picker" options={SELECTOR_MODAL_OPTIONS} />
+                                                            <Stack.Screen name="contact-selector" options={SELECTOR_MODAL_OPTIONS} />
+                                                            <Stack.Screen name="tags-selector" options={SELECTOR_MODAL_OPTIONS} />
+                                                            <Stack.Screen name="voice-review" options={VOICE_REVIEW_MODAL_OPTIONS} />
+                                                            <Stack.Screen name="category-form" options={CATEGORY_EDIT_MODAL_OPTIONS} />
+                                                            <Stack.Screen name="tag-form" options={CATEGORY_EDIT_MODAL_OPTIONS} />
+                                                            <Stack.Screen name="date-picker" options={DATE_PICKER_MODAL_OPTIONS} />
+                                                            <Stack.Screen name="note-input" options={NOTE_INPUT_MODAL_OPTIONS} />
+                                                            <Stack.Screen
+                                                                name="convert-to-transfer"
+                                                                options={CONVERT_TO_TRANSFER_MODAL_OPTIONS}
+                                                            />
+                                                            <Stack.Screen name="icon-selector" options={ICON_SELECTOR_MODAL_OPTIONS} />
+                                                            <Stack.Screen name="split-entries" options={SPLIT_ENTRIES_MODAL_OPTIONS} />
+                                                            <Stack.Screen
+                                                                name="consolidation-source"
+                                                                options={CONSOLIDATION_SOURCE_MODAL_OPTIONS}
+                                                            />
+                                                            <Stack.Screen
+                                                                name="import-column-mapper"
+                                                                options={UNIFIED_FILTER_SHEET_OPTIONS}
+                                                            />
+                                                            <Stack.Screen
+                                                                name="transaction-type-filter"
+                                                                options={COMPACT_FILTER_SHEET_OPTIONS}
+                                                            />
+                                                            <Stack.Screen name="date-filter" options={DATE_FILTER_SHEET_OPTIONS} />
+                                                            <Stack.Screen
+                                                                name="transaction-category-filter"
+                                                                options={UNIFIED_FILTER_SHEET_OPTIONS}
+                                                            />
+                                                            <Stack.Screen
+                                                                name="transaction-account-filter"
+                                                                options={UNIFIED_FILTER_SHEET_OPTIONS}
+                                                            />
+                                                            <Stack.Screen
+                                                                name="transaction-tag-filter"
+                                                                options={UNIFIED_FILTER_SHEET_OPTIONS}
+                                                            />
+                                                            <Stack.Screen name="rule-form" options={RULE_FORM_MODAL_OPTIONS} />
+                                                            <Stack.Screen name="rule-selector" options={RULE_SELECTOR_MODAL_OPTIONS} />
+                                                            <Stack.Screen name="rule-mcc-selector" options={SELECTOR_MODAL_OPTIONS} />
+                                                        </Stack>
+                                                    </VoiceInputProvider>
+                                                </ModalProvider>
+                                                <Toast config={APP_TOAST_CONFIG} />
+                                            </AiProvider>
+                                        </CreateActionProvider>
+                                    </AuthGuard>
+                                </AuthProvider>
+                            </GestureHandlerRootView>
+                        </ThemeProvider>
+                    </KeyboardProvider>
+                </I18nProvider>
+            </SettingsProvider>
         </SafeAreaProvider>
     );
 };


### PR DESCRIPTION
## Summary

Fixes a major contributor to the SQLite close-race crash (#459). The app currently opens **two native SQLite handles to the same DB file**:

1. \`packages/app/src/@generic/drizzle/db/db.ts:45\` — \`global.__expoSqliteDb__\` via \`SQLite.openDatabaseSync(DB_NAME, ...)\` (used by drizzle and every repository).
2. \`packages/app/src/app/root-layout-content.tsx:78\` — \`<SQLiteProvider databaseName={DB_NAME}>\` (used by \`useSQLiteContext()\` in one place).

When destructive operations (rekey, import) call \`closeAsync()\` on one handle while React unmounts the provider tree (e.g., during \`reloadApp()\` after import), **both handles' \`closeAsync()\` invocations dispatch onto separate GCD worker threads and race through the native module's open-DB array** — observed as concurrent threads in \`SQLiteModule.closeDatabase → Collection.firstIndex(where:)\` at \`SQLiteModule.swift:492\` in five TestFlight crash reports (SIGBUS, SIGTRAP/PAC, SIGSEGV).

This PR removes the provider entirely.

## What changed

- \`packages/app/src/app/root-layout-content.tsx\` — removed \`<SQLiteProvider>\` wrapping, removed unused \`DB_NAME\` import and \`SQLOptions\` const.
- \`packages/app/src/app/(tabs)/index.tsx\` — the sole \`useSQLiteContext()\` consumer (line 42, used only to hand the handle to \`useDrizzleStudio\`). Migrated to \`import { expoDb } from '.../db'\` + \`useDrizzleStudio(expoDb)\`.

## Why this is safe

- The provider's handle was never used by the data layer; drizzle and all 23 repository singletons already use \`global.__expoSqliteDb__\` from \`db.ts\`.
- The provider had exactly one consumer in the app (verified via grep), used in a way that doesn't depend on React context — \`useDrizzleStudio\` just needs the SQLite handle.

## Scope

This PR fixes one half of the close race (the unnecessary second handle). A follow-up PR will introduce a single-flight lock on the remaining close paths (rekey + import) as defense in depth.

Refs #459

## Test plan

- [ ] App launches normally.
- [ ] Home tab (\`(tabs)/index.tsx\`) renders; \`useDrizzleStudio\` still functions in dev (or no-op in prod as before).
- [ ] Import a backup → app reloads cleanly, no crash with the \`SQLiteModule.swift:492\` signature in the device console.
- [ ] PIN change (rekey) → app reloads cleanly, no crash.
- [ ] \`yarn ts && yarn lint && yarn deadcode && yarn cpd\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)