### PR TITLE
fix(app): dedupe tags when consolidating refunds and transfers

### DIFF
--- a/packages/app/src/sync/service/transfer-consolidation-executor.service.ts
+++ b/packages/app/src/sync/service/transfer-consolidation-executor.service.ts
@@ -432,7 +432,9 @@ class TransferConsolidationExecutorService {
 
     private async copySourceTags(sourceTransactionIds: number[], canonicalTransactionId: number, tx: DB): Promise<void> {
         const sourceTags = await this.findSourceTags(sourceTransactionIds, tx);
-        const uniqueTagIds = [...new Set(sourceTags.map(tag => tag.tagId))];
+        const existingTags = await transactionTagsRepository.findByTransactionId(canonicalTransactionId, tx);
+        const existingTagIds = new Set(existingTags.map(tag => tag.tagId));
+        const uniqueTagIds = [...new Set(sourceTags.map(tag => tag.tagId))].filter(tagId => !existingTagIds.has(tagId));
 
         if (isEmptyArray(uniqueTagIds)) {
             return;

--- a/tests/bank-sync-tests/src/scenarios/consolidation/refund-pair-shared-tag.test.ts
+++ b/tests/bank-sync-tests/src/scenarios/consolidation/refund-pair-shared-tag.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { and, eq } from 'drizzle-orm';
+
+import { PRECISION, TagEntityTable, TransactionConsolidationTypeEnum, TransactionTagsEntityTable } from '@budgie/contracts';
+
+import { fetchTransactionById, seed, seedRefundedExpense, testDb } from '../../harness';
+
+import { transferConsolidationService } from '@app/sync/service/transfer-consolidation.service';
+
+describe('consolidation/refund-pair-shared-tag', () => {
+    it('reparents a refund whose income shares a tag with the expense without breaking the unique tag constraint', async () => {
+        const account = seed.account({ externalId: 'mono-card' });
+        const { expense, refunds } = seedRefundedExpense({
+            accountId: account.id,
+            expenseAmount: 120 * PRECISION,
+            refundAmounts: [120 * PRECISION]
+        });
+
+        const [tag] = testDb
+            .insert(TagEntityTable)
+            .values({ title: 'Travel', titleSearch: 'travel', titleEn: null, titleTags: null, tagsGeneratedAt: null })
+            .returning()
+            .all();
+
+        testDb
+            .insert(TransactionTagsEntityTable)
+            .values([
+                { transactionId: expense.id, tagId: tag.id, isPrimary: false },
+                { transactionId: refunds[0].id, tagId: tag.id, isPrimary: false }
+            ])
+            .run();
+
+        const result = await transferConsolidationService.consolidate();
+
+        expect(result.consolidated).toBe(1);
+        expect(fetchTransactionById(expense.id).consolidationType).toBe(TransactionConsolidationTypeEnum.REFUND);
+
+        const expenseTagRows = testDb
+            .select()
+            .from(TransactionTagsEntityTable)
+            .where(and(eq(TransactionTagsEntityTable.transactionId, expense.id), eq(TransactionTagsEntityTable.tagId, tag.id)))
+            .all();
+
+        expect(expenseTagRows).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
## Problem

Discovered while testing on real production data: every refund consolidation crashed with

```
[TransferConsolidationExecutorService::consolidateRefund] throw
UNIQUE constraint failed: transaction_tags.transaction_id, transaction_tags.tag_id
```

`copySourceTags()` copied every source-transaction tag onto the canonical transaction with a plain bulk insert, deduping only *among the sources* — it never checked which tags the canonical (the expense being promoted, or the surviving transfer leg) already carried. When a refund's income shared a tag with its expense (common in real data), the insert violated the primary key on `transaction_tags(transaction_id, tag_id)`, rolled back the entire `transactionAsync`, and the pair was left unconsolidated. All four `consolidate*` paths route through `copySourceTags`, so transfers were exposed to the same failure.

This bug is pre-existing on `main` (not introduced by any open feature branch) — it only surfaces when source and canonical transactions share a tag.

## Fix

Make `copySourceTags` idempotent: load the canonical transaction's existing tags and exclude them before inserting.

```ts
const existingTags = await transactionTagsRepository.findByTransactionId(canonicalTransactionId, tx);
const existingTagIds = new Set(existingTags.map(tag => tag.tagId));
const uniqueTagIds = [...new Set(sourceTags.map(tag => tag.tagId))].filter(tagId => !existingTagIds.has(tagId));
```

(Deliberately not switching the shared `bulkCreate` to `onConflictDoNothing` — that would silently mask genuine duplicate-insert bugs elsewhere.)

## Test

Adds `tests/bank-sync-tests/.../refund-pair-shared-tag.test.ts` reproducing the exact case: a refund income sharing a tag with the expense it merges into. Verified it **fails on `main`** (UNIQUE constraint → `consolidated: 0`) and **passes** with the fix, asserting the canonical ends with exactly one row for the shared tag.

## Validation

- `yarn ts` ✅
- `yarn lint` ✅ (only a pre-existing unrelated warning)
- `yarn deadcode` ✅
- `yarn cpd` ✅ (0 clones)
- Consolidation integration suite: 61/61 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where duplicate tags could be created when consolidating refunded transactions that share tags.

* **Tests**
  * Added test coverage for tag consolidation behavior with shared tags on refunded transactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/budgie-at/budgie/pull/507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->