### PR TITLE
fix(app): cap exchange rate display at 6 decimals via shared util

### DIFF
--- a/packages/app/src/@generic/component/currency-selector/currency-selector.tsx
+++ b/packages/app/src/@generic/component/currency-selector/currency-selector.tsx
@@ -32,7 +32,7 @@ export const CurrencySelector = ({ instrumentId, onChange, testID }: Props) => {
     const { code: selectedCurrencyCode, name, symbol } = selectedCurrency;
     const { code: defaultInstrumentCode } = defaultInstrument;
 
-    const convertedAmount = isDefined(rate) ? rate.rate : 1;
+    const convertedAmount = isDefined(rate) ? Number(rate.rate.toFixed(6)) : 1;
     const isBaseCurrency = !isDefined(rate);
 
     const handleOpen = async () => {

--- a/packages/app/src/@generic/component/currency-selector/currency-selector.tsx
+++ b/packages/app/src/@generic/component/currency-selector/currency-selector.tsx
@@ -8,6 +8,7 @@ import { useGetRatesByBaseAndQuoteIdsQuery } from '../../../exchange-rate/query/
 import { useGetInstrumentsByTypeQuery } from '../../../instrument/query/use-get-instruments-by-type.query';
 import { useSettingsContext } from '../../../settings/context/settings.context';
 import { useCurrencySelectorModal } from '../../context/currency-selector-modal.context';
+import { formatExchangeRate } from '../../utils/format-exchange-rate.util';
 import { HorizontalCell } from '../horizontal-cell/horizontal-cell';
 import { Icon } from '../icon/icon';
 
@@ -32,7 +33,7 @@ export const CurrencySelector = ({ instrumentId, onChange, testID }: Props) => {
     const { code: selectedCurrencyCode, name, symbol } = selectedCurrency;
     const { code: defaultInstrumentCode } = defaultInstrument;
 
-    const convertedAmount = isDefined(rate) ? Number(rate.rate.toFixed(6)) : 1;
+    const convertedAmount = isDefined(rate) ? formatExchangeRate(rate.rate) : '1';
     const isBaseCurrency = !isDefined(rate);
 
     const handleOpen = async () => {

--- a/packages/app/src/@generic/utils/format-exchange-rate.util.ts
+++ b/packages/app/src/@generic/utils/format-exchange-rate.util.ts
@@ -1,0 +1,3 @@
+const MAX_RATE_DECIMALS = 6;
+
+export const formatExchangeRate = (rate: number): string => Number(rate.toFixed(MAX_RATE_DECIMALS)).toString();

--- a/packages/app/src/transaction/components/conversion-row/conversion-row.tsx
+++ b/packages/app/src/transaction/components/conversion-row/conversion-row.tsx
@@ -5,6 +5,7 @@ import Animated, { FadeInUp } from 'react-native-reanimated';
 import { isPositiveNumber } from '@rnw-community/shared';
 
 import { HapticPressable } from '../../../@generic/component/haptic-pressable/haptic-pressable';
+import { formatExchangeRate } from '../../../@generic/utils/format-exchange-rate.util';
 import { TransferQuickFormSelector } from '../transfer-quick-form/transfer-quick-form.selector';
 
 interface Props {
@@ -20,7 +21,6 @@ interface Props {
 const ANIMATION_DELAY = 100;
 const ANIMATION_DURATION = 200;
 const ENTERING_ANIMATION = FadeInUp.delay(ANIMATION_DELAY).duration(ANIMATION_DURATION);
-const RATE_DECIMALS = 4;
 
 export const ConversionRow = (props: Props) => {
     const { destinationAmount, destinationSymbol, sourceCode, destinationCode, exchangeRate, isManualRate, onPress } = props;
@@ -28,7 +28,7 @@ export const ConversionRow = (props: Props) => {
 
     const prefix = isManualRate ? '=' : '\u2248';
     const formattedAmount = isPositiveNumber(destinationAmount) ? destinationAmount.toFixed(2) : '0.00';
-    const formattedRate = isPositiveNumber(exchangeRate) ? exchangeRate.toFixed(RATE_DECIMALS) : '—';
+    const formattedRate = isPositiveNumber(exchangeRate) ? formatExchangeRate(exchangeRate) : '—';
     const rateLabel = t`1 ${sourceCode} = ${formattedRate} ${destinationCode}`;
     const accessibilityLabel = t`Exchange rate: ${rateLabel}. Tap to edit receiving amount`;
 


### PR DESCRIPTION
## Summary

Exchange rates rendered in the UI could show an excessive number of decimal digits. This caps every rate-display site at **6 decimal places** (trailing zeros trimmed, so `1.5` stays `1.5`, not `1.500000`) through a single shared util.

## Changes

- **New util** `packages/app/src/@generic/utils/format-exchange-rate.util.ts`:
  ```ts
  const MAX_RATE_DECIMALS = 6;
  export const formatExchangeRate = (rate: number): string => Number(rate.toFixed(MAX_RATE_DECIMALS)).toString();
  ```
- **`CurrencySelector`** (account/transaction creation currency card) — previously rendered the raw `rate.rate` with no decimal limiting; now uses `formatExchangeRate`.
- **`ConversionRow`** (cross-currency transfer row) — previously used a local `RATE_DECIMALS = 4` constant; now uses the shared util, unifying the cap at 6 across the app.

The transfer "secondary amount" (`toFixed(2)`, money) and category/tag stats percentages (`toFixed(2)`) are not exchange rates and are intentionally left unchanged.

## Testing

- `yarn ts` passes
- `yarn lint` passes (only a pre-existing, unrelated `react-hooks/exhaustive-deps` warning in `use-suggestion-base.hook.ts`)

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)