### PR TITLE
fix(app): refresh Monobank background sync registration

### DIFF
--- a/packages/app/src/@generic/drizzle/db/db.ts
+++ b/packages/app/src/@generic/drizzle/db/db.ts
@@ -32,6 +32,7 @@ import * as schema from './schema';
 import { getErrorMessage, isDefined, isNotEmptyString } from '@rnw-community/shared';
 import * as SecureStore from 'expo-secure-store';
 import { PIN_KEY } from '../../../auth/constant/pin-key.constant';
+import { PIN_SECURE_STORE_OPTIONS } from '../../../auth/constant/pin-secure-store-options.constant';
 
 import type { DB } from '@budgie/contracts';
 
@@ -45,7 +46,7 @@ declare global {
 const dbInit = () => {
     global.__expoSqliteDb__ ?? (global.__expoSqliteDb__ = SQLite.openDatabaseSync(DB_NAME, { enableChangeListener: true }));
 
-    const pin = SecureStore.getItem(PIN_KEY);
+    const pin = SecureStore.getItem(PIN_KEY, PIN_SECURE_STORE_OPTIONS);
     if (isNotEmptyString(pin)) {
         global.__expoSqliteDb__.execSync(`PRAGMA key = '${pin}';`);
     }

--- a/packages/app/src/@generic/hook/use-app-initialization.hook.ts
+++ b/packages/app/src/@generic/hook/use-app-initialization.hook.ts
@@ -8,6 +8,7 @@ import { accountBalanceIncrementalService } from '../../account/service/account-
 import { authService } from '../../auth/service/auth.service';
 import { exchangeRatesSyncService } from '../../exchange-rate/service/exchange-rates-sync.service';
 import { monobankSyncService } from '../../sync/service/monobank-sync.service';
+import { syncWorkloadService } from '../../sync/service/sync-workload.service';
 import { transferConsolidationService } from '../../sync/service/transfer-consolidation.service';
 
 const logger = getLogger('useAppInitialization');
@@ -28,21 +29,22 @@ const registerBackgroundTasks = async (): Promise<void> => {
     await monobankSyncService.registerBackgroundTask();
 };
 
+const syncAppData = async (): Promise<void> => {
+    await monobankSyncService.sync();
+    await exchangeRatesSyncService.sync();
+    await accountBalanceIncrementalService.updateAllBalances(false);
+};
+
+const initializeAppServices = async (): Promise<void> => {
+    await registerBackgroundTasks();
+    await syncWorkloadService.run('startup', syncAppData);
+};
+
 export const useAppInitialization = (success: boolean) => {
     useEffect(() => {
         if (success) {
-            try {
-                runInitializationTask(exchangeRatesSyncService.sync());
-
-                runInitializationTask(accountBalanceIncrementalService.updateAllBalances(false));
-
-                runInitializationTask(monobankSyncService.sync());
-                runInitializationTask(registerBackgroundTasks());
-            } catch (error: unknown) {
-                handleInitializationError(error);
-            } finally {
-                setTimeout(() => void SplashScreen.hideAsync(), 200);
-            }
+            runInitializationTask(initializeAppServices());
+            setTimeout(() => void SplashScreen.hideAsync(), 200);
         }
     }, [success]);
 };

--- a/packages/app/src/@generic/hook/use-app-initialization.hook.ts
+++ b/packages/app/src/@generic/hook/use-app-initialization.hook.ts
@@ -1,8 +1,7 @@
-import { getLogger } from '@budgie/logger';
 import * as SplashScreen from 'expo-splash-screen';
 import { useEffect } from 'react';
 
-import { getErrorMessage } from '@rnw-community/shared';
+import { emptyFn } from '@rnw-community/shared';
 
 import { accountBalanceIncrementalService } from '../../account/service/account-balance-incremental.service';
 import { authService } from '../../auth/service/auth.service';
@@ -10,24 +9,10 @@ import { exchangeRatesSyncService } from '../../exchange-rate/service/exchange-r
 import { monobankSyncService } from '../../sync/service/monobank-sync.service';
 import { syncWorkloadService } from '../../sync/service/sync-workload.service';
 import { transferConsolidationService } from '../../sync/service/transfer-consolidation.service';
+import { scheduleIdleCallback } from '../utils/schedule-idle-callback.util';
 
-const logger = getLogger('useAppInitialization');
-
-const handleInitializationError = (error: unknown): void => {
-    logger.error('failed', { errorMessage: getErrorMessage(error) });
-};
-
-const runInitializationTask = (task: Promise<unknown>): void => {
-    void task.catch(handleInitializationError);
-};
-
-const registerBackgroundTasks = async (): Promise<void> => {
-    await authService.ensurePinBackgroundAccessibility();
-    await exchangeRatesSyncService.registerBackgroundTask();
-    await accountBalanceIncrementalService.registerBackgroundTask();
-    await transferConsolidationService.registerBackgroundTask();
-    await monobankSyncService.registerBackgroundTask();
-};
+const SPLASH_HIDE_DELAY_MS = 200;
+const STARTUP_SERVICE_DELAY_MS = 1_000;
 
 const syncAppData = async (): Promise<void> => {
     await monobankSyncService.sync();
@@ -36,15 +21,41 @@ const syncAppData = async (): Promise<void> => {
 };
 
 const initializeAppServices = async (): Promise<void> => {
-    await registerBackgroundTasks();
+    await authService.ensurePinBackgroundAccessibility().catch(emptyFn);
+    await exchangeRatesSyncService.registerBackgroundTask().catch(emptyFn);
+    await accountBalanceIncrementalService.registerBackgroundTask().catch(emptyFn);
+    await transferConsolidationService.registerBackgroundTask().catch(emptyFn);
+    await monobankSyncService.registerBackgroundTask().catch(emptyFn);
     await syncWorkloadService.run('startup', syncAppData);
+};
+
+const scheduleAppServicesInitialization = (): (() => void) => {
+    let cancelIdleCallback: () => void = emptyFn;
+
+    const timer = setTimeout(() => {
+        cancelIdleCallback = scheduleIdleCallback(() => {
+            void initializeAppServices().catch(emptyFn);
+        });
+    }, STARTUP_SERVICE_DELAY_MS);
+
+    return () => {
+        clearTimeout(timer);
+        cancelIdleCallback();
+    };
 };
 
 export const useAppInitialization = (success: boolean) => {
     useEffect(() => {
-        if (success) {
-            runInitializationTask(initializeAppServices());
-            setTimeout(() => void SplashScreen.hideAsync(), 200);
+        if (!success) {
+            return emptyFn;
         }
+
+        const cancelAppServicesInitialization = scheduleAppServicesInitialization();
+        const splashHideTimer = setTimeout(() => void SplashScreen.hideAsync(), SPLASH_HIDE_DELAY_MS);
+
+        return () => {
+            cancelAppServicesInitialization();
+            clearTimeout(splashHideTimer);
+        };
     }, [success]);
 };

--- a/packages/app/src/@generic/hook/use-app-initialization.hook.ts
+++ b/packages/app/src/@generic/hook/use-app-initialization.hook.ts
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 import { getErrorMessage } from '@rnw-community/shared';
 
 import { accountBalanceIncrementalService } from '../../account/service/account-balance-incremental.service';
+import { authService } from '../../auth/service/auth.service';
 import { exchangeRatesSyncService } from '../../exchange-rate/service/exchange-rates-sync.service';
 import { monobankSyncService } from '../../sync/service/monobank-sync.service';
 import { transferConsolidationService } from '../../sync/service/transfer-consolidation.service';
@@ -19,20 +20,24 @@ const runInitializationTask = (task: Promise<unknown>): void => {
     void task.catch(handleInitializationError);
 };
 
+const registerBackgroundTasks = async (): Promise<void> => {
+    await authService.ensurePinBackgroundAccessibility();
+    await exchangeRatesSyncService.registerBackgroundTask();
+    await accountBalanceIncrementalService.registerBackgroundTask();
+    await transferConsolidationService.registerBackgroundTask();
+    await monobankSyncService.registerBackgroundTask();
+};
+
 export const useAppInitialization = (success: boolean) => {
     useEffect(() => {
         if (success) {
             try {
                 runInitializationTask(exchangeRatesSyncService.sync());
-                runInitializationTask(exchangeRatesSyncService.registerBackgroundTask());
 
                 runInitializationTask(accountBalanceIncrementalService.updateAllBalances(false));
-                runInitializationTask(accountBalanceIncrementalService.registerBackgroundTask());
 
                 runInitializationTask(monobankSyncService.sync());
-                runInitializationTask(monobankSyncService.registerBackgroundTask());
-
-                runInitializationTask(transferConsolidationService.registerBackgroundTask());
+                runInitializationTask(registerBackgroundTasks());
             } catch (error: unknown) {
                 handleInitializationError(error);
             } finally {

--- a/packages/app/src/@generic/hook/use-modal-resolver/use-modal-resolver.hook.ts
+++ b/packages/app/src/@generic/hook/use-modal-resolver/use-modal-resolver.hook.ts
@@ -19,7 +19,7 @@ export const useModalResolver = <TParams, TResult>(route: string): UseModalResol
         new Promise(resolve => {
             setCurrentParams((params ?? {}) as TParams);
             resolverRef.current = resolve;
-            router.push(route as never);
+            router.push(route);
         });
 
     const resolve = (result: TResult, options?: ResolveOptions) => {

--- a/packages/app/src/@generic/hook/use-modal-resolver/use-modal-resolver.hook.ts
+++ b/packages/app/src/@generic/hook/use-modal-resolver/use-modal-resolver.hook.ts
@@ -1,4 +1,4 @@
-import { router } from 'expo-router';
+import { type Href, router } from 'expo-router';
 import { useRef, useState } from 'react';
 
 interface ResolveOptions {
@@ -11,7 +11,7 @@ interface UseModalResolverResult<TParams, TResult> {
     resolve: (result: TResult, options?: ResolveOptions) => void;
 }
 
-export const useModalResolver = <TParams, TResult>(route: string): UseModalResolverResult<TParams, TResult> => {
+export const useModalResolver = <TParams, TResult>(route: Href): UseModalResolverResult<TParams, TResult> => {
     const [currentParams, setCurrentParams] = useState<TParams | null>(null);
     const resolverRef = useRef<((result: TResult) => void) | null>(null);
 

--- a/packages/app/src/account/constant/minutes-in-seconds.constant.ts
+++ b/packages/app/src/account/constant/minutes-in-seconds.constant.ts
@@ -1,2 +1,1 @@
-export const FIFTEEN_MINUTES_IN_SECONDS = 900;
 export const TWO_MINUTES_IN_SECONDS = 120;

--- a/packages/app/src/account/constant/one-week-in-seconds.constant.ts
+++ b/packages/app/src/account/constant/one-week-in-seconds.constant.ts
@@ -1,1 +1,0 @@
-export const ONE_WEEK_IN_SECONDS = 7 * 24 * 60 * 60;

--- a/packages/app/src/account/service/account-balance-incremental.service.ts
+++ b/packages/app/src/account/service/account-balance-incremental.service.ts
@@ -6,11 +6,12 @@ import { getErrorMessage, isDefined, isEmptyArray } from '@rnw-community/shared'
 
 import { accountBalanceRepository, accountRepository } from '../../@generic/drizzle/db/db';
 import { ACCOUNT_BALANCE_INCREMENTAL_TASK } from '../constant/account-balance-incremental-task.constant';
-import { ONE_WEEK_IN_SECONDS } from '../constant/one-week-in-seconds.constant';
 
 import type { AccountBalanceCreateEntityInterface, AccountBalanceEntityInterface, DB } from '@budgie/contracts';
 
 class AccountBalanceIncrementalService {
+    private static readonly BACKGROUND_TASK_MINIMUM_INTERVAL_MINUTES = 7 * 24 * 60;
+
     @Log(
         (truncate, tx) => `enter truncate=${String(truncate)} tx=${String(isDefined(tx))}`,
         (result, truncate, tx) => `done truncate=${String(truncate)} tx=${String(isDefined(tx))} result=${String(result)}`,
@@ -43,7 +44,7 @@ class AccountBalanceIncrementalService {
         }
 
         await BackgroundTask.registerTaskAsync(ACCOUNT_BALANCE_INCREMENTAL_TASK, {
-            minimumInterval: ONE_WEEK_IN_SECONDS
+            minimumInterval: AccountBalanceIncrementalService.BACKGROUND_TASK_MINIMUM_INTERVAL_MINUTES
         });
     }
 

--- a/packages/app/src/account/task/account-balance-incremental.task.ts
+++ b/packages/app/src/account/task/account-balance-incremental.task.ts
@@ -1,12 +1,13 @@
 import * as BackgroundTask from 'expo-background-task';
 import * as TaskManager from 'expo-task-manager';
 
+import { syncWorkloadService } from '../../sync/service/sync-workload.service';
 import { ACCOUNT_BALANCE_INCREMENTAL_TASK } from '../constant/account-balance-incremental-task.constant';
 import { accountBalanceIncrementalService } from '../service/account-balance-incremental.service';
 
 TaskManager.defineTask(ACCOUNT_BALANCE_INCREMENTAL_TASK, async () => {
     try {
-        await accountBalanceIncrementalService.updateAllBalances(false);
+        await syncWorkloadService.run('background-account-balance', () => accountBalanceIncrementalService.updateAllBalances(false));
     } catch {
         return BackgroundTask.BackgroundTaskResult.Failed;
     }

--- a/packages/app/src/app/root-layout-content.tsx
+++ b/packages/app/src/app/root-layout-content.tsx
@@ -50,6 +50,7 @@ import { I18nProvider } from '../i18n/provider/i18n.provider';
 import { i18nGetOSLocale } from '../i18n/util/i18n.util';
 import { SettingsProvider } from '../settings/provider/settings.provider';
 import { monobankSyncService } from '../sync/service/monobank-sync.service';
+import { syncWorkloadService } from '../sync/service/sync-workload.service';
 import { ThemeProvider } from '../theme/provider/theme.provider';
 
 enableScreens();
@@ -60,7 +61,11 @@ i18n.activate(i18nGetOSLocale());
 void SplashScreen.preventAutoHideAsync();
 
 const SQLOptions = { enableChangeListener: true };
-const handleAppStateChange = (isActive: boolean) => void (isActive && monobankSyncService.sync());
+const handleAppStateChange = (isActive: boolean): void => {
+    if (isActive) {
+        void syncWorkloadService.run('foreground-monobank', () => monobankSyncService.sync());
+    }
+};
 
 // eslint-disable-next-line max-lines-per-function -- Layout component requires many lines
 export const RootLayoutContent = () => {

--- a/packages/app/src/auth/constant/pin-secure-store-options.constant.ts
+++ b/packages/app/src/auth/constant/pin-secure-store-options.constant.ts
@@ -1,0 +1,5 @@
+import * as SecureStore from 'expo-secure-store';
+
+export const PIN_SECURE_STORE_OPTIONS: SecureStore.SecureStoreOptions = {
+    keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY
+};

--- a/packages/app/src/auth/service/auth.service.ts
+++ b/packages/app/src/auth/service/auth.service.ts
@@ -1,8 +1,9 @@
 /* eslint-disable lingui/no-unlocalized-strings */
+import { Log } from '@budgie/logger';
 import * as LocalAuthentication from 'expo-local-authentication';
 import * as SecureStore from 'expo-secure-store';
 
-import { isNotEmptyString } from '@rnw-community/shared';
+import { getErrorMessage, isNotEmptyString } from '@rnw-community/shared';
 
 import { databaseRekeyService } from '../../@generic/drizzle/service/database-rekey.service';
 import { RekeyParamsInterface } from '../../@generic/drizzle/service/interface/rekey-params.interface';
@@ -12,6 +13,15 @@ import { PIN_SECURE_STORE_OPTIONS } from '../constant/pin-secure-store-options.c
 import { BiometricTypesInterface } from '../interface/biometric-types.interface';
 
 class AuthService {
+    @Log('enter', 'done', error => `throw error=${getErrorMessage(error)}`)
+    async ensurePinBackgroundAccessibility(): Promise<void> {
+        const pin = await this.getPin();
+
+        if (isNotEmptyString(pin)) {
+            await this.persistPin(pin);
+        }
+    }
+
     async getBiometricTypes(): Promise<BiometricTypesInterface> {
         try {
             const hasHardware = await LocalAuthentication.hasHardwareAsync();
@@ -91,14 +101,6 @@ class AuthService {
 
     async clearAllPins(): Promise<void> {
         await SecureStore.deleteItemAsync(PIN_KEY, PIN_SECURE_STORE_OPTIONS);
-    }
-
-    async ensurePinBackgroundAccessibility(): Promise<void> {
-        const pin = await this.getPin();
-
-        if (isNotEmptyString(pin)) {
-            await this.persistPin(pin);
-        }
     }
 
     private async rekeyDatabase(params: RekeyParamsInterface): Promise<void> {

--- a/packages/app/src/auth/service/auth.service.ts
+++ b/packages/app/src/auth/service/auth.service.ts
@@ -8,6 +8,7 @@ import { databaseRekeyService } from '../../@generic/drizzle/service/database-re
 import { RekeyParamsInterface } from '../../@generic/drizzle/service/interface/rekey-params.interface';
 import { reloadApp } from '../../@generic/utils/reload-app.util';
 import { PIN_KEY } from '../constant/pin-key.constant';
+import { PIN_SECURE_STORE_OPTIONS } from '../constant/pin-secure-store-options.constant';
 import { BiometricTypesInterface } from '../interface/biometric-types.interface';
 
 class AuthService {
@@ -69,7 +70,7 @@ class AuthService {
     }
 
     async verifyPin(pin: string): Promise<boolean> {
-        const savedPin = await SecureStore.getItemAsync(PIN_KEY);
+        const savedPin = await SecureStore.getItemAsync(PIN_KEY, PIN_SECURE_STORE_OPTIONS);
 
         return savedPin === pin;
     }
@@ -85,11 +86,19 @@ class AuthService {
     }
 
     async getPin(): Promise<string | null> {
-        return SecureStore.getItemAsync(PIN_KEY);
+        return SecureStore.getItemAsync(PIN_KEY, PIN_SECURE_STORE_OPTIONS);
     }
 
     async clearAllPins(): Promise<void> {
-        await SecureStore.deleteItemAsync(PIN_KEY);
+        await SecureStore.deleteItemAsync(PIN_KEY, PIN_SECURE_STORE_OPTIONS);
+    }
+
+    async ensurePinBackgroundAccessibility(): Promise<void> {
+        const pin = await this.getPin();
+
+        if (isNotEmptyString(pin)) {
+            await this.persistPin(pin);
+        }
     }
 
     private async rekeyDatabase(params: RekeyParamsInterface): Promise<void> {
@@ -106,9 +115,9 @@ class AuthService {
 
     private async persistPin(pin: string | null): Promise<void> {
         if (isNotEmptyString(pin)) {
-            await SecureStore.setItemAsync(PIN_KEY, pin);
+            await SecureStore.setItemAsync(PIN_KEY, pin, PIN_SECURE_STORE_OPTIONS);
         } else {
-            await SecureStore.deleteItemAsync(PIN_KEY);
+            await SecureStore.deleteItemAsync(PIN_KEY, PIN_SECURE_STORE_OPTIONS);
         }
     }
 

--- a/packages/app/src/exchange-rate/constant/one-hour-in-seconds.constant.ts
+++ b/packages/app/src/exchange-rate/constant/one-hour-in-seconds.constant.ts
@@ -1,1 +1,0 @@
-export const ONE_HOUR_IN_SECONDS = 60 * 60;

--- a/packages/app/src/exchange-rate/service/exchange-rates-sync.service.ts
+++ b/packages/app/src/exchange-rate/service/exchange-rates-sync.service.ts
@@ -1,7 +1,8 @@
+import { Log } from '@budgie/logger';
 import * as BackgroundTask from 'expo-background-task';
 import * as TaskManager from 'expo-task-manager';
 
-import { isDefined, isPositiveNumber } from '@rnw-community/shared';
+import { getErrorMessage, isDefined, isPositiveNumber } from '@rnw-community/shared';
 
 import { exchangeRateRepository, instrumentRepository } from '../../@generic/drizzle/db/db';
 import { EXCHANGE_RATE_SYNC_TASK } from '../constant/exchange-rate-sync-task.constant';
@@ -11,6 +12,17 @@ import { exchangeRatesService } from './exchange-rates.service';
 
 class ExchangeRatesSyncService {
     private static readonly BACKGROUND_TASK_MINIMUM_INTERVAL_MINUTES = 60;
+
+    @Log('enter', 'done', error => `throw error=${getErrorMessage(error)}`)
+    async registerBackgroundTask(): Promise<void> {
+        if (await TaskManager.isTaskRegisteredAsync(EXCHANGE_RATE_SYNC_TASK)) {
+            return;
+        }
+
+        await BackgroundTask.registerTaskAsync(EXCHANGE_RATE_SYNC_TASK, {
+            minimumInterval: ExchangeRatesSyncService.BACKGROUND_TASK_MINIMUM_INTERVAL_MINUTES
+        });
+    }
 
     async sync(): Promise<void> {
         const baseInstrument = await exchangeRatesService.getBaseInstrument();
@@ -27,16 +39,6 @@ class ExchangeRatesSyncService {
                 await this.updateInstrumentRate(baseInstrument.id, instrument, apiData.rates);
             }
         }
-    }
-
-    async registerBackgroundTask(): Promise<void> {
-        if (await TaskManager.isTaskRegisteredAsync(EXCHANGE_RATE_SYNC_TASK)) {
-            return;
-        }
-
-        await BackgroundTask.registerTaskAsync(EXCHANGE_RATE_SYNC_TASK, {
-            minimumInterval: ExchangeRatesSyncService.BACKGROUND_TASK_MINIMUM_INTERVAL_MINUTES
-        });
     }
 
     private async fetch(code: string): Promise<ExchangeRateApiResponseInterface> {

--- a/packages/app/src/exchange-rate/service/exchange-rates-sync.service.ts
+++ b/packages/app/src/exchange-rate/service/exchange-rates-sync.service.ts
@@ -5,12 +5,13 @@ import { isDefined, isPositiveNumber } from '@rnw-community/shared';
 
 import { exchangeRateRepository, instrumentRepository } from '../../@generic/drizzle/db/db';
 import { EXCHANGE_RATE_SYNC_TASK } from '../constant/exchange-rate-sync-task.constant';
-import { ONE_HOUR_IN_SECONDS } from '../constant/one-hour-in-seconds.constant';
 import { ExchangeRateApiResponseInterface, emptyExchangeRateApiResponse } from '../interface/exchange-rate-api-response.interface';
 
 import { exchangeRatesService } from './exchange-rates.service';
 
 class ExchangeRatesSyncService {
+    private static readonly BACKGROUND_TASK_MINIMUM_INTERVAL_MINUTES = 60;
+
     async sync(): Promise<void> {
         const baseInstrument = await exchangeRatesService.getBaseInstrument();
 
@@ -34,7 +35,7 @@ class ExchangeRatesSyncService {
         }
 
         await BackgroundTask.registerTaskAsync(EXCHANGE_RATE_SYNC_TASK, {
-            minimumInterval: ONE_HOUR_IN_SECONDS
+            minimumInterval: ExchangeRatesSyncService.BACKGROUND_TASK_MINIMUM_INTERVAL_MINUTES
         });
     }
 

--- a/packages/app/src/exchange-rate/task/exchange-rate-sync.task.ts
+++ b/packages/app/src/exchange-rate/task/exchange-rate-sync.task.ts
@@ -1,12 +1,13 @@
 import * as BackgroundTask from 'expo-background-task';
 import * as TaskManager from 'expo-task-manager';
 
+import { syncWorkloadService } from '../../sync/service/sync-workload.service';
 import { EXCHANGE_RATE_SYNC_TASK } from '../constant/exchange-rate-sync-task.constant';
 import { exchangeRatesSyncService } from '../service/exchange-rates-sync.service';
 
 TaskManager.defineTask(EXCHANGE_RATE_SYNC_TASK, async () => {
     try {
-        await exchangeRatesSyncService.sync();
+        await syncWorkloadService.run('background-exchange-rates', () => exchangeRatesSyncService.sync());
     } catch {
         return BackgroundTask.BackgroundTaskResult.Failed;
     }

--- a/packages/app/src/sync/constant/time.constant.ts
+++ b/packages/app/src/sync/constant/time.constant.ts
@@ -1,1 +1,0 @@
-export const THIRTY_MINUTES_IN_SECONDS = 30 * 60;

--- a/packages/app/src/sync/service/monobank-sync.service.ts
+++ b/packages/app/src/sync/service/monobank-sync.service.ts
@@ -9,7 +9,7 @@ import { getErrorMessage, isDefined, isNotEmptyArray, isNotEmptyString, isPositi
 
 import { accountRepository, bankSyncRepository } from '../../@generic/drizzle/db/db';
 import { microPause } from '../../@generic/utils/micro-pause.util';
-import { FIFTEEN_MINUTES_IN_SECONDS, TWO_MINUTES_IN_SECONDS } from '../../account/constant/minutes-in-seconds.constant';
+import { TWO_MINUTES_IN_SECONDS } from '../../account/constant/minutes-in-seconds.constant';
 import { ruleApplicationDrainerService } from '../../rule/service/rule-application-drainer.service';
 import { ruleEngineService } from '../../rule/service/rule-engine.service';
 import { transactionService } from '../../transaction/service/transaction.service';
@@ -31,6 +31,7 @@ import type { AccountEntityInterface, BankSyncEntityInterface, MccCategoryLookup
 const logger = getLogger('AppMonobankSyncService');
 
 class AppMonobankSyncService {
+    private static readonly BACKGROUND_TASK_MINIMUM_INTERVAL_MINUTES = 15;
     private static readonly FORWARD_SYNC_STALE_THRESHOLD_MS = TWO_MINUTES_IN_SECONDS * 1000;
 
     private readonly provider = ExternalSourceEnum.MONOBANK;
@@ -310,7 +311,9 @@ class AppMonobankSyncService {
         if (await TaskManager.isTaskRegisteredAsync(MONOBANK_SYNC_TASK)) {
             await BackgroundTask.unregisterTaskAsync(MONOBANK_SYNC_TASK);
         }
-        await BackgroundTask.registerTaskAsync(MONOBANK_SYNC_TASK, { minimumInterval: FIFTEEN_MINUTES_IN_SECONDS });
+        await BackgroundTask.registerTaskAsync(MONOBANK_SYNC_TASK, {
+            minimumInterval: AppMonobankSyncService.BACKGROUND_TASK_MINIMUM_INTERVAL_MINUTES
+        });
     }
 
     private async processPendingSyncs(): Promise<BackgroundTask.BackgroundTaskResult> {

--- a/packages/app/src/sync/service/monobank-sync.service.ts
+++ b/packages/app/src/sync/service/monobank-sync.service.ts
@@ -71,6 +71,16 @@ class AppMonobankSyncService {
         return mapBankAccountsToPreview(bankAccounts, this.provider);
     }
 
+    @Log('enter', 'done', error => `throw error=${getErrorMessage(error)}`)
+    async registerBackgroundTask(): Promise<void> {
+        if (await TaskManager.isTaskRegisteredAsync(MONOBANK_SYNC_TASK)) {
+            await BackgroundTask.unregisterTaskAsync(MONOBANK_SYNC_TASK);
+        }
+        await BackgroundTask.registerTaskAsync(MONOBANK_SYNC_TASK, {
+            minimumInterval: AppMonobankSyncService.BACKGROUND_TASK_MINIMUM_INTERVAL_MINUTES
+        });
+    }
+
     @Log(
         'enter',
         result =>
@@ -305,15 +315,6 @@ class AppMonobankSyncService {
         if (enabled) {
             void this.sync();
         }
-    }
-
-    async registerBackgroundTask(): Promise<void> {
-        if (await TaskManager.isTaskRegisteredAsync(MONOBANK_SYNC_TASK)) {
-            await BackgroundTask.unregisterTaskAsync(MONOBANK_SYNC_TASK);
-        }
-        await BackgroundTask.registerTaskAsync(MONOBANK_SYNC_TASK, {
-            minimumInterval: AppMonobankSyncService.BACKGROUND_TASK_MINIMUM_INTERVAL_MINUTES
-        });
     }
 
     private async processPendingSyncs(): Promise<BackgroundTask.BackgroundTaskResult> {

--- a/packages/app/src/sync/service/monobank-sync.service.ts
+++ b/packages/app/src/sync/service/monobank-sync.service.ts
@@ -308,7 +308,7 @@ class AppMonobankSyncService {
 
     async registerBackgroundTask(): Promise<void> {
         if (await TaskManager.isTaskRegisteredAsync(MONOBANK_SYNC_TASK)) {
-            return;
+            await BackgroundTask.unregisterTaskAsync(MONOBANK_SYNC_TASK);
         }
         await BackgroundTask.registerTaskAsync(MONOBANK_SYNC_TASK, { minimumInterval: FIFTEEN_MINUTES_IN_SECONDS });
     }

--- a/packages/app/src/sync/service/resync-bank-sync.service.ts
+++ b/packages/app/src/sync/service/resync-bank-sync.service.ts
@@ -8,6 +8,7 @@ import { microPause } from '../../@generic/utils/micro-pause.util';
 import { unconsolidateByIdInTransaction } from '../../transaction/utils/unconsolidate-by-id-in-transaction.util';
 
 import { monobankSyncService } from './monobank-sync.service';
+import { syncWorkloadService } from './sync-workload.service';
 
 import type { ResyncBankSyncInputInterface } from '../interface/resync-bank-sync-input.interface';
 import type { DB, TransactionEntityInterface } from '@budgie/contracts';
@@ -30,7 +31,7 @@ class ResyncBankSyncService {
             }
         });
 
-        monobankSyncService.sync().catch(emptyFn);
+        syncWorkloadService.run('manual-monobank-resync', () => monobankSyncService.sync()).catch(emptyFn);
     }
 
     private async resyncFull(accountId: number, tx: DB): Promise<void> {

--- a/packages/app/src/sync/service/sync-workload.service.ts
+++ b/packages/app/src/sync/service/sync-workload.service.ts
@@ -1,0 +1,21 @@
+import { Log } from '@budgie/logger';
+
+import { emptyFn, getErrorMessage } from '@rnw-community/shared';
+
+class SyncWorkloadService {
+    private queue: Promise<unknown> = Promise.resolve();
+
+    @Log(
+        (name, work) => `enter name="${name}" workName="${work.name}"`,
+        (result, name, work) => `done name="${name}" workName="${work.name}" result=${String(result)}`,
+        (error, name, work) => `throw name="${name}" workName="${work.name}" error=${getErrorMessage(error)}`
+    )
+    async run<T>(name: string, work: () => Promise<T>): Promise<T> {
+        const current = this.queue.then(work, work);
+        this.queue = current.catch(() => void emptyFn(name));
+
+        return current;
+    }
+}
+
+export const syncWorkloadService = new SyncWorkloadService();

--- a/packages/app/src/sync/service/sync-workload.service.ts
+++ b/packages/app/src/sync/service/sync-workload.service.ts
@@ -12,7 +12,7 @@ class SyncWorkloadService {
     )
     async run<T>(name: string, work: () => Promise<T>): Promise<T> {
         const current = this.queue.then(work, work);
-        this.queue = current.catch(() => void emptyFn(name));
+        this.queue = current.catch((error: unknown) => void emptyFn(error, name));
 
         return current;
     }

--- a/packages/app/src/sync/service/transfer-consolidation-drainer.service.ts
+++ b/packages/app/src/sync/service/transfer-consolidation-drainer.service.ts
@@ -7,6 +7,7 @@ import { foregroundWorkloadService } from '../../@generic/service/foreground-wor
 import { scheduleIdleCallback } from '../../@generic/utils/schedule-idle-callback.util';
 import { TransferConsolidationDrainReasonEnum } from '../enum/transfer-consolidation-drain-reason.enum';
 
+import { syncWorkloadService } from './sync-workload.service';
 import { transferConsolidationService } from './transfer-consolidation.service';
 
 class TransferConsolidationDrainerService {
@@ -56,7 +57,7 @@ class TransferConsolidationDrainerService {
         try {
             while (this.hasPendingRun) {
                 this.hasPendingRun = false;
-                await transferConsolidationService.consolidate();
+                await syncWorkloadService.run('transfer-consolidation-drain', () => transferConsolidationService.consolidate());
             }
         } finally {
             this.isRunning = false;

--- a/packages/app/src/sync/service/transfer-consolidation.service.ts
+++ b/packages/app/src/sync/service/transfer-consolidation.service.ts
@@ -6,7 +6,6 @@ import { emptyFn, getErrorMessage, isDefined, isPositiveNumber } from '@rnw-comm
 
 import { foregroundWorkloadService } from '../../@generic/service/foreground-workload.service';
 import { accountBalanceIncrementalService } from '../../account/service/account-balance-incremental.service';
-import { THIRTY_MINUTES_IN_SECONDS } from '../constant/time.constant';
 import { TRANSFER_CONSOLIDATION_TASK } from '../constant/transfer-consolidation-task.constant';
 
 import { transferConsolidationAutoCandidateService } from './transfer-consolidation-auto-candidate.service';
@@ -22,6 +21,8 @@ import type {
 const logger = getLogger('TransferConsolidationService');
 
 class TransferConsolidationService {
+    private static readonly BACKGROUND_TASK_MINIMUM_INTERVAL_MINUTES = 30;
+
     private activeOperation: Promise<unknown> | null = null;
     private isRunning = false;
 
@@ -32,7 +33,7 @@ class TransferConsolidationService {
         }
 
         await BackgroundTask.registerTaskAsync(TRANSFER_CONSOLIDATION_TASK, {
-            minimumInterval: THIRTY_MINUTES_IN_SECONDS
+            minimumInterval: TransferConsolidationService.BACKGROUND_TASK_MINIMUM_INTERVAL_MINUTES
         });
     }
 

--- a/packages/app/src/sync/task/monobank-sync.task.ts
+++ b/packages/app/src/sync/task/monobank-sync.task.ts
@@ -6,13 +6,14 @@ import { getErrorMessage } from '@rnw-community/shared';
 
 import { MONOBANK_SYNC_TASK } from '../constant/monobank-sync-task.constant';
 import { monobankSyncService } from '../service/monobank-sync.service';
+import { syncWorkloadService } from '../service/sync-workload.service';
 
 const logger = getLogger('monobankSyncTask');
 
 TaskManager.defineTask(MONOBANK_SYNC_TASK, async () => {
     logger.log('enter');
     try {
-        const result = await monobankSyncService.sync();
+        const result = await syncWorkloadService.run('background-monobank', () => monobankSyncService.sync());
         logger.log('done', { result });
 
         return result;

--- a/packages/app/src/sync/task/monobank-sync.task.ts
+++ b/packages/app/src/sync/task/monobank-sync.task.ts
@@ -1,25 +1,14 @@
-import { getLogger } from '@budgie/logger';
 import * as BackgroundTask from 'expo-background-task';
 import * as TaskManager from 'expo-task-manager';
-
-import { getErrorMessage } from '@rnw-community/shared';
 
 import { MONOBANK_SYNC_TASK } from '../constant/monobank-sync-task.constant';
 import { monobankSyncService } from '../service/monobank-sync.service';
 import { syncWorkloadService } from '../service/sync-workload.service';
 
-const logger = getLogger('monobankSyncTask');
-
 TaskManager.defineTask(MONOBANK_SYNC_TASK, async () => {
-    logger.log('enter');
     try {
-        const result = await syncWorkloadService.run('background-monobank', () => monobankSyncService.sync());
-        logger.log('done', { result });
-
-        return result;
-    } catch (error) {
-        logger.error('throw', { errorMessage: getErrorMessage(error) });
-
+        return await syncWorkloadService.run('background-monobank', () => monobankSyncService.sync());
+    } catch {
         return BackgroundTask.BackgroundTaskResult.Failed;
     }
 });

--- a/packages/app/src/sync/task/transfer-consolidation.task.ts
+++ b/packages/app/src/sync/task/transfer-consolidation.task.ts
@@ -5,6 +5,7 @@ import * as TaskManager from 'expo-task-manager';
 import { getErrorMessage } from '@rnw-community/shared';
 
 import { TRANSFER_CONSOLIDATION_TASK } from '../constant/transfer-consolidation-task.constant';
+import { syncWorkloadService } from '../service/sync-workload.service';
 import { transferConsolidationService } from '../service/transfer-consolidation.service';
 
 const logger = getLogger('transferConsolidationTask');
@@ -12,7 +13,9 @@ const logger = getLogger('transferConsolidationTask');
 TaskManager.defineTask(TRANSFER_CONSOLIDATION_TASK, async () => {
     logger.log('enter');
     try {
-        const { found, consolidated } = await transferConsolidationService.consolidate();
+        const { found, consolidated } = await syncWorkloadService.run('background-transfer-consolidation', () =>
+            transferConsolidationService.consolidate()
+        );
         logger.log('done', { found, consolidated });
 
         return BackgroundTask.BackgroundTaskResult.Success;

--- a/packages/app/src/sync/task/transfer-consolidation.task.ts
+++ b/packages/app/src/sync/task/transfer-consolidation.task.ts
@@ -1,27 +1,16 @@
-import { getLogger } from '@budgie/logger';
 import * as BackgroundTask from 'expo-background-task';
 import * as TaskManager from 'expo-task-manager';
-
-import { getErrorMessage } from '@rnw-community/shared';
 
 import { TRANSFER_CONSOLIDATION_TASK } from '../constant/transfer-consolidation-task.constant';
 import { syncWorkloadService } from '../service/sync-workload.service';
 import { transferConsolidationService } from '../service/transfer-consolidation.service';
 
-const logger = getLogger('transferConsolidationTask');
-
 TaskManager.defineTask(TRANSFER_CONSOLIDATION_TASK, async () => {
-    logger.log('enter');
     try {
-        const { found, consolidated } = await syncWorkloadService.run('background-transfer-consolidation', () =>
-            transferConsolidationService.consolidate()
-        );
-        logger.log('done', { found, consolidated });
+        await syncWorkloadService.run('background-transfer-consolidation', () => transferConsolidationService.consolidate());
 
         return BackgroundTask.BackgroundTaskResult.Success;
-    } catch (error) {
-        logger.error('throw', { errorMessage: getErrorMessage(error) });
-
+    } catch {
         return BackgroundTask.BackgroundTaskResult.Failed;
     }
 });


### PR DESCRIPTION
Follow-up to #534 after dev-client testing showed background sync still did not run.

Summary:
- Re-register Monobank background task when already present so stale dev-client registrations pick up the 15-minute interval.
- Register background tasks in sequence with Monobank last because Expo background tasks share one worker interval.
- Store and read the PIN with AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY so locked-device background wakes can open the encrypted database after first unlock.

Testing:
- yarn format
- yarn ts
- yarn lint (passes with existing use-suggestion-base exhaustive-deps warning)
- yarn deadcode
- yarn cpd
- yarn workspace @budgie-at/bank-sync-tests test src/scenarios/monobank

Fixes #532

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable PIN storage/retrieval with consistent secure-store options, improving background access and task registration.
  * Background sync/registration now consistently (re)registers tasks to avoid missed jobs.

* **New Features**
  * Added a workload runner to serialize and supervise background/foreground sync jobs.

* **Refactor**
  * Startup initialization now defers and sequences service syncs and task registration; background registration is gated by PIN accessibility.

* **Chores**
  * Several exported timing constants replaced with internal interval values for simpler scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->