### PR TITLE
fix(app): render debt account settings form

### DIFF
--- a/packages/app/src/account/hooks/use-debt-account-form.hook.ts
+++ b/packages/app/src/account/hooks/use-debt-account-form.hook.ts
@@ -1,11 +1,4 @@
-import {
-    AccountDebtTypeEnum,
-    AccountEntityInterface,
-    AccountTypeEnum,
-    DebtAccountCreateInputInterface,
-    DebtAccountCreateInputSchema,
-    UserIconNameEnum
-} from '@budgie/contracts';
+import { AccountEntityInterface, DebtAccountCreateInputInterface, DebtAccountCreateInputSchema } from '@budgie/contracts';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { router } from 'expo-router';
 import { Resolver, useForm, useWatch } from 'react-hook-form';
@@ -20,25 +13,15 @@ interface DebtAccountFormValues extends Omit<DebtAccountCreateInputInterface, 'c
 }
 
 export const useDebtAccountForm = (
-    defaultValues: DebtAccountFormValues,
+    initialValues: DebtAccountFormValues,
     onSubmit: (values: DebtAccountFormValues) => Promise<AccountEntityInterface>
 ) => {
     const showError = useShowError();
     const form = useForm<DebtAccountFormValues>({
         resolver: zodResolver(DebtAccountCreateInputSchema) as Resolver<DebtAccountFormValues>,
         mode: 'onSubmit',
-        defaultValues: {
-            debtType: AccountDebtTypeEnum.LENT,
-            icon: UserIconNameEnum.Home,
-            type: AccountTypeEnum.DEBT,
-            targetBalance: 0,
-            instrumentId: 0,
-            includeInNetWorth: false,
-            contactId: null,
-            deadline: null,
-            title: ''
-        },
-        values: defaultValues
+        defaultValues: initialValues,
+        values: initialValues
     });
 
     const [instrumentId, debtType] = useWatch({


### PR DESCRIPTION
## Summary

- Initialize the debt account form from the caller-provided account values instead of a hardcoded placeholder object.
- Prevent the debt account settings screen from rendering `EmptyScreen` while the watched instrument id starts at `0`.

## Root Cause

The debt account form hook had an internal fallback `instrumentId: 0`. The update screen watches `instrumentId`, queries the matching instrument, and returns the black `EmptyScreen` when no instrument is found. Debt account settings could therefore appear as an empty black screen before the form picked up the real account values.

## Validation

- `yarn install`
- `yarn format`
- `yarn ts`
- `yarn lint` (exits 0; existing unrelated warning in `packages/app/src/ai/hook/use-suggestion-base.hook.ts`)
- `yarn deadcode`
- `yarn cpd`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced debt account form initialization for improved flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->