### PR TITLE
fix(app): yield between db batches

### DIFF
--- a/packages/app/src/@generic/utils/process-input-with-batches.util.ts
+++ b/packages/app/src/@generic/utils/process-input-with-batches.util.ts
@@ -1,11 +1,21 @@
+import { microPause } from './micro-pause.util';
+
 export const processInputWithBatches = async <T, O>(inputs: T[], batchSize: number, cb: (batch: T[]) => Promise<O[]>): Promise<O[]> => {
     const results: O[] = [];
 
     for (let index = 0; index < inputs.length; index += batchSize) {
         const batch = inputs.slice(index, index + batchSize);
+        const hasMoreBatches = index + batchSize < inputs.length;
 
         // eslint-disable-next-line no-await-in-loop
-        results.push(...(await cb(batch)));
+        await cb(batch).then(batchResults => {
+            results.push(...batchResults);
+            if (hasMoreBatches) {
+                return microPause();
+            }
+
+            return null;
+        });
     }
 
     return results;

--- a/packages/app/src/ai/service/base-drainer.service.ts
+++ b/packages/app/src/ai/service/base-drainer.service.ts
@@ -249,6 +249,7 @@ export abstract class BaseDrainerService<TRow> extends SnapshotStore<DrainerSnap
             emptyFn();
         }
         await this.refreshPending();
+        await microPause();
     }
 
     private scheduleDrainAfter(ms: number): void {

--- a/packages/app/src/sync/service/base-file-bank-sync.service.ts
+++ b/packages/app/src/sync/service/base-file-bank-sync.service.ts
@@ -11,6 +11,7 @@ import { Log } from '@budgie/logger';
 import { getErrorMessage, isDefined, isNotEmptyArray } from '@rnw-community/shared';
 
 import { accountRepository, bankSyncRepository, db } from '../../@generic/drizzle/db/db';
+import { microPause } from '../../@generic/utils/micro-pause.util';
 import { ruleApplicationDrainerService } from '../../rule/service/rule-application-drainer.service';
 import { transactionImportService } from '../../transaction/service/transaction-import.service';
 import { transactionService } from '../../transaction/service/transaction.service';
@@ -142,6 +143,7 @@ export abstract class BaseFileBankSyncService {
 
             for (const bankAccount of bankAccounts) {
                 await this.importAccountTransactions(client, bankAccount, context);
+                await microPause();
             }
 
             await transactionService.updateAllBalances(tx);

--- a/packages/app/src/sync/service/resync-bank-sync.service.ts
+++ b/packages/app/src/sync/service/resync-bank-sync.service.ts
@@ -4,15 +4,17 @@ import { Log } from '@budgie/logger';
 import { emptyFn, getErrorMessage, isDefined } from '@rnw-community/shared';
 
 import { bankSyncRepository, db, transactionRepository } from '../../@generic/drizzle/db/db';
+import { microPause } from '../../@generic/utils/micro-pause.util';
 import { unconsolidateByIdInTransaction } from '../../transaction/utils/unconsolidate-by-id-in-transaction.util';
 
 import { monobankSyncService } from './monobank-sync.service';
 
 import type { ResyncBankSyncInputInterface } from '../interface/resync-bank-sync-input.interface';
-import type { DB } from '@budgie/contracts';
+import type { DB, TransactionEntityInterface } from '@budgie/contracts';
 
 class ResyncBankSyncService {
     private static readonly MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+    private static readonly YIELD_EVERY_ROWS = 5;
 
     @Log(
         input => `enter accountId=${input.accountId} sinceDays=${String(input.sinceDays)}`,
@@ -33,21 +35,41 @@ class ResyncBankSyncService {
 
     private async resyncFull(accountId: number, tx: DB): Promise<void> {
         const canonicals = await transactionRepository.findActiveAutoConsolidatedByAccountIds([accountId], tx);
-        for (const canonical of canonicals) {
-            // eslint-disable-next-line no-await-in-loop -- Sequential unconsolidation must precede the resync reset
-            await unconsolidateByIdInTransaction(canonical.id, tx);
-        }
+        await this.unconsolidateCanonicals(canonicals, tx);
         await bankSyncRepository.resetForResync(accountId, tx);
     }
 
     private async resyncWindowed(accountId: number, sinceDays: number, tx: DB): Promise<void> {
         const since = new Date(Date.now() - sinceDays * ResyncBankSyncService.MILLISECONDS_PER_DAY);
         const canonicals = await transactionRepository.findActiveAutoConsolidatedByAccountIdsSince([accountId], since, tx);
-        for (const canonical of canonicals) {
-            // eslint-disable-next-line no-await-in-loop -- Sequential unconsolidation must precede the resync reset
-            await unconsolidateByIdInTransaction(canonical.id, tx);
-        }
+        await this.unconsolidateCanonicals(canonicals, tx);
         await bankSyncRepository.resetForWindowedResync(accountId, since, tx);
+    }
+
+    private async unconsolidateCanonicals(canonicals: Array<Pick<TransactionEntityInterface, 'id'>>, tx: DB, index = 0): Promise<void> {
+        if (index >= canonicals.length) {
+            return;
+        }
+
+        const batch = canonicals.slice(index, index + ResyncBankSyncService.YIELD_EVERY_ROWS);
+        await this.unconsolidateCanonicalBatch(batch, tx);
+
+        if (index + ResyncBankSyncService.YIELD_EVERY_ROWS < canonicals.length) {
+            await microPause();
+        }
+
+        await this.unconsolidateCanonicals(canonicals, tx, index + ResyncBankSyncService.YIELD_EVERY_ROWS);
+    }
+
+    private async unconsolidateCanonicalBatch(canonicals: Array<Pick<TransactionEntityInterface, 'id'>>, tx: DB): Promise<void> {
+        const [canonical, ...remainingCanonicals] = canonicals;
+
+        if (!isDefined(canonical)) {
+            return;
+        }
+
+        await unconsolidateByIdInTransaction(canonical.id, tx);
+        await this.unconsolidateCanonicalBatch(remainingCanonicals, tx);
     }
 }
 


### PR DESCRIPTION
## Summary

- Yield between shared bulk DB batches used by import flows.
- Yield after AI drainer batch finalization so embedding/translation drains give the JS event loop a turn between batches.
- Yield between file-bank account imports and chunk resync unconsolidation work in groups of five canonicals.

## Why

Long import, resync, and embedding-drain paths can run many DB operations back-to-back. The queries are async, but result handling, live-query invalidation, and follow-up JS work still need chances to breathe between chunks.

## Validation

- `yarn format && yarn ts && yarn lint && yarn deadcode && yarn cpd`

Notes: lint exits successfully with the existing `react-hooks/exhaustive-deps` warning in `packages/app/src/ai/hook/use-suggestion-base.hook.ts`. `yarn cpd` reported 0 clones.

Requested review: @liaugust