### PR TITLE
fix(app): clamp quick form transaction title

### DIFF
--- a/packages/app/src/transaction/components/mcc-info-row/mcc-info-row.tsx
+++ b/packages/app/src/transaction/components/mcc-info-row/mcc-info-row.tsx
@@ -20,8 +20,12 @@ export const MccInfoRow = ({ transactionTitle, mccCategoryId }: Props) => {
     }
 
     return (
-        <View className="items-center mx-xl">
-            {hasTitle ? <Text className="text-sm text-secondary-foreground font-medium">{transactionTitle}</Text> : null}
+        <View className="items-center mx-xl gap-xs">
+            {hasTitle ? (
+                <Text className="w-full text-sm text-secondary-foreground font-medium text-center" numberOfLines={2}>
+                    {transactionTitle}
+                </Text>
+            ) : null}
 
             {hasMcc ? (
                 <View className="rounded-full py-xs px-md bg-primary/10 border border-primary/20">


### PR DESCRIPTION
## Summary

- Clamp the quick form transaction title to two centered lines.
- Add a small gap between the title and MCC pill so long imported merchant strings do not crowd the metadata chip.

## Why

Long imported bank transaction titles could wrap into an awkward block under the amount, making the edit transaction screen look visually heavy and uneven.

## Validation

- `yarn install` in the isolated PR worktree with Node 20.20.0 on PATH; repo after-install build completed with existing peer dependency warnings.
- `yarn format`
- `yarn ts`
- `yarn lint` exited 0 with the existing `use-suggestion-base.hook.ts` exhaustive-deps warning.
- `yarn deadcode`
- `yarn cpd` found 0 clones.
