### PR TITLE
fix(app): stabilize symbol quick rules

### DIFF
--- a/packages/app/src/rule/components/rule-suggestion-card/rule-suggestion-card.tsx
+++ b/packages/app/src/rule/components/rule-suggestion-card/rule-suggestion-card.tsx
@@ -1,5 +1,6 @@
 import {
     RuleActionTypeEnum,
+    RuleAssociationEnum,
     RuleConditionMatchTypeEnum,
     RuleCreateInputInterface,
     RuleWithRelationsEntityInterface
@@ -37,8 +38,8 @@ const areConditionsEqual = (inputConditions: RuleConditionInputInterface[], exis
 const findDuplicateRule = (
     conditions: RuleConditionInputInterface[],
     conditionMatchType: RuleConditionMatchTypeEnum,
-    existingRules: RuleWithRelationsEntityInterface[]
-): RuleWithRelationsEntityInterface | undefined =>
+    existingRules: Pick<RuleWithRelationsEntityInterface, 'id' | 'conditionMatchType' | RuleAssociationEnum.CONDITIONS>[]
+): Pick<RuleWithRelationsEntityInterface, 'id' | 'conditionMatchType' | RuleAssociationEnum.CONDITIONS> | undefined =>
     existingRules.find(
         rule =>
             rule.conditionMatchType === conditionMatchType &&
@@ -99,7 +100,10 @@ export const RuleSuggestionCard = (props: Props) => {
     const { suggestRuleData, onRuleCreated, onDismiss, onCreatingChange } = props;
     const { openRuleForm } = useRuleFormModal();
 
-    const handleDuplicateRule = (duplicateRule: RuleWithRelationsEntityInterface, ruleInput: RuleCreateInputInterface): Promise<void> => {
+    const handleDuplicateRule = (
+        duplicateRule: Pick<RuleWithRelationsEntityInterface, 'id'>,
+        ruleInput: RuleCreateInputInterface
+    ): Promise<void> => {
         logger.log('handleYes:duplicate-alert:shown', { duplicateRuleId: duplicateRule.id });
 
         return new Promise<void>((resolve, reject) => {
@@ -150,7 +154,7 @@ export const RuleSuggestionCard = (props: Props) => {
             throw new Error('Invalid rule input');
         }
 
-        const existingRules = await ruleRepository.findAllWithActionsAndCategories();
+        const existingRules = await ruleRepository.findAllWithConditions();
         const duplicateRule = findDuplicateRule(ruleInput.conditions, ruleInput.conditionMatchType, existingRules);
         logger.log('handleYes:duplicate-check', {
             existingRulesCount: existingRules.length,

--- a/packages/app/src/rule/util/select-suggest-condition.util.ts
+++ b/packages/app/src/rule/util/select-suggest-condition.util.ts
@@ -18,9 +18,13 @@ const EXTRA_WHITESPACE = /\s{2,}/gu;
 const LEADING_TRAILING_SEPARATORS = /^[\s*\-_.,/]+|[\s*\-_.,/]+$/gu;
 const REGEX_SPECIAL_CHARACTERS = /[\\^$.*+?()[\]{}|]/gu;
 const TOKEN_SEPARATOR = /\s+/u;
+const QUICK_RULE_SYMBOL_SEPARATOR_PATTERN = /[:+\\]+/u;
+const TITLE_TOKEN_SEPARATOR_PATTERN = /[^\p{L}\p{N}]+/gu;
 
 const MINIMUM_CLEANED_LENGTH = 3;
 const MAX_CONDITION_REGEX_LENGTH = 200;
+const MINIMUM_TITLE_TOKEN_LENGTH = 2;
+const MAXIMUM_TITLE_TOKEN_CONDITIONS = 2;
 
 // eslint-disable-next-line max-statements -- sequential regex cleanup steps absorbed from clean-merchant-title util per CLAUDE.md rule 38/51
 const cleanMerchantTitle = (title: string): string => {
@@ -90,23 +94,57 @@ const buildFlexibleContainsRegex = (text: string): string => {
     return regex;
 };
 
-const buildTextCondition = (
+const buildSymbolSeparatedTextConditions = (
+    field: RuleConditionFieldEnum.TITLE | RuleConditionFieldEnum.COMMENT,
+    value: string
+): RuleConditionCreateInputInterface[] => {
+    const tokenValues = value
+        .split(TITLE_TOKEN_SEPARATOR_PATTERN)
+        .filter(token => token.length >= MINIMUM_TITLE_TOKEN_LENGTH)
+        .slice(0, MAXIMUM_TITLE_TOKEN_CONDITIONS);
+
+    if (!isNotEmptyArray(tokenValues)) {
+        return [
+            {
+                field,
+                operator: RuleConditionOperatorEnum.CONTAINS,
+                value,
+                secondaryValue: null
+            }
+        ];
+    }
+
+    return tokenValues.map(tokenValue => ({
+        field,
+        operator: RuleConditionOperatorEnum.CONTAINS,
+        value: tokenValue,
+        secondaryValue: null
+    }));
+};
+
+const buildTextConditions = (
     field: RuleConditionFieldEnum.TITLE | RuleConditionFieldEnum.COMMENT,
     text: string
-): RuleConditionCreateInputInterface | null => {
+): RuleConditionCreateInputInterface[] | null => {
     const cleanedText = cleanMerchantTitle(text);
 
     if (!isCleanedTextUsable(cleanedText)) {
         return null;
     }
 
+    if (QUICK_RULE_SYMBOL_SEPARATOR_PATTERN.test(cleanedText)) {
+        return buildSymbolSeparatedTextConditions(field, cleanedText);
+    }
+
     if (text.toLowerCase().includes(cleanedText.toLowerCase())) {
-        return {
-            field,
-            operator: RuleConditionOperatorEnum.CONTAINS,
-            value: cleanedText,
-            secondaryValue: null
-        };
+        return [
+            {
+                field,
+                operator: RuleConditionOperatorEnum.CONTAINS,
+                value: cleanedText,
+                secondaryValue: null
+            }
+        ];
     }
 
     const regex = buildFlexibleContainsRegex(cleanedText);
@@ -115,12 +153,14 @@ const buildTextCondition = (
         return null;
     }
 
-    return {
-        field,
-        operator: RuleConditionOperatorEnum.MATCHES_REGEX,
-        value: regex,
-        secondaryValue: null
-    };
+    return [
+        {
+            field,
+            operator: RuleConditionOperatorEnum.MATCHES_REGEX,
+            value: regex,
+            secondaryValue: null
+        }
+    ];
 };
 
 export const selectSuggestConditions = (
@@ -139,15 +179,15 @@ export const selectSuggestConditions = (
         });
     }
 
-    const titleCondition = buildTextCondition(RuleConditionFieldEnum.TITLE, title);
+    const titleConditions = buildTextConditions(RuleConditionFieldEnum.TITLE, title);
 
-    if (isDefined(titleCondition)) {
-        conditions.push(titleCondition);
+    if (isDefined(titleConditions)) {
+        conditions.push(...titleConditions);
     } else if (isNotEmptyString(comment)) {
-        const commentCondition = buildTextCondition(RuleConditionFieldEnum.COMMENT, comment);
+        const commentConditions = buildTextConditions(RuleConditionFieldEnum.COMMENT, comment);
 
-        if (isDefined(commentCondition)) {
-            conditions.push(commentCondition);
+        if (isDefined(commentConditions)) {
+            conditions.push(...commentConditions);
         }
     }
 

--- a/packages/contracts/src/rule/repository/rule.repository.ts
+++ b/packages/contracts/src/rule/repository/rule.repository.ts
@@ -41,6 +41,16 @@ export class RuleRepository {
         });
     }
 
+    findAllWithConditions() {
+        return this.db.query.RuleEntityTable.findMany({
+            where: isNull(RuleEntityTable.deletedAt),
+            orderBy: [asc(RuleEntityTable.id)],
+            with: {
+                [RuleAssociationEnum.CONDITIONS]: true
+            }
+        });
+    }
+
     findAllWithActionsAndCategories() {
         return this.db.query.RuleEntityTable.findMany({
             where: isNull(RuleEntityTable.deletedAt),

--- a/tests/app-tests/fixtures/test17-suggested-rule.csv
+++ b/tests/app-tests/fixtures/test17-suggested-rule.csv
@@ -1,2 +1,2 @@
 externalId,toAccount,category,operatedAt,toAmount,toCurrency,comment,mcc
-001,Rules Test Account,Other,04/10/2026 10:00:00,-35.00,USD,Test17 Direct Create,5411
+001,Rules Test Account,Other,04/10/2026 10:00:00,-35.00,USD,Store C++ \ Kyiv,5411

--- a/tests/app-tests/flows/26.rules-application.flow.yaml
+++ b/tests/app-tests/flows/26.rules-application.flow.yaml
@@ -923,10 +923,10 @@ env:
 
 - extendedWaitUntil:
     visible:
-      id: 'TransactionCard.Label.Test17_Direct_Create'
+      id: 'TransactionCard.Label.Store_C_Kyiv'
     timeout: 10000
 - tapOn:
-    id: 'TransactionCard.Label.Test17_Direct_Create'
+    id: 'TransactionCard.Label.Store_C_Kyiv'
 - waitForAnimationToEnd
 
 - tapOn:
@@ -971,6 +971,8 @@ env:
     id: 'RuleForm.Condition.0.FieldSelector'
 - assertVisible:
     id: 'RuleForm.Condition.1.FieldSelector'
+- assertVisible:
+    id: 'RuleForm.Condition.2.FieldSelector'
 - tapOn:
     id: 'PageHeader.BackButton'
 - waitForAnimationToEnd


### PR DESCRIPTION
## Summary
- Split quick-rule title conditions with `:`, `+`, or `\` into stable literal `contains` tokens instead of one fragile symbol-heavy condition.
- Use a lightweight conditions-only rule query for duplicate detection before quick-rule creation.
- Enhance the existing quick-rule Maestro direct-create scenario with a symbol-heavy transaction title.

## Root Cause
Quick-rule creation derived its condition directly from the transaction title and then synchronously checked duplicate rules with a heavier relation query. Symbol-heavy titles could make the generated rule condition brittle and make the create interaction feel stalled before the rule appeared.

## Validation
- `yarn format`
- `yarn ts`
- `yarn lint` (passes with existing warning in `packages/app/src/ai/hook/use-suggestion-base.hook.ts`)
- `yarn deadcode`
- `yarn cpd`
- `git diff --check`