### PR TITLE
fix(app): value pre-range transactions at the oldest historical rate

### DIFF
--- a/packages/app/src/money-data/service/entry-base-valuation.service.ts
+++ b/packages/app/src/money-data/service/entry-base-valuation.service.ts
@@ -16,7 +16,7 @@ import { exchangeRatesService } from '../../exchange-rate/service/exchange-rates
 
 import type { EntryBaseValuationInputInterface } from '../interface/entry-base-valuation-input.interface';
 import type { EntryBaseValuationInterface } from '../interface/entry-base-valuation.interface';
-import type { DB, TransactionEntryCreateInputInterface } from '@budgie/contracts';
+import type { DB, HistoricalExchangeRateEntityInterface, TransactionEntryCreateInputInterface } from '@budgie/contracts';
 
 class EntryBaseValuationService {
     private static readonly RATE_DATE_FORMAT = 'yyyy-MM-dd';
@@ -81,26 +81,24 @@ class EntryBaseValuationService {
         tx?: DB
     ): Promise<number> {
         const rateDate = format(operatedAt, EntryBaseValuationService.RATE_DATE_FORMAT);
-        const exchangeRate = await historicalExchangeRateRepository.findForDateOrBefore(
+        const dateRate = await this.resolveDirectOrInverseRate(
+            (sourceId, targetId) => historicalExchangeRateRepository.findForDateOrBefore(sourceId, targetId, rateDate, tx),
             sourceInstrumentId,
-            targetInstrumentId,
-            rateDate,
-            tx
+            targetInstrumentId
         );
 
-        if (isDefined(exchangeRate)) {
-            return exchangeRate.rate;
+        if (isDefined(dateRate)) {
+            return dateRate;
         }
 
-        const inverseExchangeRate = await historicalExchangeRateRepository.findForDateOrBefore(
-            targetInstrumentId,
+        const oldestRate = await this.resolveDirectOrInverseRate(
+            (sourceId, targetId) => historicalExchangeRateRepository.findEarliest(sourceId, targetId, tx),
             sourceInstrumentId,
-            rateDate,
-            tx
+            targetInstrumentId
         );
 
-        if (isDefined(inverseExchangeRate)) {
-            return 1 / inverseExchangeRate.rate;
+        if (isDefined(oldestRate)) {
+            return oldestRate;
         }
 
         const bridgeExchangeRate = await this.resolveHistoricalBridgeExchangeRate(sourceInstrumentId, targetInstrumentId, rateDate, tx);
@@ -127,6 +125,26 @@ class EntryBaseValuationService {
         );
 
         return valuations;
+    }
+
+    private async resolveDirectOrInverseRate(
+        lookup: (sourceInstrumentId: number, targetInstrumentId: number) => Promise<HistoricalExchangeRateEntityInterface | undefined>,
+        sourceInstrumentId: number,
+        targetInstrumentId: number
+    ): Promise<number | null> {
+        const direct = await lookup(sourceInstrumentId, targetInstrumentId);
+
+        if (isDefined(direct)) {
+            return direct.rate;
+        }
+
+        const inverse = await lookup(targetInstrumentId, sourceInstrumentId);
+
+        if (isDefined(inverse)) {
+            return 1 / inverse.rate;
+        }
+
+        return null;
     }
 
     private async resolveCurrentBaseExchangeRate(sourceInstrumentId: number, targetInstrumentId: number): Promise<number> {

--- a/packages/contracts/src/historical-exchange-rate/repository/historical-exchange-rate.repository.ts
+++ b/packages/contracts/src/historical-exchange-rate/repository/historical-exchange-rate.repository.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNull, lte } from 'drizzle-orm';
+import { SQL, and, asc, desc, eq, isNull, lte } from 'drizzle-orm';
 
 import { HistoricalExchangeRateEntityTable } from '../table/historical-exchange-rate-entity.table';
 
@@ -15,15 +15,22 @@ export class HistoricalExchangeRateRepository {
         rateDate: string,
         tx?: DB
     ): Promise<HistoricalExchangeRateEntityInterface | undefined> {
-        return await (tx ?? this.db).query.HistoricalExchangeRateEntityTable.findFirst({
-            where: and(
-                eq(HistoricalExchangeRateEntityTable.sourceInstrumentId, sourceInstrumentId),
-                eq(HistoricalExchangeRateEntityTable.targetInstrumentId, targetInstrumentId),
-                lte(HistoricalExchangeRateEntityTable.rateDate, rateDate),
-                isNull(HistoricalExchangeRateEntityTable.deletedAt)
-            ),
-            orderBy: desc(HistoricalExchangeRateEntityTable.rateDate)
-        });
+        const where = and(
+            this.buildPairCondition(sourceInstrumentId, targetInstrumentId),
+            lte(HistoricalExchangeRateEntityTable.rateDate, rateDate)
+        );
+
+        return await this.findFirstRate(where, desc(HistoricalExchangeRateEntityTable.rateDate), tx);
+    }
+
+    async findEarliest(
+        sourceInstrumentId: number,
+        targetInstrumentId: number,
+        tx?: DB
+    ): Promise<HistoricalExchangeRateEntityInterface | undefined> {
+        const where = this.buildPairCondition(sourceInstrumentId, targetInstrumentId);
+
+        return await this.findFirstRate(where, asc(HistoricalExchangeRateEntityTable.rateDate), tx);
     }
 
     async upsert(input: HistoricalExchangeRateCreateEntityInterface, tx?: DB): Promise<void> {
@@ -41,5 +48,21 @@ export class HistoricalExchangeRateRepository {
                     updatedAt: new Date()
                 }
             });
+    }
+
+    private buildPairCondition(sourceInstrumentId: number, targetInstrumentId: number): SQL | undefined {
+        return and(
+            eq(HistoricalExchangeRateEntityTable.sourceInstrumentId, sourceInstrumentId),
+            eq(HistoricalExchangeRateEntityTable.targetInstrumentId, targetInstrumentId),
+            isNull(HistoricalExchangeRateEntityTable.deletedAt)
+        );
+    }
+
+    private async findFirstRate(
+        where: SQL | undefined,
+        order: SQL,
+        tx?: DB
+    ): Promise<HistoricalExchangeRateEntityInterface | undefined> {
+        return await (tx ?? this.db).query.HistoricalExchangeRateEntityTable.findFirst({ where, orderBy: order });
     }
 }

--- a/tests/bank-sync-tests/src/scenarios/money-data/oldest-rate-fallback.test.ts
+++ b/tests/bank-sync-tests/src/scenarios/money-data/oldest-rate-fallback.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { CurrencyEnum, PRECISION, SettingsEntityTable } from '@budgie/contracts';
+
+import { entryBaseValuationService } from '@app/money-data/service/entry-base-valuation.service';
+
+import { requireInstrument } from '../../harness';
+import { testDb } from '../../harness/scenario/setup';
+import { seed } from '../../harness/seed/seed';
+
+describe('valuation oldest-rate fallback', () => {
+    it('values a transaction older than the seeded range using the oldest available historical rate', async () => {
+        const euro = await requireInstrument(CurrencyEnum.EUR);
+        const hryvnia = await requireInstrument(CurrencyEnum.UAH);
+        const account = seed.account({ instrumentId: hryvnia.id });
+
+        await testDb.update(SettingsEntityTable).set({ defaultInstrumentId: euro.id });
+
+        const valuation = await entryBaseValuationService.valueMicroUnitEntry({
+            accountId: account.id,
+            amount: 50 * PRECISION,
+            operatedAt: new Date('2009-01-01T12:00:00.000Z'),
+            externalSource: null
+        });
+
+        expect(valuation).toStrictEqual({
+            baseInstrumentId: euro.id,
+            baseExchangeRate: 0.0889028367561666,
+            baseAmount: 4_445_142
+        });
+    });
+});


### PR DESCRIPTION
## Problem

`resolveHistoricalBaseExchangeRate` only looks for a rate **on or before** the transaction date (`findForDateOrBefore`). The seeded historical rates start at **2011-05-25**, so any transaction older than that finds no row and falls straight through to `resolveCurrentBaseExchangeRate` — valuing a 15+ year-old entry at **today's** rate. For currencies that have devalued heavily (e.g. UAH ~5×) that's a large error.

There was **no fallback to the oldest available rate**.

## Fix

Add `HistoricalExchangeRateRepository.findEarliest` and, in the resolver, try the **oldest available historical rate** (direct then inverse) before the bridge/current fallback:

```
date-or-before (direct/inverse) → oldest-available (direct/inverse) → bridge → current
```

So a pre-range transaction is valued at the closest-in-time historical rate (e.g. a 2009 UAH entry uses the 2011-05-25 rate) instead of today's.

This only changes behaviour for dates **before all** rates for a pair (normal in-range dates are unaffected, since `findForDateOrBefore` already returns the prior rate).

Refactors:
- `resolveDirectOrInverseRate` helper keeps the resolver under the statement limit and DRY.
- `buildPairCondition` + `findFirstRate` dedupe the two repository lookups.

## Test

Adds `oldest-rate-fallback.test.ts` — a 2009 UAH entry now values at the 2011-05-25 rate (0.0889) instead of throwing/using the current rate.

## Validation

- Full bank-sync suite: **96/96** ✅
- `yarn ts` ✅, `yarn lint` ✅, `yarn cpd` ✅ (0 clones), `yarn deadcode` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved historical exchange rate fallback to use the oldest available rate when recent data is unavailable.

* **Refactor**
  * Enhanced internal exchange rate resolution to eliminate code duplication and improve maintainability.

* **Tests**
  * Added test coverage for oldest-rate fallback scenarios in historical valuations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->