### PR TITLE
fix(app): show loading state in filter sheets

### DIFF
--- a/packages/app/src/@generic/component/filter-sheet/filter-sheet-list/filter-sheet-list.tsx
+++ b/packages/app/src/@generic/component/filter-sheet/filter-sheet-list/filter-sheet-list.tsx
@@ -1,10 +1,11 @@
 import { ReactNode } from 'react';
-import { ScrollView, ViewStyle } from 'react-native';
+import { ActivityIndicator, ScrollView, ViewStyle } from 'react-native';
 
 interface Props {
     readonly children: ReactNode;
     readonly topSpacing?: number;
     readonly alignToBottom?: boolean;
+    readonly isLoading?: boolean;
 }
 
 const DEFAULT_TOP_PADDING = 16;
@@ -12,14 +13,17 @@ const DEFAULT_BOTTOM_PADDING = 160;
 const HORIZONTAL_PADDING = 12;
 const ITEM_GAP = 8;
 
-export const FilterSheetList = ({ children, topSpacing = 0, alignToBottom = false }: Props) => {
+export const FilterSheetList = ({ children, topSpacing = 0, alignToBottom = false, isLoading = false }: Props) => {
     const contentContainerStyle: ViewStyle = {
         paddingTop: DEFAULT_TOP_PADDING + topSpacing,
         paddingBottom: DEFAULT_BOTTOM_PADDING,
         paddingHorizontal: HORIZONTAL_PADDING,
         gap: ITEM_GAP,
-        ...(alignToBottom && { flexGrow: 1, justifyContent: 'flex-end' })
+        ...(alignToBottom && !isLoading && { flexGrow: 1, justifyContent: 'flex-end' }),
+        ...(isLoading && { flexGrow: 1, justifyContent: 'center' })
     };
+
+    const content = isLoading ? <ActivityIndicator size="large" color="var(--color-primary)" /> : children;
 
     return (
         <ScrollView
@@ -28,7 +32,7 @@ export const FilterSheetList = ({ children, topSpacing = 0, alignToBottom = fals
             keyboardShouldPersistTaps="handled"
             showsVerticalScrollIndicator={false}
         >
-            {children}
+            {content}
         </ScrollView>
     );
 };

--- a/packages/app/src/account/query/use-search-accounts-grouped.query.ts
+++ b/packages/app/src/account/query/use-search-accounts-grouped.query.ts
@@ -1,13 +1,21 @@
 import { AccountTypeEnum, AccountWithInstrumentEntityInterface } from '@budgie/contracts';
 import { useLiveQuery } from 'drizzle-orm/expo-sqlite';
 
+import { isDefined } from '@rnw-community/shared';
+
 import { accountRepository } from '../../@generic/drizzle/db/db';
 
 type AccountGroups = Partial<Record<AccountTypeEnum, AccountWithInstrumentEntityInterface[]>>;
 
 export const useSearchAccountsGroupedQuery = (search = '', withActive = true) => {
-    const { data, ...rest } = useLiveQuery(accountRepository.findBySearchQuery(search), [search]);
+    const { data, error, updatedAt } = useLiveQuery(accountRepository.findBySearchQuery(search), [search]);
     const { data: countData } = useLiveQuery(accountRepository.count(), []);
+
+    if (!isDefined(updatedAt)) {
+        const accountsGrouped: AccountGroups = {};
+
+        return { accounts: [], total: 0, accountsGrouped, isLoading: true, error, updatedAt: null };
+    }
 
     const filteredData = data.filter(account => (withActive ? account.isActive : true));
 
@@ -21,6 +29,8 @@ export const useSearchAccountsGroupedQuery = (search = '', withActive = true) =>
             }),
             {}
         ),
-        ...rest
+        isLoading: false,
+        error,
+        updatedAt
     };
 };

--- a/packages/app/src/app/transaction-account-filter.tsx
+++ b/packages/app/src/app/transaction-account-filter.tsx
@@ -27,7 +27,7 @@ export default function TransactionAccountFilterModal() {
     const state = useSearchableFilterState(currentParams?.value ?? null);
     const { localValue, setLocalValue, localValueRef, search, setSearch, selectedCount, handleDeselectAll } = state;
 
-    const { accountsGrouped, accounts, total } = useSearchAccountsGroupedQuery(search);
+    const { accountsGrouped, accounts, total, isLoading } = useSearchAccountsGroupedQuery(search);
 
     const showControls = !(isEmptyArray(accounts) && isEmptyString(search));
     const showEmptySearch = isNotEmptyString(search) && isPositiveNumber(total);
@@ -53,7 +53,7 @@ export default function TransactionAccountFilterModal() {
 
     return (
         <FilterSheet>
-            <FilterSheetList alignToBottom={isNotEmptyString(search)}>
+            <FilterSheetList alignToBottom={isNotEmptyString(search)} isLoading={isLoading}>
                 {isNotEmptyArray(accounts) ? (
                     <View className="gap-y-lg">
                         {isNotEmptyArray(accountsGrouped.BANK) ? (

--- a/packages/app/src/app/transaction-category-filter.tsx
+++ b/packages/app/src/app/transaction-category-filter.tsx
@@ -27,7 +27,7 @@ export default function TransactionCategoryFilterModal() {
     const state = useSearchableFilterState(currentParams?.value ?? null);
     const { localValue, setLocalValue, localValueRef, search, setSearch, selectedCount, handleDeselectAll } = state;
 
-    const { categories, total } = useSearchCategoriesQuery(search, true);
+    const { categories, total, isLoading } = useSearchCategoriesQuery(search, true);
 
     const items = categories ?? [];
     const showControls = !(isEmptyArray(items) && isEmptyString(search));
@@ -53,7 +53,7 @@ export default function TransactionCategoryFilterModal() {
 
     return (
         <FilterSheet>
-            <FilterSheetList alignToBottom={isNotEmptyString(search)}>
+            <FilterSheetList alignToBottom={isNotEmptyString(search)} isLoading={isLoading}>
                 {isNotEmptyArray(items) ? (
                     <View className="gap-y-sm">
                         {items.map(category => (

--- a/packages/app/src/app/transaction-tag-filter.tsx
+++ b/packages/app/src/app/transaction-tag-filter.tsx
@@ -27,7 +27,7 @@ export default function TransactionTagFilterModal() {
     const state = useSearchableFilterState(currentParams?.value ?? null);
     const { localValue, setLocalValue, localValueRef, search, setSearch, selectedCount, handleDeselectAll } = state;
 
-    const { tags, total } = useSearchTagsQuery(search);
+    const { tags, total, isLoading } = useSearchTagsQuery(search);
 
     const items = tags ?? [];
     const showControls = !(isEmptyArray(items) && isEmptyString(search));
@@ -53,7 +53,7 @@ export default function TransactionTagFilterModal() {
 
     return (
         <FilterSheet>
-            <FilterSheetList alignToBottom={isNotEmptyString(search)}>
+            <FilterSheetList alignToBottom={isNotEmptyString(search)} isLoading={isLoading}>
                 {isNotEmptyArray(items) ? (
                     <View className="gap-y-sm">
                         {items.map(tag => (


### PR DESCRIPTION
## Summary

- Add a generic loading state to `FilterSheetList` so filter sheets can show a centered spinner instead of flashing empty content.
- Thread loading state through account, category, and tag transaction filter sheets.
- Keep grouped account filters loading until the first live-query update arrives.

## Validation

- `yarn install`
- `yarn format && yarn ts && yarn lint && yarn deadcode && yarn cpd`

Note: lint reports the existing `use-suggestion-base.hook.ts` exhaustive-deps warning with no new lint errors.