### PR TITLE
fix(app): ignore package scripts in fingerprint

### DIFF
--- a/packages/app/fingerprint.config.js
+++ b/packages/app/fingerprint.config.js
@@ -3,7 +3,7 @@ const config = {
     sourceSkips: [
         'ExpoConfigRuntimeVersionIfString',
         'ExpoConfigVersions',
-        'PackageJsonAndroidAndIosScriptsIfNotContainRun',
+        'PackageJsonScriptsAll',
         'ExpoConfigIosBundleIdentifier',
         'ExpoConfigAndroidPackage',
         'ExpoConfigNames'


### PR DESCRIPTION
## Summary

- Replace the narrower Expo fingerprint script skip with `PackageJsonScriptsAll`.
- Prevent local/CI `package.json` script edits from changing the EAS fingerprint runtime lane.

## Root cause

The production update runtime drift was caused by `packageJson:scripts`. The previous skip, `PackageJsonAndroidAndIosScriptsIfNotContainRun`, still included scripts such as `expo run:ios`, so adding `EXPO_PUBLIC_AI_DISABLE=true` changed the runtime hash even though no native runtime compatibility changed.

## Verification

- `fingerprint:generate --platform ios --source-skips 1055 --debug` on `96699a0f` and `49827dc6`
- `fingerprint:diff /tmp/budgie-fp-verify-966-newskip.json /tmp/budgie-fp-verify-498-newskip.json` returned `[]`
- Both hashes matched: `f510cf34079833aceead3fe85a8697190df02597`
- `packageJson:scripts` source count was `0` in both fingerprints
- `yarn format && yarn ts && yarn lint && yarn deadcode && yarn cpd` exited `0`

Known existing validation noise:

- `yarn lint` reports one existing `react-hooks/exhaustive-deps` warning in `packages/app/src/ai/hook/use-suggestion-base.hook.ts`.
- `yarn deadcode` reports existing Knip configuration hints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated fingerprint configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->