### PR TITLE
fix: restore release workflow state

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+          ref: main
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -37,8 +38,16 @@ jobs:
           git config user.email "vitalyiegorov@gmail.com"
           git remote rm origin
           git remote add origin https://vitalyiegorov:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          git fetch
+          git fetch origin main --tags
+          git switch main
           git branch --set-upstream-to=origin/main main
+
+      - name: Verify release branch
+        run: |
+          if [ "$(git branch --show-current)" != "main" ]; then
+            echo "Release must run on the main branch, not a detached HEAD."
+            exit 1
+          fi
 
       - name: Install dependencies
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [5.28.0](https://github.com/budgie-at/budgie/compare/v5.27.0...v5.28.0) (2026-05-30)
+
+### Features
+
+- **app:** always allow convert-to-transfer rule action and show account on rule card ([#506](https://github.com/budgie-at/budgie/issues/506)) ([83dde51](https://github.com/budgie-at/budgie/commit/83dde5191466672c30c7ed588bb0291d9bd90cfd))
+
 # [5.27.0](https://github.com/budgie-at/budgie/compare/v5.26.0...v5.27.0) (2026-05-29)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
         }
     },
     "npmClient": "yarn",
-    "version": "5.27.0"
+    "version": "5.28.0"
 }

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [5.28.0](https://github.com/budgie-at/budgie/compare/v5.27.0...v5.28.0) (2026-05-30)
+
+**Note:** Version bump only for package @budgie/ai
+
 # [5.27.0](https://github.com/budgie-at/budgie/compare/v5.26.0...v5.27.0) (2026-05-29)
 
 **Note:** Version bump only for package @budgie/ai

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@budgie/ai",
-    "version": "5.27.0",
+    "version": "5.28.0",
     "private": true,
     "description": "AI services for transaction categorization, embedding suggestions, and voice extraction",
     "sideEffects": false,

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [5.28.0](https://github.com/budgie-at/budgie/compare/v5.27.0...v5.28.0) (2026-05-30)
+
+### Features
+
+- **app:** always allow convert-to-transfer rule action and show account on rule card ([#506](https://github.com/budgie-at/budgie/issues/506)) ([83dde51](https://github.com/budgie-at/budgie/commit/83dde5191466672c30c7ed588bb0291d9bd90cfd))
+
 # [5.27.0](https://github.com/budgie-at/budgie/compare/v5.26.0...v5.27.0) (2026-05-29)
 
 ### Bug Fixes

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@budgie-at/app",
-    "version": "5.27.0",
+    "version": "5.28.0",
     "private": true,
     "scripts": {
         "android": "expo run:android",

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [5.28.0](https://github.com/budgie-at/budgie/compare/v5.27.0...v5.28.0) (2026-05-30)
+
+### Features
+
+- **app:** always allow convert-to-transfer rule action and show account on rule card ([#506](https://github.com/budgie-at/budgie/issues/506)) ([83dde51](https://github.com/budgie-at/budgie/commit/83dde5191466672c30c7ed588bb0291d9bd90cfd))
+
 # [5.27.0](https://github.com/budgie-at/budgie/compare/v5.26.0...v5.27.0) (2026-05-29)
 
 ### Features

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@budgie/contracts",
-    "version": "5.27.0",
+    "version": "5.28.0",
     "private": true,
     "description": "Contracts",
     "sideEffects": false,


### PR DESCRIPTION
## Summary
- Restore the orphaned v5.28.0 release commit into main history so Lerna no longer retries an already-existing tag.
- Harden the production workflow to checkout, switch to, and verify main before publishing a release.
- Unblock the EAS Update job, which was skipped because the release job failed first.

## Root Cause
The remote v5.28.0 tag existed, but the release commit was not contained in main. Main still reported version 5.27.0, so yarn release tried to create v5.28.0 again and failed with fatal: tag 'v5.28.0' already exists.

## Verification
- yarn format && yarn ts && yarn lint && yarn deadcode && yarn cpd
- gh run logs confirmed Deploy production failed in yarn release before EAS Update.
- eas update:list --branch production --limit 1 --json confirmed production is still on the older #496 update until this workflow is unblocked.

## Notes
- Existing lint warning remains in packages/app/src/ai/hook/use-suggestion-base.hook.ts:101.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced convert-to-transfer rule action to always be available; account information now displays on rule cards.

* **Chores**
  * Version bump to 5.28.0 across all packages.
  * Improved production deployment workflow with enhanced git handling and validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->