### PR TITLE
fix(app): keep generated rules SQL-pushable

### DIFF
--- a/packages/app/src/rule/service/rule-matcher.service.ts
+++ b/packages/app/src/rule/service/rule-matcher.service.ts
@@ -44,6 +44,8 @@ type FindMatchingTransactionsResultType = {
 };
 
 class RuleMatcherService {
+    private static readonly UNSUPPORTED_SQL_REGEX_TOKEN_PATTERN = /[\\^$.*+?()[\]{}|]/u;
+
     @Log(
         params => `enter conditions=${params.conditions.length} matchType=${params.conditionMatchType}`,
         result => `done count=${result}`,
@@ -239,10 +241,31 @@ class RuleMatcherService {
                 return sql`CAST(${column} AS TEXT) COLLATE NOCASE IN (${sql.join(placeholders, sql`, `)})`;
             }
             case RuleConditionOperatorEnum.MATCHES_REGEX:
-                return null;
+                return this.buildRegexSql(column, value);
             default:
                 return null;
         }
+    }
+
+    private buildRegexSql(column: Column | SQL, value: string): SQL | null {
+        const tokens = this.getFlexibleRegexTokens(value);
+
+        if (!isDefined(tokens)) {
+            return null;
+        }
+
+        const pattern = `%${tokens.map(token => this.escapeSqlLikeValue(token)).join('%')}%`;
+
+        return sql`CAST(${column} AS TEXT) LIKE ${pattern} ESCAPE '\\'`;
+    }
+
+    private getFlexibleRegexTokens(value: string): string[] | null {
+        const tokens = value.split('.*');
+        const hasOnlySqlSafeTokens = tokens.every(
+            token => isNotEmptyString(token) && !RuleMatcherService.UNSUPPORTED_SQL_REGEX_TOKEN_PATTERN.test(token)
+        );
+
+        return isNotEmptyArray(tokens) && hasOnlySqlSafeTokens ? tokens : null;
     }
 
     private escapeSqlLikeValue(value: string): string {

--- a/packages/app/src/rule/util/select-suggest-condition.util.ts
+++ b/packages/app/src/rule/util/select-suggest-condition.util.ts
@@ -16,15 +16,12 @@ const SUFFIX_PATTERN = /\.?\b(?:COM|NET|ORG|INC|LLC|LTD|GMBH|CO|CORP|PLC|SA|AG|S
 
 const EXTRA_WHITESPACE = /\s{2,}/gu;
 const LEADING_TRAILING_SEPARATORS = /^[\s*\-_.,/]+|[\s*\-_.,/]+$/gu;
-const REGEX_SPECIAL_CHARACTERS = /[\\^$.*+?()[\]{}|]/gu;
-const TOKEN_SEPARATOR = /\s+/u;
-const QUICK_RULE_SYMBOL_SEPARATOR_PATTERN = /[:+\\]+/u;
+const QUICK_RULE_SYMBOL_SEPARATOR_PATTERN = /[^\p{L}\p{N}\s]+/u;
 const TITLE_TOKEN_SEPARATOR_PATTERN = /[^\p{L}\p{N}]+/gu;
 
 const MINIMUM_CLEANED_LENGTH = 3;
-const MAX_CONDITION_REGEX_LENGTH = 200;
 const MINIMUM_TITLE_TOKEN_LENGTH = 2;
-const MAXIMUM_TITLE_TOKEN_CONDITIONS = 2;
+const MAXIMUM_TITLE_TOKEN_CONDITIONS = 3;
 
 // eslint-disable-next-line max-statements -- sequential regex cleanup steps absorbed from clean-merchant-title util per CLAUDE.md rule 38/51
 const cleanMerchantTitle = (title: string): string => {
@@ -74,25 +71,6 @@ const isGenericTitle = (title: string): boolean => {
 
 const isCleanedTextUsable = (cleaned: string): boolean =>
     isNotEmptyString(cleaned) && cleaned.length >= MINIMUM_TITLE_LENGTH && !isGenericTitle(cleaned);
-
-const escapeRegexToken = (token: string): string => token.replace(REGEX_SPECIAL_CHARACTERS, '\\$&');
-
-const buildFlexibleContainsRegex = (text: string): string => {
-    const tokens = text.split(TOKEN_SEPARATOR).filter(isNotEmptyString).map(escapeRegexToken);
-    let regex = '';
-
-    for (const token of tokens) {
-        const nextRegex = isNotEmptyString(regex) ? `${regex}.*${token}` : token;
-
-        if (nextRegex.length > MAX_CONDITION_REGEX_LENGTH) {
-            return regex;
-        }
-
-        regex = nextRegex;
-    }
-
-    return regex;
-};
 
 const buildSymbolSeparatedTextConditions = (
     field: RuleConditionFieldEnum.TITLE | RuleConditionFieldEnum.COMMENT,
@@ -147,20 +125,7 @@ const buildTextConditions = (
         ];
     }
 
-    const regex = buildFlexibleContainsRegex(cleanedText);
-
-    if (!isNotEmptyString(regex)) {
-        return null;
-    }
-
-    return [
-        {
-            field,
-            operator: RuleConditionOperatorEnum.MATCHES_REGEX,
-            value: regex,
-            secondaryValue: null
-        }
-    ];
+    return buildSymbolSeparatedTextConditions(field, cleanedText);
 };
 
 export const selectSuggestConditions = (


### PR DESCRIPTION
## Summary

- Stop generated quick-rule conditions from defaulting to `MATCHES_REGEX` when cleaned merchant tokens are non-contiguous.
- Split symbol/non-contiguous generated rule text into literal `CONTAINS` tokens so matching remains SQL-pushable.
- Add a narrow SQL fast path for existing generated `foo.*bar` rule regex values, while leaving complex/manual regex on the existing fallback path.

## Root Cause

PR #471 introduced flexible generated regex conditions for rules whose cleaned merchant title was not a contiguous substring of the raw transaction title. `MATCHES_REGEX` could not be represented in SQL, so counting/applying matching transactions fell back to JS batch scanning and regex evaluation over transaction rows. On larger local datasets that made rule creation/application feel stuck.

## Review Notes

- A normal SQLite b-tree index on `transactions.title` would not help `LIKE '%token%'` or `LIKE '%token%next%'` because the leading wildcard prevents index usage.
- This keeps the fix scoped to generated rules and avoids adding FTS/trigram schema complexity.
- Explicit complex regex rules still behave through the existing fallback evaluator.

## Validation

- `yarn format && yarn ts && yarn lint && yarn deadcode && yarn cpd`

Lint exits successfully with the existing `packages/app/src/ai/hook/use-suggestion-base.hook.ts` exhaustive-deps warning.