### PR TITLE
fix(app): define background tasks at app entry

### DIFF
--- a/packages/app/index.js
+++ b/packages/app/index.js
@@ -4,4 +4,8 @@ import '@formatjs/intl-pluralrules/locale-data/en.js';
 import '@formatjs/intl-pluralrules/locale-data/es.js';
 import '@formatjs/intl-pluralrules/locale-data/fr.js';
 import '@formatjs/intl-pluralrules/locale-data/uk.js';
+import './src/account/task/account-balance-incremental.task';
+import './src/exchange-rate/task/exchange-rate-sync.task';
+import './src/sync/task/monobank-sync.task';
+import './src/sync/task/transfer-consolidation.task';
 import 'expo-router/entry';

--- a/packages/app/src/app/root-layout-content.tsx
+++ b/packages/app/src/app/root-layout-content.tsx
@@ -11,10 +11,6 @@ import { enableFreeze, enableScreens } from 'react-native-screens';
 import Toast from 'react-native-toast-message';
 
 import migrations from '../../drizzle/migrations';
-import '../account/task/account-balance-incremental.task';
-import '../exchange-rate/task/exchange-rate-sync.task';
-import '../sync/task/monobank-sync.task';
-import '../sync/task/transfer-consolidation.task';
 import '../global.css';
 import { DevMenuController } from '../@generic/component/dev-menu-controller/dev-menu-controller';
 import { ScreenLayout } from '../@generic/component/screen-layout/screen-layout';


### PR DESCRIPTION
## Summary
- Move main-existing background task definition imports from RootLayoutContent to index.js.
- Ensure Expo TaskManager definitions load during headless background launches.
- Keep this branch based directly on origin/main, without the budget-branch task import.

## Test Plan
- git diff --cached --check
- yarn exec prettier --check packages/app/index.js packages/app/src/app/root-layout-content.tsx
- yarn workspace @budgie-at/app ts

## Not Tested
- Device background-wake smoke test

Closes #532

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized task loading sequence during application initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->