### PR TITLE
fix(app): stabilize quick rule hints

### DIFF
--- a/packages/app/src/rule/util/select-suggest-condition.util.ts
+++ b/packages/app/src/rule/util/select-suggest-condition.util.ts
@@ -1,6 +1,6 @@
 import { RuleConditionCreateInputInterface, RuleConditionFieldEnum, RuleConditionOperatorEnum } from '@budgie/contracts';
 
-import { isNotEmptyArray, isNotEmptyString } from '@rnw-community/shared';
+import { isDefined, isNotEmptyArray, isNotEmptyString } from '@rnw-community/shared';
 
 const REFERENCE_PATTERNS = [/\bREF[#:]?\w*/giu, /#\w{4,}/gu, /\b\d{5,}\b/gu];
 
@@ -16,8 +16,11 @@ const SUFFIX_PATTERN = /\.?\b(?:COM|NET|ORG|INC|LLC|LTD|GMBH|CO|CORP|PLC|SA|AG|S
 
 const EXTRA_WHITESPACE = /\s{2,}/gu;
 const LEADING_TRAILING_SEPARATORS = /^[\s*\-_.,/]+|[\s*\-_.,/]+$/gu;
+const REGEX_SPECIAL_CHARACTERS = /[\\^$.*+?()[\]{}|]/gu;
+const TOKEN_SEPARATOR = /\s+/u;
 
 const MINIMUM_CLEANED_LENGTH = 3;
+const MAX_CONDITION_REGEX_LENGTH = 200;
 
 // eslint-disable-next-line max-statements -- sequential regex cleanup steps absorbed from clean-merchant-title util per CLAUDE.md rule 38/51
 const cleanMerchantTitle = (title: string): string => {
@@ -68,6 +71,58 @@ const isGenericTitle = (title: string): boolean => {
 const isCleanedTextUsable = (cleaned: string): boolean =>
     isNotEmptyString(cleaned) && cleaned.length >= MINIMUM_TITLE_LENGTH && !isGenericTitle(cleaned);
 
+const escapeRegexToken = (token: string): string => token.replace(REGEX_SPECIAL_CHARACTERS, '\\$&');
+
+const buildFlexibleContainsRegex = (text: string): string => {
+    const tokens = text.split(TOKEN_SEPARATOR).filter(isNotEmptyString).map(escapeRegexToken);
+    let regex = '';
+
+    for (const token of tokens) {
+        const nextRegex = isNotEmptyString(regex) ? `${regex}.*${token}` : token;
+
+        if (nextRegex.length > MAX_CONDITION_REGEX_LENGTH) {
+            return regex;
+        }
+
+        regex = nextRegex;
+    }
+
+    return regex;
+};
+
+const buildTextCondition = (
+    field: RuleConditionFieldEnum.TITLE | RuleConditionFieldEnum.COMMENT,
+    text: string
+): RuleConditionCreateInputInterface | null => {
+    const cleanedText = cleanMerchantTitle(text);
+
+    if (!isCleanedTextUsable(cleanedText)) {
+        return null;
+    }
+
+    if (text.toLowerCase().includes(cleanedText.toLowerCase())) {
+        return {
+            field,
+            operator: RuleConditionOperatorEnum.CONTAINS,
+            value: cleanedText,
+            secondaryValue: null
+        };
+    }
+
+    const regex = buildFlexibleContainsRegex(cleanedText);
+
+    if (!isNotEmptyString(regex)) {
+        return null;
+    }
+
+    return {
+        field,
+        operator: RuleConditionOperatorEnum.MATCHES_REGEX,
+        value: regex,
+        secondaryValue: null
+    };
+};
+
 export const selectSuggestConditions = (
     title: string,
     mccCode: string | null,
@@ -84,25 +139,15 @@ export const selectSuggestConditions = (
         });
     }
 
-    const cleanedTitle = cleanMerchantTitle(title);
+    const titleCondition = buildTextCondition(RuleConditionFieldEnum.TITLE, title);
 
-    if (isCleanedTextUsable(cleanedTitle)) {
-        conditions.push({
-            field: RuleConditionFieldEnum.TITLE,
-            operator: RuleConditionOperatorEnum.CONTAINS,
-            value: cleanedTitle,
-            secondaryValue: null
-        });
+    if (isDefined(titleCondition)) {
+        conditions.push(titleCondition);
     } else if (isNotEmptyString(comment)) {
-        const cleanedComment = cleanMerchantTitle(comment);
+        const commentCondition = buildTextCondition(RuleConditionFieldEnum.COMMENT, comment);
 
-        if (isCleanedTextUsable(cleanedComment)) {
-            conditions.push({
-                field: RuleConditionFieldEnum.COMMENT,
-                operator: RuleConditionOperatorEnum.CONTAINS,
-                value: cleanedComment,
-                secondaryValue: null
-            });
+        if (isDefined(commentCondition)) {
+            conditions.push(commentCondition);
         }
     }
 

--- a/packages/app/src/transaction/components/simple-quick-form/simple-quick-form.tsx
+++ b/packages/app/src/transaction/components/simple-quick-form/simple-quick-form.tsx
@@ -172,7 +172,7 @@ export const SimpleQuickForm = (props: Props) => {
 
     const isSplitActive = splitEntryCount > 1;
     const hasTagsSelected = isNotEmptyArray(tagIds);
-    const isCategoryUserConfirmed = !isDefined(categorySource) || categorySource === CategorySourceEnum.USER;
+    const isCategoryUserConfirmed = categorySource !== CategorySourceEnum.MCC_DEFAULT;
 
     const handleNormalConfirm = () => {
         const amount = getValues('amount');


### PR DESCRIPTION
## Summary
- Treat rule-assigned and AI-assigned categories as confirmed on transaction edit forms so category hints do not reappear after a category is selected.
- Generate flexible regex conditions for cleaned quick-rule merchant text when the cleaned text is not a literal substring of the raw transaction title/comment.

## Root Cause
- The quick form only considered `CategorySourceEnum.USER` confirmed, so `CategorySourceEnum.RULE` categories were treated like replaceable MCC defaults and could trigger the AI category hint again.
- Quick-rule condition creation cleaned merchant titles before storing a `CONTAINS` condition. When cleanup removed middle tokens such as legal suffixes or long reference numbers, the cleaned value no longer appeared contiguously in the raw transaction title, so the newly created rule could fail to match the transaction that created it.

## Validation
- `yarn format`
- `yarn ts`
- `yarn lint` (0 errors; existing warning in `packages/app/src/ai/hook/use-suggestion-base.hook.ts`)
- `yarn deadcode`
- `yarn cpd`
- `git diff --check`

Closes #470