### PR TITLE
fix(landing): keep api routes out of locale proxy

### DIFF
--- a/packages/landing/AGENTS.md
+++ b/packages/landing/AGENTS.md
@@ -47,7 +47,7 @@ Before starting any of the work areas below, read the corresponding doc first.
 | -------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
 | Blog articles, feature pages, pillar hubs, legal pages, sitemap entries, `generateMetadata`, JSON-LD helpers, anything SEO-related     | `docs/seo-pages.md`  |
 | `<Trans>` / `t` / `msg`, `generateMetadata` i18n strings, catalog `.po`/`.ts` files, RSC i18n setup, dispatching translation subagents | `docs/lingui-rsc.md` |
-| IndexNow key file, GSC/Bing sitemap submission, merge-to-main URL submission, root `.txt` proxy bypass rules                           | `docs/indexnow.md`   |
+| IndexNow key file, GSC/Bing sitemap submission, merge-to-main URL submission, API/root `.txt` proxy bypass rules                       | `docs/indexnow.md`   |
 
 ---
 

--- a/packages/landing/docs/indexnow.md
+++ b/packages/landing/docs/indexnow.md
@@ -93,23 +93,25 @@ Acceptable responses: `200 OK`, `202 Accepted`. A `403` means the key file is un
 
 ---
 
-## C. Proxy `matcher` must exclude root `.txt` files
+## C. Proxy `matcher` must exclude API routes and root `.txt` files
 
 The `config.matcher` in `src/proxy.ts` excludes:
 
 ```
-_next/static | _next/image | favicon.ico | robots.txt | sitemap.xml | manifest.webmanifest | .well-known | images (svg/png/jpg/jpeg/gif/webp)
+api | _next/static | _next/image | favicon.ico | robots.txt | sitemap.xml | manifest.webmanifest | .well-known | images (svg/png/jpg/jpeg/gif/webp)
 ```
 
-Root `.txt` files must stay excluded, otherwise IndexNow verification and LLM text files are locale-redirected to HTML pages.
+API routes and root `.txt` files must stay excluded, otherwise the IndexNow submitter and key verification file are locale-redirected to HTML pages.
 
 ```ts
 export const config = {
     matcher: [
-        '/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|manifest.webmanifest|.well-known|[^/]+\\.txt$|[^.]*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)'
+        '/((?!api|_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|manifest.webmanifest|.well-known|[^/]+\\.txt$|[^.]*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)'
     ]
 };
 ```
+
+The `api` pattern keeps `/api/indexnow` reachable as a Next.js route instead of redirecting to `/<locale>/api/indexnow`.
 
 The `[^/]+\\.txt` pattern matches any `.txt` file directly at the root path (one path segment, no slash). This covers:
 
@@ -187,13 +189,13 @@ Only submit on merge to `main` (production deployments). Do not submit on previe
 
 ## G. Related files
 
-| File                                   | Role                                                                                           |
-| -------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `src/app/sitemap.ts`                   | Single source of truth for indexable URLs — IndexNow submission derives its URL list from this |
-| `src/app/robots.ts`                    | Points crawlers to `${BASE_URL}/sitemap.xml`                                                   |
-| `src/proxy.ts`                         | Locale redirect middleware — its `config.matcher` must exclude `.txt` files at the root        |
-| `src/generic/constant/seo.constant.ts` | Declares `BASE_URL` — must match the live canonical host (`budgie.at`)                     |
-| `public/<key>.txt`                     | [TO BE IMPLEMENTED] IndexNow key file served as static asset                                   |
-| `src/app/api/indexnow/route.ts`        | [TO BE IMPLEMENTED] Admin-guarded submission endpoint                                          |
+| File                                   | Role                                                                                            |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `src/app/sitemap.ts`                   | Single source of truth for indexable URLs — IndexNow submission derives its URL list from this  |
+| `src/app/robots.ts`                    | Points crawlers to `${BASE_URL}/sitemap.xml`                                                    |
+| `src/proxy.ts`                         | Locale redirect middleware — its `config.matcher` must exclude API routes and root `.txt` files |
+| `src/generic/constant/seo.constant.ts` | Declares `BASE_URL` — must match the live canonical host (`budgie.at`)                          |
+| `public/<key>.txt`                     | [TO BE IMPLEMENTED] IndexNow key file served as static asset                                    |
+| `src/app/api/indexnow/route.ts`        | [TO BE IMPLEMENTED] Admin-guarded submission endpoint                                           |
 
 See `docs/lingui-rsc.md` for the i18n contract, and `docs/seo-pages.md` for sitemap entry patterns and JSON-LD.

--- a/packages/landing/src/generic/constant/indexnow.constant.ts
+++ b/packages/landing/src/generic/constant/indexnow.constant.ts
@@ -1,3 +1,7 @@
-export const INDEXNOW_KEY = process.env.INDEXNOW_KEY ?? 'c642d43afb7beae8f76dbaf27cea5bab';
+import { isNotEmptyString } from '@rnw-community/shared';
+
+const FALLBACK_INDEXNOW_KEY = 'c642d43afb7beae8f76dbaf27cea5bab';
+
+export const INDEXNOW_KEY = isNotEmptyString(process.env.INDEXNOW_KEY) ? process.env.INDEXNOW_KEY : FALLBACK_INDEXNOW_KEY;
 export const INDEXNOW_ENDPOINT = 'https://api.indexnow.org/IndexNow';
 export const INDEXNOW_HOST = 'budgie.at';

--- a/packages/landing/src/proxy.ts
+++ b/packages/landing/src/proxy.ts
@@ -38,6 +38,6 @@ export function proxy(request: NextRequest) {
 
 export const config = {
     matcher: [
-        '/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|manifest.webmanifest|.well-known|[^/]+\\.txt$|[^.]*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)'
+        '/((?!api|_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|manifest.webmanifest|.well-known|[^/]+\\.txt$|[^.]*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)'
     ]
 };

--- a/turbo.json
+++ b/turbo.json
@@ -21,6 +21,7 @@
         },
         "build": {
             "dependsOn": ["^build"],
+            "env": ["ADMIN_SECRET", "INDEXNOW_KEY"],
             "outputs": ["dist/**", ".next/**"]
         },
         "test": {


### PR DESCRIPTION
## Summary
- exclude API routes from the landing locale proxy matcher
- make `INDEXNOW_KEY` fall back when env is empty
- allow landing build access to IndexNow env names in Turbo
- document the API and root `.txt` bypass requirements for IndexNow

## Verification
- `yarn prettier --write packages/landing/src/proxy.ts packages/landing/docs/indexnow.md packages/landing/AGENTS.md`
- `yarn workspace @budgie-at/landing ts`
- `yarn workspace @budgie-at/landing lint`
- `yarn workspace @budgie-at/landing build`
- local `POST /api/indexnow` returns route JSON instead of locale redirect
- production `POST https://budgie.at/api/indexnow` without auth returns `401`, not redirect
- production authenticated IndexNow submit returned `HTTP 200` with `count: 325`
- production sitemap crawl: 325 URLs, 65 per locale, no duplicate/non-apex URLs
- `git diff --check`