### PR TITLE
fix(ai): deduplicate generated keywords

### DIFF
--- a/packages/ai/src/suggestion/service/translation-llm.service.ts
+++ b/packages/ai/src/suggestion/service/translation-llm.service.ts
@@ -1,6 +1,6 @@
 import { Log } from '@budgie/logger';
 
-import { getErrorMessage } from '@rnw-community/shared';
+import { getErrorMessage, isNotEmptyString } from '@rnw-community/shared';
 
 import { ChatInvokerInterface } from '../../chat/interface/chat-invoker.interface';
 import { containsNonLatin } from '../../embedding/util/contains-non-latin.util';
@@ -30,7 +30,7 @@ export class TranslationLlmService {
     private async generateTags(titleEn: string): Promise<string> {
         const tags = await this.chat.generate(TAG_GENERATION_SYSTEM_PROMPT, titleEn, { temperature: TRANSLATION_TEMPERATURE });
 
-        return tags.trim().toLowerCase();
+        return this.normalizeTags(tags);
     }
 
     @Log(
@@ -46,5 +46,16 @@ export class TranslationLlmService {
         const titleEn = await this.chat.generate(TRANSLATION_SYSTEM_PROMPT, title, { temperature: TRANSLATION_TEMPERATURE });
 
         return titleEn.trim().toLowerCase();
+    }
+
+    private normalizeTags(tags: string): string {
+        const normalizedTags = tags
+            .split(',')
+            .map(tag => tag.trim().toLowerCase())
+            .filter(isNotEmptyString);
+
+        const uniqueTags = [...new Set(normalizedTags)];
+
+        return uniqueTags.join(', ');
     }
 }


### PR DESCRIPTION
## Summary

Deduplicate AI-generated search keywords before storing them in translation metadata.

## Root Cause

`TranslationLlmService.generateTags` accepted the local model's comma-separated keyword output verbatim after trimming and lowercasing. When the model repeated the same keyword, the duplicate list was persisted and rendered in the category metadata UI.

## Changes

- Normalize generated tags by splitting comma-separated output.
- Trim and lowercase each keyword.
- Drop empty entries.
- Preserve first-seen order while removing duplicates with a `Set`.

## Validation

- Temporary red/green Jest check reproduced `clearmove, clearmove, clearmove` and passed after the fix; removed afterward per repo rules.
- `yarn format`
- `yarn ts` after clearing stale `packages/landing/.next` generated types
- `yarn lint` (passes with existing warning in `packages/app/src/ai/hook/use-suggestion-base.hook.ts:101`)
- `yarn deadcode`
- `yarn cpd`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tag processing in AI-generated content to remove duplicates, ensure consistent formatting, eliminate empty values, and deliver cleaner, more reliable tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->