### PR TITLE
fix(app): stabilize list item sizing

### DIFF
--- a/packages/app/src/@generic/component/searchable-page-list/searchable-page-list.tsx
+++ b/packages/app/src/@generic/component/searchable-page-list/searchable-page-list.tsx
@@ -18,6 +18,7 @@ import { DeletableRow } from '../deletable-row/deletable-row';
 
 import { SEARCHABLE_LIST_CONTENT_PADDING_BOTTOM, SEARCHABLE_LIST_FOOTER_HEIGHT } from './searchable-page-list.constant';
 
+import type { LegendListSizingInterface } from '../../interface/legend-list-sizing.interface';
 import type { DeleteConfirmation } from '../deletable-row/deletable-row';
 
 interface Props<T extends IdInterface> {
@@ -26,6 +27,7 @@ interface Props<T extends IdInterface> {
     renderCard: (item: T) => ReactNode;
     getDeleteConfirmation?: (item: T) => DeleteConfirmation | undefined;
     children?: ReactNode;
+    sizing?: LegendListSizingInterface<T>;
 }
 
 const CONTENT_CONTAINER_STYLE = { gap: LEGEND_LIST_CONTENT_GAP, paddingBottom: SEARCHABLE_LIST_CONTENT_PADDING_BOTTOM };
@@ -36,7 +38,14 @@ const FOOTER_SPACER_STYLE = { height: SEARCHABLE_LIST_FOOTER_HEIGHT };
 const listHeader = <View style={HEADER_SPACER_STYLE} />;
 const listFooter = <View style={FOOTER_SPACER_STYLE} />;
 
-export const SearchablePageList = <T extends IdInterface>({ data, onDelete, renderCard, getDeleteConfirmation, children }: Props<T>) => {
+export const SearchablePageList = <T extends IdInterface>({
+    data,
+    onDelete,
+    renderCard,
+    getDeleteConfirmation,
+    children,
+    sizing
+}: Props<T>) => {
     const [notify] = useVibration();
 
     const handleDeleteItem = async (id: number) => {
@@ -77,7 +86,8 @@ export const SearchablePageList = <T extends IdInterface>({ data, onDelete, rend
                 ListHeaderComponent={listHeader}
                 renderItem={renderItem}
                 keyExtractor={legendListKeyExtractor}
-                estimatedItemSize={LEGEND_LIST_ESTIMATED_ITEM_SIZE}
+                estimatedItemSize={sizing?.estimatedItemSize ?? LEGEND_LIST_ESTIMATED_ITEM_SIZE}
+                getItemType={sizing?.getItemType}
                 recycleItems
                 showsVerticalScrollIndicator={false}
                 keyboardShouldPersistTaps="handled"

--- a/packages/app/src/@generic/component/searchable-page/searchable-page.tsx
+++ b/packages/app/src/@generic/component/searchable-page/searchable-page.tsx
@@ -14,6 +14,7 @@ import { SearchablePageList } from '../searchable-page-list/searchable-page-list
 
 import { SEARCH_BLUR_OFFSET, SEARCH_BLUR_Z_INDEX, SEARCH_INPUT_VERTICAL_OFFSET, SEARCH_KEYBOARD_GAP } from './searchable-page.constant';
 
+import type { LegendListSizingInterface } from '../../interface/legend-list-sizing.interface';
 import type { DeleteConfirmation } from '../deletable-row/deletable-row';
 
 interface Props<T extends IdInterface> {
@@ -30,6 +31,7 @@ interface Props<T extends IdInterface> {
     searchInputTestID?: string;
     testID?: string;
     children?: ReactNode;
+    sizing?: LegendListSizingInterface<T>;
 }
 
 export const SearchablePage = <T extends IdInterface>({
@@ -45,7 +47,8 @@ export const SearchablePage = <T extends IdInterface>({
     getDeleteConfirmation,
     searchInputTestID,
     testID,
-    children
+    children,
+    sizing
 }: Props<T>) => {
     const { bottom } = useSafeAreaInsets();
     const searchInputBottom = FLOATING_TAB_BAR_HEIGHT + FLOATING_TAB_BAR_MARGIN + bottom - SEARCH_INPUT_VERTICAL_OFFSET;
@@ -60,6 +63,7 @@ export const SearchablePage = <T extends IdInterface>({
                         data={data}
                         renderCard={renderCard}
                         getDeleteConfirmation={getDeleteConfirmation}
+                        sizing={sizing}
                     >
                         {children}
                     </SearchablePageList>

--- a/packages/app/src/@generic/interface/legend-list-sizing.interface.ts
+++ b/packages/app/src/@generic/interface/legend-list-sizing.interface.ts
@@ -1,0 +1,4 @@
+export interface LegendListSizingInterface<TItem, TItemType extends string = string> {
+    readonly estimatedItemSize: number;
+    readonly getItemType?: (item: TItem, index: number) => TItemType;
+}

--- a/packages/app/src/rule/components/rules-list-page/rules-list-page.tsx
+++ b/packages/app/src/rule/components/rules-list-page/rules-list-page.tsx
@@ -12,12 +12,8 @@ import { MenuSpacer } from '../../../@generic/component/menu-spacer/menu-spacer'
 import { Page } from '../../../@generic/component/page/page';
 import { PageHeader } from '../../../@generic/component/page-header/page-header';
 import { SearchablePageEmptyState } from '../../../@generic/component/searchagle-page-empty-state/searchagle-page-empty-state';
-import {
-    LEGEND_LIST_CONTENT_GAP,
-    LEGEND_LIST_ESTIMATED_ITEM_SIZE,
-    LEGEND_LIST_HEADER_HEIGHT,
-    LEGEND_LIST_STYLE
-} from '../../../@generic/constant/legend-list.constant';
+import { LEGEND_LIST_CONTENT_GAP, LEGEND_LIST_HEADER_HEIGHT, LEGEND_LIST_STYLE } from '../../../@generic/constant/legend-list.constant';
+import { RULES_LIST_SIZING } from '../../constant/rules-list-sizing.constant';
 import { useRulesListPageActions } from '../../hooks/use-rules-list-page-actions.hook';
 import { RulesPageSelector } from '../../selector/rules-page.selector';
 import { RuleCard } from '../rule-card/rule-card';
@@ -78,7 +74,8 @@ export const RulesListPage = ({ matchingRuleIds = [], onGoBack }: RulesListPageP
                     data={visibleRules}
                     renderItem={renderItem}
                     keyExtractor={getKeyExtractor}
-                    estimatedItemSize={LEGEND_LIST_ESTIMATED_ITEM_SIZE}
+                    estimatedItemSize={RULES_LIST_SIZING.estimatedItemSize}
+                    getItemType={RULES_LIST_SIZING.getItemType}
                     recycleItems
                     showsVerticalScrollIndicator={false}
                     ListFooterComponent={listFooter}

--- a/packages/app/src/rule/constant/rules-list-sizing.constant.ts
+++ b/packages/app/src/rule/constant/rules-list-sizing.constant.ts
@@ -1,0 +1,23 @@
+import type { LegendListSizingInterface } from '../../@generic/interface/legend-list-sizing.interface';
+import type { RuleWithActionsRelationsEntityInterface } from '@budgie/contracts';
+
+const RULES_LIST_ESTIMATED_ITEM_SIZE = 116;
+const RULES_LIST_SIMPLE_ITEM_LIMIT = 3;
+const RULES_LIST_MEDIUM_ITEM_LIMIT = 6;
+
+export const RULES_LIST_SIZING: LegendListSizingInterface<RuleWithActionsRelationsEntityInterface> = {
+    estimatedItemSize: RULES_LIST_ESTIMATED_ITEM_SIZE,
+    getItemType: rule => {
+        const itemCount = rule.conditions.length + rule.actions.length;
+
+        if (itemCount <= RULES_LIST_SIMPLE_ITEM_LIMIT) {
+            return 'simple';
+        }
+
+        if (itemCount <= RULES_LIST_MEDIUM_ITEM_LIMIT) {
+            return 'medium';
+        }
+
+        return 'complex';
+    }
+};

--- a/packages/app/src/transaction/components/transaction-sections-list/transaction-sections-list.tsx
+++ b/packages/app/src/transaction/components/transaction-sections-list/transaction-sections-list.tsx
@@ -12,7 +12,7 @@ import { PopoverMenuAnchor } from '../../../@generic/component/popover-menu/popo
 import { FLOATING_TAB_BAR_HEIGHT, FLOATING_TAB_BAR_MARGIN } from '../../../@generic/constant/floating-tab-bar.constant';
 import { useVibration } from '../../../@generic/hook/use-vibration.hook';
 import { useFormatDate } from '../../../i18n/hook/use-format-date.hook';
-import { TRANSACTION_LIST_ESTIMATED_ITEM_SIZE } from '../../constant/transaction-list.constant';
+import { TRANSACTION_LIST_SIZING } from '../../constant/transaction-list.constant';
 import { TransactionMenuStateInterface } from '../../interface/transaction-menu-state.interface';
 import { TransactionsByMonthSection } from '../../interface/transactions-by-month-section.type';
 import { TransactionListItemType } from '../../type/transaction-list-item.type';
@@ -31,7 +31,6 @@ interface Props {
 }
 
 const keyExtractor = (item: TransactionListItemType) => item.id;
-const getItemType = (item: TransactionListItemType | undefined) => item?.type ?? '';
 
 const getStickyIndices = (sections: (TransactionListItemType | undefined)[]) =>
     sections.reduce<number[]>((headers, item, idx) => (item?.type === 'header' ? [...headers, idx] : headers), []);
@@ -119,7 +118,7 @@ export const TransactionSectionsList = ({
                     data={flatData}
                     keyExtractor={keyExtractor}
                     renderItem={renderItem}
-                    estimatedItemSize={TRANSACTION_LIST_ESTIMATED_ITEM_SIZE}
+                    estimatedItemSize={TRANSACTION_LIST_SIZING.estimatedItemSize}
                     stickyIndices={getStickyIndices(flatData)}
                     recycleItems
                     onEndReached={onEndReached}
@@ -127,7 +126,7 @@ export const TransactionSectionsList = ({
                     showsVerticalScrollIndicator={false}
                     contentContainerStyle={contentContainerStyle}
                     ListEmptyComponent={listEmptyState}
-                    getItemType={getItemType}
+                    getItemType={TRANSACTION_LIST_SIZING.getItemType}
                 />
             </View>
             <TransactionListContextMenu

--- a/packages/app/src/transaction/constant/transaction-list.constant.ts
+++ b/packages/app/src/transaction/constant/transaction-list.constant.ts
@@ -1,1 +1,9 @@
-export const TRANSACTION_LIST_ESTIMATED_ITEM_SIZE = 150;
+import type { LegendListSizingInterface } from '../../@generic/interface/legend-list-sizing.interface';
+import type { TransactionListItemType } from '../type/transaction-list-item.type';
+
+const TRANSACTION_LIST_ESTIMATED_ITEM_SIZE = 150;
+
+export const TRANSACTION_LIST_SIZING: LegendListSizingInterface<TransactionListItemType> = {
+    estimatedItemSize: TRANSACTION_LIST_ESTIMATED_ITEM_SIZE,
+    getItemType: item => item.type
+};


### PR DESCRIPTION
## Summary
- add a reusable `LegendListSizingInterface` for estimated item size and item-type bucketing
- thread optional list sizing through `SearchablePage` and `SearchablePageList`
- move rules list sizing into a domain constant and align the transaction list with the same sizing-object pattern

## Why
LegendList handles heterogeneous rows best when the list receives a representative estimate plus stable item types. The rules screen has variable-height cards based on condition/action count, so this fixes the scroll range at the height-estimation layer instead of adding bottom spacing.

## Validation
- `yarn format && yarn ts && yarn lint && yarn deadcode && yarn cpd`

Note: lint still reports the existing warning in `packages/app/src/ai/hook/use-suggestion-base.hook.ts` about `react-hooks/exhaustive-deps`; it does not fail the validation command.