### PR TITLE
fix(contracts): consolidate legacy bridge transfers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -478,6 +478,17 @@ Free-form `context: string`. Convention: hook/file/component name. Instantiate o
 4. **Before PR:** Run all validation commands
 5. **Do not commit new Markdown notes from agent work unless explicitly requested.** If a local instruction, scratch note, report, or generated Markdown file is needed only for the working session, keep it untracked and add the local pattern to `.gitignore` instead of committing it.
 
+## Simulator Dev Testing
+
+1. For dev-client feature checks and debugging, use the local `serve-sim` skill and the Codex in-app browser.
+2. Read `.agents/skills/serve-sim/SKILL.md` before using serve-sim. Follow its referenced workflow files when interacting with the simulator.
+3. Start or discover serve-sim with JSON output: `npx --yes serve-sim --detach -q` or `npx --yes serve-sim --list -q`.
+4. Do not hardcode serve-sim ports. Use the returned `url`, `streamUrl`, and `wsUrl`; ports can differ when multiple simulators or sessions are running.
+5. When several simulators are booted, target the requested device with `-d <udid|name>`.
+6. Run serve-sim with project Node `>=22`; taps can fail on older shell Node versions.
+7. Use `serve-sim tap` for taps. Use normalized coordinates only.
+8. Do not use Maestro for dev-client checks. Maestro is only acceptance evidence against a clean E2E build.
+
 ## E2E Testing
 
 1. Prefer black-box E2E flows over app-owned test hooks.

--- a/packages/contracts/src/transaction/interface/iban-bridge-transfer-candidate.interface.ts
+++ b/packages/contracts/src/transaction/interface/iban-bridge-transfer-candidate.interface.ts
@@ -5,11 +5,11 @@ export interface IbanBridgeTransferCandidateInterface {
     readonly expenseTransactionComment: string | null;
     readonly operatedAt: number;
     readonly expenseEntryId: number;
-    readonly expenseEntryToIban: string;
+    readonly expenseEntryToIban: string | null;
     readonly incomeTransactionId: number;
     readonly incomeTransactionTitle: string | null;
     readonly incomeEntryId: number;
-    readonly incomeEntryToIban: string;
+    readonly incomeEntryToIban: string | null;
     readonly bridgeAccountId: number;
     readonly bridgeAccountTitle: string;
     readonly bridgeAmount: number;

--- a/packages/contracts/src/transaction/repository/sql-factory/transfer-pair-iban-bridge-transfer-sql.factory.ts
+++ b/packages/contracts/src/transaction/repository/sql-factory/transfer-pair-iban-bridge-transfer-sql.factory.ts
@@ -1,5 +1,6 @@
 import { TRANSFER_MCC_GROUP_ID } from '../../constant/transfer-mcc-group-id.constant';
 import { TRANSFER_PAIR_FAST_TIME_WINDOW_SECONDS } from '../../constant/transfer-pair-fast-time-window.constant';
+import { TRANSFER_PAIR_IMPLIED_RATE_TOLERANCE } from '../../constant/transfer-pair-implied-rate-tolerance.constant';
 import { TransactionTypeEnum } from '../../enum/transaction-type.enum';
 
 export const IBAN_BRIDGE_TRANSFER_CANDIDATES_SQL = `
@@ -121,4 +122,205 @@ export const IBAN_BRIDGE_TRANSFER_CANDIDATES_SQL = `
                 ) as existingDirectTransferId,
                 timeDiff
             FROM bridge_candidates
+`;
+
+export const LEGACY_DIRECT_BRIDGE_TRANSFER_CANDIDATES_SQL = `
+            WITH latest_exchange_rates AS (
+                SELECT
+                    base_instrument_id,
+                    quote_instrument_id,
+                    rate * 1.0 as rate,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY base_instrument_id, quote_instrument_id
+                        ORDER BY created_at DESC
+                    ) as exchangeRateRank
+                FROM exchange_rates
+                WHERE deleted_at IS NULL
+                    AND rate > 0
+            ),
+            available_exchange_rates AS (
+                SELECT base_instrument_id, quote_instrument_id, rate
+                FROM (
+                    SELECT
+                        base_instrument_id,
+                        quote_instrument_id,
+                        rate,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY base_instrument_id, quote_instrument_id
+                            ORDER BY direction
+                        ) as directionRank
+                    FROM (
+                        SELECT
+                            base_instrument_id,
+                            quote_instrument_id,
+                            rate,
+                            0 as direction
+                        FROM latest_exchange_rates
+                        WHERE exchangeRateRank = 1
+                        UNION ALL
+                        SELECT
+                            quote_instrument_id as base_instrument_id,
+                            base_instrument_id as quote_instrument_id,
+                            1.0 / rate as rate,
+                            1 as direction
+                        FROM latest_exchange_rates
+                        WHERE exchangeRateRank = 1
+                    )
+                )
+                WHERE directionRank = 1
+            ),
+            direct_bridge_transfers AS MATERIALIZED (
+                SELECT
+                    direct_tx.id as existingDirectTransferId,
+                    direct_tx.operated_at as directOperatedAt,
+                    direct_tx.from_account_id as bridgeAccountId,
+                    direct_tx.to_account_id as targetAccountId,
+                    direct_source_entry.amount as bridgeAmount
+                FROM transactions direct_tx
+                INNER JOIN transaction_entries direct_source_entry ON
+                    direct_source_entry.transaction_id = direct_tx.id
+                    AND direct_source_entry.deleted_at IS NULL
+                    AND direct_source_entry.original_transaction_id IS NULL
+                    AND direct_source_entry.account_id = direct_tx.from_account_id
+                WHERE direct_tx.type = '${TransactionTypeEnum.TRANSFER}'
+                    AND direct_tx.deleted_at IS NULL
+                    AND direct_tx.consolidation_parent_transaction_id IS NULL
+            ),
+            bridge_candidates AS (
+                SELECT
+                    expense_tx.id as expenseTransactionId,
+                    expense_tx.title as expenseTransactionTitle,
+                    expense_tx.comment as expenseTransactionComment,
+                    expense_tx.operated_at as operatedAt,
+                    expense_entry.id as expenseEntryId,
+                    expense_entry.to_iban as expenseEntryToIban,
+                    income_tx.id as incomeTransactionId,
+                    income_tx.title as incomeTransactionTitle,
+                    income_entry.id as incomeEntryId,
+                    income_entry.to_iban as incomeEntryToIban,
+                    bridge_account.id as bridgeAccountId,
+                    bridge_account.title as bridgeAccountTitle,
+                    income_entry.amount as bridgeAmount,
+                    source_account.id as sourceAccountId,
+                    source_account.title as sourceAccountTitle,
+                    direct_transfer.targetAccountId,
+                    target_account.title as targetAccountTitle,
+                    expense_entry.amount as sourceAmount,
+                    direct_transfer.existingDirectTransferId,
+                    MAX(
+                        ABS(income_tx.operated_at - expense_tx.operated_at),
+                        ABS(direct_transfer.directOperatedAt - income_tx.operated_at)
+                    ) as timeDiff,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY expense_tx.id
+                        ORDER BY
+                            ABS((income_entry.amount * 1.0 / expense_entry.amount) - exchange_rate.rate) / exchange_rate.rate,
+                            MAX(
+                                ABS(income_tx.operated_at - expense_tx.operated_at),
+                                ABS(direct_transfer.directOperatedAt - income_tx.operated_at)
+                            ),
+                            income_tx.id,
+                            direct_transfer.existingDirectTransferId
+                    ) as expenseRank,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY income_tx.id
+                        ORDER BY
+                            ABS((income_entry.amount * 1.0 / expense_entry.amount) - exchange_rate.rate) / exchange_rate.rate,
+                            MAX(
+                                ABS(income_tx.operated_at - expense_tx.operated_at),
+                                ABS(direct_transfer.directOperatedAt - income_tx.operated_at)
+                            ),
+                            expense_tx.id,
+                            direct_transfer.existingDirectTransferId
+                    ) as incomeRank,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY direct_transfer.existingDirectTransferId
+                        ORDER BY
+                            ABS((income_entry.amount * 1.0 / expense_entry.amount) - exchange_rate.rate) / exchange_rate.rate,
+                            MAX(
+                                ABS(income_tx.operated_at - expense_tx.operated_at),
+                                ABS(direct_transfer.directOperatedAt - income_tx.operated_at)
+                            ),
+                            expense_tx.id,
+                            income_tx.id
+                    ) as directTransferRank
+                FROM transactions income_tx
+                INNER JOIN transaction_entries income_entry ON
+                    income_entry.transaction_id = income_tx.id
+                    AND income_entry.deleted_at IS NULL
+                    AND income_entry.original_transaction_id IS NULL
+                    AND income_entry.amount > 0
+                    AND (income_entry.to_iban IS NULL OR income_entry.to_iban = '')
+                INNER JOIN accounts bridge_account ON
+                    bridge_account.id = income_entry.account_id
+                    AND bridge_account.deleted_at IS NULL
+                    AND bridge_account.iban IS NOT NULL
+                    AND bridge_account.iban != ''
+                INNER JOIN direct_bridge_transfers direct_transfer ON
+                    direct_transfer.bridgeAccountId = bridge_account.id
+                    AND direct_transfer.bridgeAmount = income_entry.amount
+                    AND direct_transfer.directOperatedAt BETWEEN
+                        income_tx.operated_at - ${TRANSFER_PAIR_FAST_TIME_WINDOW_SECONDS}
+                        AND income_tx.operated_at + ${TRANSFER_PAIR_FAST_TIME_WINDOW_SECONDS}
+                INNER JOIN accounts target_account ON
+                    target_account.id = direct_transfer.targetAccountId
+                    AND target_account.deleted_at IS NULL
+                    AND target_account.id != bridge_account.id
+                INNER JOIN transactions expense_tx ON
+                    expense_tx.type = '${TransactionTypeEnum.EXPENSE}'
+                    AND expense_tx.deleted_at IS NULL
+                    AND expense_tx.consolidation_parent_transaction_id IS NULL
+                    AND expense_tx.operated_at BETWEEN
+                        income_tx.operated_at - ${TRANSFER_PAIR_FAST_TIME_WINDOW_SECONDS}
+                        AND income_tx.operated_at + ${TRANSFER_PAIR_FAST_TIME_WINDOW_SECONDS}
+                INNER JOIN transaction_entries expense_entry ON
+                    expense_entry.transaction_id = expense_tx.id
+                    AND expense_entry.deleted_at IS NULL
+                    AND expense_entry.original_transaction_id IS NULL
+                    AND expense_entry.amount > 0
+                    AND (expense_entry.to_iban IS NULL OR expense_entry.to_iban = '')
+                INNER JOIN accounts source_account ON
+                    source_account.id = expense_entry.account_id
+                    AND source_account.deleted_at IS NULL
+                    AND source_account.iban IS NOT NULL
+                    AND source_account.iban != ''
+                    AND source_account.id != bridge_account.id
+                    AND source_account.id != target_account.id
+                    AND source_account.instrument_id != bridge_account.instrument_id
+                    AND SUBSTR(source_account.iban, 5, 6) = SUBSTR(bridge_account.iban, 5, 6)
+                INNER JOIN available_exchange_rates exchange_rate ON
+                    exchange_rate.base_instrument_id = source_account.instrument_id
+                    AND exchange_rate.quote_instrument_id = bridge_account.instrument_id
+                WHERE income_tx.type = '${TransactionTypeEnum.INCOME}'
+                    AND income_tx.deleted_at IS NULL
+                    AND income_tx.consolidation_parent_transaction_id IS NULL
+                    AND ABS((income_entry.amount * 1.0 / expense_entry.amount) - exchange_rate.rate) / exchange_rate.rate <= ${TRANSFER_PAIR_IMPLIED_RATE_TOLERANCE}
+            )
+            SELECT
+                'AUTO_IBAN_BRIDGE_TRANSFER' as confidenceBucket,
+                expenseTransactionId,
+                expenseTransactionTitle,
+                expenseTransactionComment,
+                operatedAt,
+                expenseEntryId,
+                expenseEntryToIban,
+                incomeTransactionId,
+                incomeTransactionTitle,
+                incomeEntryId,
+                incomeEntryToIban,
+                bridgeAccountId,
+                bridgeAccountTitle,
+                bridgeAmount,
+                sourceAccountId,
+                sourceAccountTitle,
+                sourceAmount,
+                targetAccountId,
+                targetAccountTitle,
+                sourceAmount * 1.0 / bridgeAmount as exchangeRate,
+                existingDirectTransferId,
+                timeDiff
+            FROM bridge_candidates
+            WHERE expenseRank = 1
+                AND incomeRank = 1
+                AND directTransferRank = 1
 `;

--- a/packages/contracts/src/transaction/repository/transfer-pair.repository.ts
+++ b/packages/contracts/src/transaction/repository/transfer-pair.repository.ts
@@ -12,7 +12,10 @@ import {
 } from './sql-factory/transfer-pair-cash-withdrawal-sql.factory';
 import { IBAN_BRIDGE_CANONICAL_DUPLICATE_CANDIDATES_SQL } from './sql-factory/transfer-pair-iban-bridge-canonical-duplicate-sql.factory';
 import { IBAN_BRIDGE_CHAIN_TRANSFER_CANDIDATES_SQL } from './sql-factory/transfer-pair-iban-bridge-chain-sql.factory';
-import { IBAN_BRIDGE_TRANSFER_CANDIDATES_SQL } from './sql-factory/transfer-pair-iban-bridge-transfer-sql.factory';
+import {
+    IBAN_BRIDGE_TRANSFER_CANDIDATES_SQL,
+    LEGACY_DIRECT_BRIDGE_TRANSFER_CANDIDATES_SQL
+} from './sql-factory/transfer-pair-iban-bridge-transfer-sql.factory';
 
 import type { DB } from '../../@generic/type/db.type';
 import type { AtmCashWithdrawalCandidateInterface } from '../interface/atm-cash-withdrawal-candidate.interface';
@@ -81,7 +84,11 @@ export class TransferPairRepository {
         error => `throw error=${getErrorMessage(error)}`
     )
     async findIbanBridgeTransferCandidates(): Promise<IbanBridgeTransferCandidateInterface[]> {
-        const sql = IBAN_BRIDGE_TRANSFER_CANDIDATES_SQL;
+        const sql = `
+            SELECT * FROM (${IBAN_BRIDGE_TRANSFER_CANDIDATES_SQL})
+            UNION ALL
+            SELECT * FROM (${LEGACY_DIRECT_BRIDGE_TRANSFER_CANDIDATES_SQL})
+        `;
 
         return this.db.$client.getAllAsync<IbanBridgeTransferCandidateInterface>(sql);
     }

--- a/tests/bank-sync-tests/src/scenarios/consolidation/iban-bridge-chain-transfer.test.ts
+++ b/tests/bank-sync-tests/src/scenarios/consolidation/iban-bridge-chain-transfer.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { eq } from 'drizzle-orm';
 
 import {
+    ExchangeRateCreateEntityInterface,
+    ExchangeRateEntityTable,
     TransactionConsolidationTypeEnum,
     TransactionCreateEntityInterface,
     TransactionEntityTable,
@@ -22,9 +24,9 @@ import {
     testDb
 } from '../../harness';
 
-const SOURCE_IBAN = 'UA-SOURCE-EUR';
-const BRIDGE_IBAN = 'UA-BRIDGE-UAH';
-const TARGET_IBAN = 'UA-TARGET-UAH';
+const SOURCE_IBAN = 'UA003220010000SOURCEEUR';
+const BRIDGE_IBAN = 'UA003220010000BRIDGEUAH';
+const TARGET_IBAN = 'UA003220010000TARGETUAH';
 const EUR_AMOUNT = 1_658_290_000;
 const UAH_AMOUNT = 84_456_700_000;
 const EUR_TO_UAH_RATE = UAH_AMOUNT / EUR_AMOUNT;
@@ -133,6 +135,72 @@ const seedDirectTransfer = (
     return directTransfer;
 };
 
+const seedLegacyDirectBridgeTransfer = (operatedAt: Date, bridgeAccountId: number, targetAccountId: number) => {
+    const directTransfer = testDb
+        .insert(TransactionEntityTable)
+        .values({
+            type: TransactionTypeEnum.TRANSFER,
+            title: 'На чорну картку',
+            externalId: null,
+            externalSource: null,
+            operatedAt,
+            exchangeRate: 1,
+            fromAccountId: bridgeAccountId,
+            toAccountId: targetAccountId,
+            comment: '',
+            needsEmbedding: false,
+            consolidationParentTransactionId: null,
+            consolidationType: null,
+            updatedBy: null
+        } satisfies TransactionCreateEntityInterface)
+        .returning()
+        .get();
+
+    testDb
+        .insert(TransactionEntryEntityTable)
+        .values([
+            {
+                transactionId: directTransfer.id,
+                accountId: bridgeAccountId,
+                categoryId: null,
+                mccCategoryId: null,
+                type: TransactionEntryTypeEnum.CREDIT,
+                amount: UAH_AMOUNT,
+                externalId: null,
+                exchangeRate: 1,
+                toIban: TARGET_IBAN,
+                originalTransactionId: null
+            },
+            {
+                transactionId: directTransfer.id,
+                accountId: targetAccountId,
+                categoryId: null,
+                mccCategoryId: null,
+                type: TransactionEntryTypeEnum.DEBIT,
+                amount: UAH_AMOUNT,
+                externalId: null,
+                exchangeRate: 1,
+                toIban: null,
+                originalTransactionId: null
+            }
+        ] satisfies TransactionEntryCreateEntityInterface[])
+        .run();
+
+    return directTransfer;
+};
+
+const seedLegacyExchangeRate = (sourceInstrumentId: number, bridgeInstrumentId: number): void => {
+    testDb
+        .insert(ExchangeRateEntityTable)
+        .values({
+            source: 'test',
+            baseInstrumentId: sourceInstrumentId,
+            quoteInstrumentId: bridgeInstrumentId,
+            rate: EUR_TO_UAH_RATE
+        } satisfies ExchangeRateCreateEntityInterface)
+        .run();
+};
+
 const fetchMovedSourceIds = (canonicalId: number): number[] => {
     const movedEntries = testDb
         .select()
@@ -215,6 +283,44 @@ describe('consolidation/iban-bridge-chain-transfer', () => {
             targetAccount.id
         );
         const sourceIds = [directTransfer.id, bridgeIncome.id, bridgeExpense.id];
+
+        expectSourcesParented(canonicalId, sourceIds);
+        expectMovedSources(canonicalId, [directTransfer.id, ...sourceIds]);
+    });
+
+    it('collapses a legacy bridge pair around an existing bridge-to-target transfer without entry IBANs', async () => {
+        const operatedAt = new Date(2026, 0, 5, 14, 47, 0);
+        const { transferMcc, sourceAccount, bridgeAccount, targetAccount } = seedBridgeAccounts();
+        const directTransfer = seedLegacyDirectBridgeTransfer(operatedAt, bridgeAccount.id, targetAccount.id);
+        const sourceExpense = seedBankPair.expense(
+            { externalId: 'legacy-source-expense', operatedAt },
+            {
+                accountId: sourceAccount.id,
+                amount: EUR_AMOUNT,
+                exchangeRate: UAH_TO_EUR_RATE,
+                mccCategoryId: transferMcc.id
+            }
+        );
+        const bridgeIncome = seedBankPair.income(
+            { externalId: 'legacy-bridge-income', operatedAt },
+            {
+                accountId: bridgeAccount.id,
+                amount: UAH_AMOUNT,
+                exchangeRate: EUR_TO_UAH_RATE,
+                mccCategoryId: transferMcc.id
+            }
+        );
+
+        seedLegacyExchangeRate(sourceAccount.instrumentId, bridgeAccount.instrumentId);
+
+        await expectSingleConsolidation();
+
+        const canonicalId = expectCanonicalTransfer(
+            TransactionConsolidationTypeEnum.IBAN_BRIDGE_TRANSFER,
+            sourceAccount.id,
+            targetAccount.id
+        );
+        const sourceIds = [directTransfer.id, sourceExpense.id, bridgeIncome.id];
 
         expectSourcesParented(canonicalId, sourceIds);
         expectMovedSources(canonicalId, [directTransfer.id, ...sourceIds]);


### PR DESCRIPTION
## What changed

- Adds a legacy IBAN bridge transfer candidate path for old imported pairs where source/bridge entries do not have `to_iban` values.
- Unions that path with the existing IBAN bridge transfer candidate query.
- Allows nullable bridge candidate IBAN fields in the shared candidate interface.
- Adds a regression fixture for the real legacy bridge-to-target transfer shape.
- Documents serve-sim dev testing rules in `AGENTS.md`.

## Why

Past Monobank FOP EUR -> FOP UAH -> card chains were not picked up by the newer IBAN-based bridge consolidation because historical entries lacked the entry IBAN metadata. The new candidate path matches those rows through the already-created bridge-to-target direct transfer, same-bank account IBAN prefix, exchange-rate tolerance, and the existing fast time window.

## Validation

- `yarn workspace @budgie-at/bank-sync-tests test src/scenarios/consolidation` -> 18 files, 41 tests passed
- `yarn ts` -> 7 packages successful
- `git diff --check` -> clean
- Dev build via serve-sim on iPhone 17 Pro: consolidation returned `0` high-confidence pairs and `50` review-only pairs after the real-data consolidation pass; no spinner hang
- Live simulator DB: `IBAN_BRIDGE_TRANSFER` total `79`, new bridge consolidations `id >= 79000` count `78`, January screenshot rows parented `9/9`