### PR TITLE
fix(app): single-flight SQLite close with pre-close drain

### DIFF
--- a/packages/app/src/@generic/drizzle/service/database-lifecycle.service.ts
+++ b/packages/app/src/@generic/drizzle/service/database-lifecycle.service.ts
@@ -1,0 +1,40 @@
+import { Log } from '@budgie/logger';
+
+import { getErrorMessage, isDefined } from '@rnw-community/shared';
+
+import { ruleApplicationDrainerService } from '../../../rule/service/rule-application-drainer.service';
+import { monobankSyncService } from '../../../sync/service/monobank-sync.service';
+import { expoDb } from '../db/db';
+
+class DatabaseLifecycleService {
+    private closeInflight: Promise<void> | null = null;
+
+    @Log('enter', 'done', error => `throw error=${getErrorMessage(error)}`)
+    async close(): Promise<void> {
+        if (isDefined(this.closeInflight)) {
+            await this.closeInflight;
+
+            return;
+        }
+        this.closeInflight = this.runClose();
+        try {
+            await this.closeInflight;
+        } finally {
+            this.closeInflight = null;
+        }
+    }
+
+    private async runClose(): Promise<void> {
+        await this.drainInFlightWork();
+
+        await expoDb.closeAsync();
+        global.__expoSqliteDb__ = undefined; // eslint-disable-line no-undefined, no-underscore-dangle
+        global.__drizzleDb__ = undefined; // eslint-disable-line no-undefined, no-underscore-dangle
+    }
+
+    private async drainInFlightWork(): Promise<void> {
+        await Promise.all([monobankSyncService.whenIdle(), ruleApplicationDrainerService.whenIdle()]);
+    }
+}
+
+export const databaseLifecycleService = new DatabaseLifecycleService();

--- a/packages/app/src/@generic/drizzle/service/database-rekey.service.ts
+++ b/packages/app/src/@generic/drizzle/service/database-rekey.service.ts
@@ -10,6 +10,8 @@ import { DB_NAME } from '../constant/db-name.constant';
 import { expoDb } from '../db/db';
 import * as schema from '../db/schema';
 
+import { databaseLifecycleService } from './database-lifecycle.service';
+
 import { RekeyParamsInterface } from './interface/rekey-params.interface';
 import { RekeyPathsInterface } from './interface/rekey-paths.interface';
 
@@ -40,8 +42,7 @@ class DatabaseRekeyService {
     }
 
     private async commit(paths: RekeyPathsInterface, onCommit: () => Promise<void>): Promise<void> {
-        await expoDb.closeAsync();
-        this.clearDatabaseGlobals();
+        await databaseLifecycleService.close();
         this.deleteDestinationSidecars(paths.destinationPath);
         this.moveExistingDatabaseToBackup(paths.destinationPath, paths.backupPath);
         new File(paths.tempDatabasePath).move(new File(paths.destinationPath));
@@ -118,13 +119,6 @@ class DatabaseRekeyService {
     private deleteDestinationSidecars(destinationPath: string): void {
         this.deleteFileIfExists(`${destinationPath}-wal`);
         this.deleteFileIfExists(`${destinationPath}-shm`);
-    }
-
-    private clearDatabaseGlobals(): void {
-        // eslint-disable-next-line no-underscore-dangle, no-undefined
-        global.__expoSqliteDb__ = undefined;
-        // eslint-disable-next-line no-underscore-dangle, no-undefined
-        global.__drizzleDb__ = undefined;
     }
 
     private deleteDatabaseFiles(databasePath: string): void {

--- a/packages/app/src/import/service/database-import.service.ts
+++ b/packages/app/src/import/service/database-import.service.ts
@@ -5,7 +5,7 @@ import * as SQLite from 'expo-sqlite';
 import { getErrorMessage } from '@rnw-community/shared';
 
 import { DB_NAME } from '../../@generic/drizzle/constant/db-name.constant';
-import { expoDb } from '../../@generic/drizzle/db/db';
+import { databaseLifecycleService } from '../../@generic/drizzle/service/database-lifecycle.service';
 import { reloadApp } from '../../@generic/utils/reload-app.util';
 import { aiCoordinatorService } from '../../ai/service/ai-coordinator.service';
 import { aiEmbeddingStatusService } from '../../ai/service/ai-embedding-status.service';
@@ -33,8 +33,7 @@ class DatabaseImportService {
         const tempPath = `${Paths.cache.uri}/import-temp.db`;
 
         await this.pauseLongLivedRuntime();
-        await expoDb.closeAsync();
-        this.clearDatabaseGlobals();
+        await databaseLifecycleService.close();
         this.deleteDestinationFiles(destinationPath, tempPath);
         this.replaceDestinationFile(sourceUri, tempPath, destinationPath);
         this.copyDatabaseSidecars(sourceUri, destinationPath);
@@ -62,13 +61,6 @@ class DatabaseImportService {
 
     private deleteDestinationFiles(destinationPath: string, tempPath: string): void {
         [destinationPath, `${destinationPath}-wal`, `${destinationPath}-shm`, tempPath].forEach(path => void this.deleteFileIfExists(path));
-    }
-
-    private clearDatabaseGlobals() {
-        // eslint-disable-next-line no-underscore-dangle, no-undefined
-        global.__expoSqliteDb__ = undefined;
-        // eslint-disable-next-line no-underscore-dangle, no-undefined
-        global.__drizzleDb__ = undefined;
     }
 
     private deleteFileIfExists(path: string) {

--- a/packages/app/src/rule/service/rule-application-drainer.service.ts
+++ b/packages/app/src/rule/service/rule-application-drainer.service.ts
@@ -84,6 +84,13 @@ class RuleApplicationDrainerService {
         }
     }
 
+    async whenIdle(): Promise<void> {
+        while (isDefined(this.runPromise)) {
+            // eslint-disable-next-line no-await-in-loop -- intentional: re-await if a new run starts during drain
+            await this.runPromise.catch(emptyFn);
+        }
+    }
+
     private async drainNextBatch(): Promise<void> {
         if (!isNotEmptyArray(this.pendingTransactionIds) && !isNotEmptyArray(this.pendingRuleIds)) {
             return;

--- a/packages/app/src/sync/service/monobank-sync.service.ts
+++ b/packages/app/src/sync/service/monobank-sync.service.ts
@@ -5,7 +5,7 @@ import { Log } from '@budgie/logger';
 import * as BackgroundTask from 'expo-background-task';
 import * as TaskManager from 'expo-task-manager';
 
-import { getErrorMessage, isDefined, isNotEmptyArray, isNotEmptyString, isPositiveNumber } from '@rnw-community/shared';
+import { emptyFn, getErrorMessage, isDefined, isNotEmptyArray, isNotEmptyString, isPositiveNumber } from '@rnw-community/shared';
 
 import { accountRepository, bankSyncRepository } from '../../@generic/drizzle/db/db';
 import { microPause } from '../../@generic/utils/micro-pause.util';
@@ -32,22 +32,17 @@ class AppMonobankSyncService {
     private static readonly FORWARD_SYNC_STALE_THRESHOLD_MS = TWO_MINUTES_IN_SECONDS * 1000;
 
     private readonly provider = ExternalSourceEnum.MONOBANK;
-    private isRunning = false;
+    private currentSync: Promise<BackgroundTask.BackgroundTaskResult> | null = null;
     private mccCategoryLookupMap = new Map<string, MccCategoryLookupInterface>();
 
     @Log('enter', 'done', error => `throw error=${getErrorMessage(error)}`)
     async sync(): Promise<BackgroundTask.BackgroundTaskResult> {
-        if (this.isRunning) {
-            return BackgroundTask.BackgroundTaskResult.Success;
+        if (isDefined(this.currentSync)) {
+            return this.currentSync;
         }
-        this.isRunning = true;
-        try {
-            await this.loadMccCategories();
+        this.currentSync = this.runSync();
 
-            return await this.executeSyncLoop();
-        } finally {
-            this.isRunning = false;
-        }
+        return this.currentSync;
     }
 
     @Log(
@@ -222,6 +217,13 @@ class AppMonobankSyncService {
         return result;
     }
 
+    async whenIdle(): Promise<void> {
+        while (isDefined(this.currentSync)) {
+            // eslint-disable-next-line no-await-in-loop -- intentional: re-await if a new sync starts during drain
+            await this.currentSync.catch(emptyFn);
+        }
+    }
+
     async setupAccountSyncBatch(token: string, externalIds: string[]): Promise<void> {
         const bankAccounts = await new MonobankSyncService(token).syncAccounts();
 
@@ -367,6 +369,16 @@ class AppMonobankSyncService {
             forwardSyncFromAt: now,
             forwardSyncedAt: null
         });
+    }
+
+    private async runSync(): Promise<BackgroundTask.BackgroundTaskResult> {
+        try {
+            await this.loadMccCategories();
+
+            return await this.executeSyncLoop();
+        } finally {
+            this.currentSync = null;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Defense-in-depth half of the SQLite close-race fix (#459). Pairs with #468 (drop \`<SQLiteProvider>\`):

- **#468** removes the *second* native handle that made concurrent close calls possible at all.
- **This PR** ensures that even with a single handle, multiple JS-initiated close paths (rekey, import, anything we add later) can never produce concurrent \`closeDatabase\` invocations in the native module.

Together they fully close the SIGBUS/SIGTRAP/SIGSEGV race observed in five TestFlight reports at \`SQLiteModule.swift:492\`.

## What changed

### New \`databaseLifecycleService\`

\`packages/app/src/@generic/drizzle/service/database-lifecycle.service.ts\` — single \`close()\` method with a module-level \`closeInflight: Promise<void> | null\` lock. Concurrent callers reuse the in-flight Promise. The native module receives exactly one \`closeAsync()\` at a time regardless of how many JS sites request it. Centralizes the global-clearing (\`global.__expoSqliteDb__ = undefined\`, \`global.__drizzleDb__ = undefined\`) that previously lived as private helpers in two services.

### Pre-close drain

\`close()\` awaits two new \`whenIdle()\` methods before invoking the native close:

- \`monobankSyncService.whenIdle()\` — added via a new \`currentSync: Promise<...> | null\` tracker that replaces the previous \`isRunning\` boolean. \`sync()\` now stores the in-flight promise and short-circuits on re-entry by returning it.
- \`ruleApplicationDrainerService.whenIdle()\` — awaits the existing \`runPromise\` if set.

In-flight write transactions finish before the close instead of racing against it.

### Migrated close call sites

- \`packages/app/src/@generic/drizzle/service/database-rekey.service.ts\` — \`commit()\` now calls \`databaseLifecycleService.close()\` instead of \`expoDb.closeAsync()\` directly. Removed the private \`clearDatabaseGlobals()\` helper.
- \`packages/app/src/import/service/database-import.service.ts\` — \`replaceFromUri()\` same treatment.

## Why this is safe

- The two close call sites (rekey, import) both call \`reloadApp()\` immediately after, so the existing "close then re-init via module reload" pattern is unchanged.
- \`whenIdle()\` is a guard: if no sync/drainer is in flight, it returns immediately. If one is, the close waits — fixing a latent window where a close could land while a write was still in flight.
- \`__REMOVE_ME_RESET_DB\` (dev-only) intentionally bypasses the lock; documented in code that it's a dev path. Pre-existing footgun, unchanged.

## Known limitations (deferred follow-ups)

- **Rekey-failure window**: if \`databaseRekeyService.rekey()\` throws *after* \`close()\` has run (e.g., during file move or \`onCommit\`), \`auth.service.ts:rekeyDatabase\` rethrows without calling \`reloadApp()\`, leaving stale repository references. Pre-existing on main, unaffected by this PR. Follow-up: move \`reloadApp()\` into a \`finally\` block in \`rekeyDatabase\`.
- **Stale module-level references**: \`expoDb\`, \`db\`, and the 23 repository singletons capture references at module load. After close they point at a freed handle until \`reloadApp()\` re-imports the module. Both production callers reload immediately after close, so this works in practice. Full fix would require converting the contracts package's repository constructors to read the live handle (out of scope).
- **Multiple rules simultaneously**: the rule drainer serializes by convention, not by code. A future direct caller of \`RuleEngineService\` would bypass the guarantee. Follow-up: defensive single-flight lock inside \`RuleEngineService\` itself.

## Test plan

- [ ] Trigger an import while a sync is mid-flight — verify the close waits for sync, no crash, import completes cleanly.
- [ ] Trigger a PIN change while sync is mid-flight — verify drain → close → reload.
- [ ] Rapid backgrounding during import — verify single-flight collapses concurrent close attempts.
- [ ] First-launch sync works (no regression in \`sync()\` refactor: \`isRunning\` → \`currentSync\`).
- [ ] \`yarn ts && yarn lint && yarn deadcode && yarn cpd\` green.
- [ ] \`tests/bank-sync-tests\` green.

Refs #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)