### PR TITLE
fix(app): pin sdk 56 native app version

### DIFF
--- a/packages/app/app.config.js
+++ b/packages/app/app.config.js
@@ -1,5 +1,4 @@
-import rootPkg from './package.json';
-
+const NATIVE_APP_VERSION = '5.28.0';
 const APP_VARIANT = process.env.APP_VARIANT;
 const IS_DEV = APP_VARIANT === 'development';
 const IS_E2E = APP_VARIANT === 'e2e';
@@ -48,7 +47,7 @@ export default ({ config }) => ({
     name: getAppName(),
     slug: 'budgie',
     scheme: 'budgie',
-    version: rootPkg.version,
+    version: NATIVE_APP_VERSION,
     orientation: 'portrait',
     userInterfaceStyle: 'automatic',
     assetBundlePatterns: ['**/*'],


### PR DESCRIPTION
## Summary
- decouple the Expo native app version from the package release version in `packages/app/app.config.js`
- set the SDK 56 production native app version to `5.28.0`
- keep EAS remote build versions aligned: iOS `buildNumber` `5.28.0`, Android `versionCode` `5280`

## Why
`packages/app/eas.json` uses `appVersionSource: "remote"`, so EAS stores platform build numbers remotely. But Expo still reads the user-facing native app version from `app.config.js`. That config was following `packages/app/package.json`, which is now `5.31.2`; for the SDK 56 native runtime we need Expo config to emit `5.28.0`.

## Verification
- `PATH=/Users/vitalyiegorov/.nvm/versions/node/v22.22.0/bin:$PATH APP_VARIANT=production yarn expo config --type public --json` emitted `version: 5.28.0`, `runtimeVersion.policy: fingerprint`, iOS bundle id `com.vitalyiegorov.budgie`, Android package `com.vitaliiyehorov.budgie`
- `PATH=/Users/vitalyiegorov/.nvm/versions/node/v22.22.0/bin:$PATH yarn dlx eas-cli@20.0.0 build:version:get --platform all --profile production --json --non-interactive` emitted `versionCode: 5280`, `buildNumber: 5.28.0`
- `PATH=/Users/vitalyiegorov/.nvm/versions/node/v22.22.0/bin:$PATH yarn format && PATH=/Users/vitalyiegorov/.nvm/versions/node/v22.22.0/bin:$PATH yarn ts && PATH=/Users/vitalyiegorov/.nvm/versions/node/v22.22.0/bin:$PATH yarn lint && PATH=/Users/vitalyiegorov/.nvm/versions/node/v22.22.0/bin:$PATH yarn deadcode && PATH=/Users/vitalyiegorov/.nvm/versions/node/v22.22.0/bin:$PATH yarn cpd`

Note: lint still reports the existing `packages/app/src/ai/hook/use-suggestion-base.hook.ts` exhaustive-deps warning, with zero lint errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated native app version management configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->