### PR TITLE
fix(contracts): stop analytics from dropping unvalued entries

### DIFF
--- a/packages/contracts/src/statistics/repository/statistics.repository.ts
+++ b/packages/contracts/src/statistics/repository/statistics.repository.ts
@@ -1,10 +1,17 @@
-import { and, desc, eq, getTableColumns, inArray, ne, sql } from 'drizzle-orm';
+/* eslint-disable max-lines -- File owns the single multi-stage statistics SQL aggregation pipeline that must stay together */
+import { SQL, and, desc, eq, getTableColumns, inArray, ne, sql } from 'drizzle-orm';
 
 import { isDefined, isNotEmptyArray } from '@rnw-community/shared';
 
 import { LanguageEnum } from '../../@generic/enum/language.enum';
 import { BaseTransactionFilterRepository } from '../../@generic/repository/base-transaction-filter.repository';
 import { buildTranslatedCategoryRelation } from '../../@generic/util/build-translated-category-relation.util';
+import {
+    getDirectExchangeRateSql,
+    getHistoricalExchangeRateSql,
+    getInverseExchangeRateSql,
+    getInverseHistoricalExchangeRateSql
+} from '../../@generic/util/get-exchange-rate-sql.util';
 import { AccountAssociationEnum } from '../../account/enum/account-association.enum';
 import { AccountTypeEnum } from '../../account/enum/account-type.enum';
 import { AccountEntityTable } from '../../account/table/account-entity.table';
@@ -68,7 +75,7 @@ export class StatisticsRepository extends BaseTransactionFilterRepository {
                         THEN 0
                         WHEN ${TransactionEntryEntityTable.type} = ${TransactionEntryTypeEnum.DEBIT}
                              AND ${AccountEntityTable.type} != ${AccountTypeEnum.DEBT}
-                        THEN ${TransactionEntryEntityTable.baseAmount}
+                        THEN ${this.buildEntryBaseValueSql(defaultInstrumentId)}
                         ELSE 0
                     END), 0)
                 `.as('income'),
@@ -77,10 +84,10 @@ export class StatisticsRepository extends BaseTransactionFilterRepository {
                         WHEN ${TransactionEntityTable.consolidationType} = ${TransactionConsolidationTypeEnum.REFUND}
                              AND ${TransactionEntryEntityTable.type} = ${TransactionEntryTypeEnum.CREDIT}
                              AND ${AccountEntityTable.type} != ${AccountTypeEnum.DEBT}
-                        THEN ${this.buildRefundAdjustedCreditBaseAmountSql()}
+                        THEN ${this.buildRefundAdjustedCreditBaseAmountSql(defaultInstrumentId)}
                         WHEN ${TransactionEntryEntityTable.type} = ${TransactionEntryTypeEnum.CREDIT}
                              AND ${AccountEntityTable.type} != ${AccountTypeEnum.DEBT}
-                        THEN ${TransactionEntryEntityTable.baseAmount}
+                        THEN ${this.buildEntryBaseValueSql(defaultInstrumentId)}
                         ELSE 0
                     END), 0)
                 `.as('expense')
@@ -88,7 +95,7 @@ export class StatisticsRepository extends BaseTransactionFilterRepository {
             .from(TransactionEntryEntityTable)
             .innerJoin(TransactionEntityTable, eq(TransactionEntryEntityTable.transactionId, TransactionEntityTable.id))
             .innerJoin(AccountEntityTable, eq(TransactionEntryEntityTable.accountId, AccountEntityTable.id))
-            .where(and(baseWhere, this.buildLedgerEntryCondition(), eq(TransactionEntryEntityTable.baseInstrumentId, defaultInstrumentId)));
+            .where(and(baseWhere, this.buildLedgerEntryCondition()));
     }
 
     getIncomeByCategoryQuery(filters: TransactionFilterInterface, defaultInstrumentId: number, language: LanguageEnum) {
@@ -185,7 +192,7 @@ export class StatisticsRepository extends BaseTransactionFilterRepository {
         defaultInstrumentId: number,
         language: LanguageEnum
     ) {
-        const amountSql = this.buildRefundAwareBaseAmountSql();
+        const amountSql = this.buildRefundAwareBaseAmountSql(defaultInstrumentId);
         const categoryTitleSql = sql<string>`COALESCE(${DefaultCategoryTranslationEntityTable.title}, ${CategoryEntityTable.title})`;
 
         return this.db
@@ -208,7 +215,6 @@ export class StatisticsRepository extends BaseTransactionFilterRepository {
                 and(
                     inArray(TransactionEntityTable.id, transactionIdsSubquery),
                     this.buildLedgerEntryCondition(),
-                    eq(TransactionEntryEntityTable.baseInstrumentId, defaultInstrumentId),
                     ne(AccountEntityTable.type, AccountTypeEnum.DEBT)
                 )
             )
@@ -217,7 +223,7 @@ export class StatisticsRepository extends BaseTransactionFilterRepository {
     }
 
     private buildTagBreakdownQuery(transactionIdsSubquery: ReturnType<typeof this.buildTransactionIdsQuery>, defaultInstrumentId: number) {
-        const amountSql = this.buildRefundAwareBaseAmountSql();
+        const amountSql = this.buildRefundAwareBaseAmountSql(defaultInstrumentId);
 
         return this.db
             .select({
@@ -233,7 +239,6 @@ export class StatisticsRepository extends BaseTransactionFilterRepository {
                 and(
                     inArray(TransactionEntityTable.id, transactionIdsSubquery),
                     this.buildLedgerEntryCondition(),
-                    eq(TransactionEntryEntityTable.baseInstrumentId, defaultInstrumentId),
                     ne(AccountEntityTable.type, AccountTypeEnum.DEBT)
                 )
             )
@@ -242,30 +247,52 @@ export class StatisticsRepository extends BaseTransactionFilterRepository {
     }
     /* jscpd:ignore-end */
 
-    private buildRefundAwareBaseAmountSql() {
+    private buildConversionRateSql(defaultInstrumentId: number, instrumentIdRef: SQL) {
+        return sql`COALESCE(
+            ${getDirectExchangeRateSql(defaultInstrumentId, instrumentIdRef)},
+            ${getInverseExchangeRateSql(defaultInstrumentId, instrumentIdRef)},
+            ${getHistoricalExchangeRateSql(defaultInstrumentId, instrumentIdRef)},
+            ${getInverseHistoricalExchangeRateSql(defaultInstrumentId, instrumentIdRef)},
+            1.0
+        )`;
+    }
+
+    private buildEntryBaseValueSql(defaultInstrumentId: number) {
+        return sql<number>`CASE
+            WHEN ${TransactionEntryEntityTable.baseInstrumentId} = ${defaultInstrumentId}
+            THEN ${TransactionEntryEntityTable.baseAmount}
+            ELSE ROUND(${TransactionEntryEntityTable.amount} * ${this.buildConversionRateSql(defaultInstrumentId, sql.raw('accounts.instrument_id'))})
+        END`;
+    }
+
+    private buildRefundAwareBaseAmountSql(defaultInstrumentId: number) {
         return sql<number>`COALESCE(SUM(CASE
             WHEN ${TransactionEntityTable.consolidationType} = ${TransactionConsolidationTypeEnum.REFUND}
                  AND ${TransactionEntryEntityTable.type} = ${TransactionEntryTypeEnum.CREDIT}
-            THEN ${this.buildRefundAdjustedCreditBaseAmountSql()}
-            ELSE ${TransactionEntryEntityTable.baseAmount}
+            THEN ${this.buildRefundAdjustedCreditBaseAmountSql(defaultInstrumentId)}
+            ELSE ${this.buildEntryBaseValueSql(defaultInstrumentId)}
         END), 0)`;
     }
 
-    private buildRefundAdjustedCreditBaseAmountSql() {
+    private buildRefundAdjustedCreditBaseAmountSql(defaultInstrumentId: number) {
         return sql<number>`
-            ${TransactionEntryEntityTable.baseAmount}
+            ${this.buildEntryBaseValueSql(defaultInstrumentId)}
             - (
-                ${this.buildRefundTotalBaseAmountSql()}
-                * ${TransactionEntryEntityTable.baseAmount}
-                / NULLIF(${this.buildLedgerCreditBaseAmountTotalSql()}, 0)
+                ${this.buildRefundTotalBaseAmountSql(defaultInstrumentId)}
+                * ${this.buildEntryBaseValueSql(defaultInstrumentId)}
+                / NULLIF(${this.buildLedgerCreditBaseAmountTotalSql(defaultInstrumentId)}, 0)
             )
         `;
     }
 
-    private buildRefundTotalBaseAmountSql() {
+    private buildRefundTotalBaseAmountSql(defaultInstrumentId: number) {
         return sql<number>`COALESCE((
-            SELECT SUM(refund_entry.base_amount)
+            SELECT SUM(CASE
+                WHEN refund_entry.base_instrument_id = ${defaultInstrumentId} THEN refund_entry.base_amount
+                ELSE ROUND(refund_entry.amount * ${this.buildConversionRateSql(defaultInstrumentId, sql.raw('refund_account.instrument_id'))})
+            END)
             FROM transaction_entries refund_entry
+            INNER JOIN accounts refund_account ON refund_account.id = refund_entry.account_id
             WHERE refund_entry.transaction_id = ${TransactionEntryEntityTable.transactionId}
               AND refund_entry.original_transaction_id IS NOT NULL
               AND refund_entry.deleted_at IS NULL
@@ -273,10 +300,14 @@ export class StatisticsRepository extends BaseTransactionFilterRepository {
         ), 0)`;
     }
 
-    private buildLedgerCreditBaseAmountTotalSql() {
+    private buildLedgerCreditBaseAmountTotalSql(defaultInstrumentId: number) {
         return sql<number>`COALESCE((
-            SELECT SUM(ledger_credit.base_amount)
+            SELECT SUM(CASE
+                WHEN ledger_credit.base_instrument_id = ${defaultInstrumentId} THEN ledger_credit.base_amount
+                ELSE ROUND(ledger_credit.amount * ${this.buildConversionRateSql(defaultInstrumentId, sql.raw('ledger_account.instrument_id'))})
+            END)
             FROM transaction_entries ledger_credit
+            INNER JOIN accounts ledger_account ON ledger_account.id = ledger_credit.account_id
             WHERE ledger_credit.transaction_id = ${TransactionEntryEntityTable.transactionId}
               AND ledger_credit.original_transaction_id IS NULL
               AND ledger_credit.deleted_at IS NULL

--- a/tests/bank-sync-tests/src/scenarios/money-data/statistics-unvalued-fallback.test.ts
+++ b/tests/bank-sync-tests/src/scenarios/money-data/statistics-unvalued-fallback.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    AccountTypeEnum,
+    CurrencyEnum,
+    DEFAULT_TRANSACTION_FILTER,
+    ExchangeRateEntityTable,
+    PRECISION,
+    SettingsEntityTable,
+    TransactionEntryEntityTable,
+    TransactionEntryTypeEnum,
+    TransactionEntityTable,
+    TransactionTypeEnum
+} from '@budgie/contracts';
+
+import { statisticsRepository } from '@app/@generic/drizzle/db/db';
+
+import { requireInstrument } from '../../harness';
+import { insertOne } from '../../harness/db/insert-one';
+import { testDb } from '../../harness/scenario/setup';
+import { seed } from '../../harness/seed/seed';
+
+import type { TransactionCreateEntityInterface, TransactionEntryCreateEntityInterface } from '@budgie/contracts';
+
+describe('statistics fallback for unvalued entries', () => {
+    it('includes an unvalued foreign income entry via live conversion instead of dropping it', async () => {
+        const euro = await requireInstrument(CurrencyEnum.EUR);
+        const hryvnia = await requireInstrument(CurrencyEnum.UAH);
+        const account = seed.account({ instrumentId: hryvnia.id, type: AccountTypeEnum.BANK });
+
+        await testDb.update(SettingsEntityTable).set({ defaultInstrumentId: euro.id });
+        insertOne(ExchangeRateEntityTable, { source: 'test', baseInstrumentId: hryvnia.id, quoteInstrumentId: euro.id, rate: 0.02 });
+
+        const transaction = insertOne(TransactionEntityTable, {
+            type: TransactionTypeEnum.INCOME,
+            title: 'Unvalued UAH income',
+            operatedAt: new Date('2026-05-15T12:00:00.000Z'),
+            comment: '',
+            fromAccountId: null,
+            toAccountId: account.id,
+            exchangeRate: 1,
+            externalId: null,
+            externalSource: null,
+            updatedBy: null
+        } satisfies TransactionCreateEntityInterface);
+
+        insertOne(TransactionEntryEntityTable, {
+            transactionId: transaction.id,
+            accountId: account.id,
+            type: TransactionEntryTypeEnum.DEBIT,
+            amount: 1000 * PRECISION,
+            categoryId: null,
+            mccCategoryId: null,
+            externalId: null,
+            exchangeRate: 1,
+            baseInstrumentId: null,
+            baseExchangeRate: null,
+            baseAmount: null,
+            toIban: null
+        } satisfies TransactionEntryCreateEntityInterface);
+
+        const totals = statisticsRepository.getTotalIncomeAndExpenseQuery(DEFAULT_TRANSACTION_FILTER, euro.id).get();
+
+        expect(totals?.income).toBe(20 * PRECISION);
+        expect(totals?.expense).toBe(0);
+    });
+});


### PR DESCRIPTION
## Problem (regression from #493 / commit 998187d3d)

The money-data PR switched the statistics queries from live-converting each entry's `amount` to summing the stored `base_amount`, and added `WHERE base_instrument_id = defaultInstrumentId`. That filter **silently drops every entry whose base valuation hasn't run** (`base_amount` NULL).

Real-world impact: after importing production data **without** running "Value Historical Entries" (or after changing the main currency), ~97% of entries are unvalued, so analytics collapses — e.g. **€52 spent / €0 income** instead of the real **€15.8k / €10.5k**. Verified live: the user's DB had 23,698 unvalued vs 659 valued entries.

## Fix

Introduce an **effective-value** expression: use the stored historical `base_amount` when an entry is valued in the default currency, otherwise **live-convert the entry `amount`** (direct → inverse → historical → 1.0, mirroring the net-worth conversion). Drop the three `base_instrument_id` exclusion filters so no row is ever lost. Refund proration converts sibling entries the same way.

Result: valued entries keep their historical value; unvalued entries are converted on the fly instead of vanishing.

## Test

Adds `statistics-unvalued-fallback.test.ts` — an unvalued foreign income entry now appears via live conversion (€20 from 1000 UAH × 0.02) instead of €0. Failed before the fix.

## Validation

- Full bank-sync suite: **96/96** ✅ (incl. the existing valued-entry historical analytics test — no regression)
- `yarn ts` ✅, `yarn lint` ✅, `yarn cpd` ✅ (0 clones), `yarn deadcode` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Statistics now compute income and expense amounts using live currency conversion for foreign transactions.

* **Bug Fixes**
  * Foreign transaction entries without base valuations are now properly included in statistics calculations via exchange-rate conversion.

* **Tests**
  * Added test coverage for currency conversion fallback in unvalued foreign transaction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->