### PR TITLE
fix(app): allow inactive accounts in rules

### DIFF
--- a/packages/app/src/rule/components/rule-action-account-selector/rule-action-account-selector.tsx
+++ b/packages/app/src/rule/components/rule-action-account-selector/rule-action-account-selector.tsx
@@ -60,7 +60,7 @@ export const RuleActionAccountSelector = ({ index, testID }: Props) => {
 
     const renderSelector = ({ field: { onChange } }: UseControllerReturn<RuleCreateInputInterface, `actions.${number}.accountId`>) => {
         const handleOpen = async () => {
-            const selectedAccountId = await openAccountSelector({ initialAccountId: accountId ?? null });
+            const selectedAccountId = await openAccountSelector({ initialAccountId: accountId ?? null, onlyActive: false });
 
             if (isDefined(selectedAccountId)) {
                 onChange(selectedAccountId);

--- a/packages/app/src/rule/components/rule-condition-account-selector/rule-condition-account-selector.tsx
+++ b/packages/app/src/rule/components/rule-condition-account-selector/rule-condition-account-selector.tsx
@@ -27,7 +27,10 @@ export const RuleConditionAccountSelector = ({ index, testID }: Props) => {
 
     const renderSelector = ({ field: { onChange } }: UseControllerReturn<RuleCreateInputInterface, `conditions.${number}.value`>) => {
         const handleOpen = async () => {
-            const selectedAccountId = await openAccountSelector({ initialAccountId: isPositiveNumber(accountId) ? accountId : null });
+            const selectedAccountId = await openAccountSelector({
+                initialAccountId: isPositiveNumber(accountId) ? accountId : null,
+                onlyActive: false
+            });
 
             if (isDefined(selectedAccountId)) {
                 onChange(String(selectedAccountId));


### PR DESCRIPTION
## Summary

- Allow rule condition account selectors to show inactive accounts.
- Allow rule convert-to-transfer action account selectors to show inactive accounts.
- Keep the shared account selector default active-only behavior for other flows.

## Why

The rule form reused the shared account selector without overriding its `onlyActive` default, so inactive accounts could not be selected even though rule matching and rule actions work from persisted account IDs.

## Validation

- `yarn prettier --check packages/app/src/rule/components/rule-condition-account-selector/rule-condition-account-selector.tsx packages/app/src/rule/components/rule-action-account-selector/rule-action-account-selector.tsx`
- `yarn eslint packages/app/src/rule/components/rule-condition-account-selector/rule-condition-account-selector.tsx packages/app/src/rule/components/rule-action-account-selector/rule-action-account-selector.tsx`
- `git diff --check`

Full validation was attempted with `yarn format && yarn ts && yarn lint && yarn deadcode && yarn cpd`, but it stopped at `yarn ts` on existing unrelated failures. The first failure is in `@budgie-at/landing`, where generated `.next/types` references missing route module `../../src/app/[lang]/features/income-to-transfer-conversion/page.js`. A direct app TypeScript check also currently fails on unrelated contracts/app drift such as missing `HistoricalExchangeRateRepository` and base valuation fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Account selectors in rules now include inactive accounts, allowing you to reference and select inactive accounts when configuring both rule actions and conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->