### PR TITLE
refactor: simplify bank import dedupe helpers

### DIFF
--- a/packages/bank-sync/src/core/util/generate-stable-external-id-hash.util.ts
+++ b/packages/bank-sync/src/core/util/generate-stable-external-id-hash.util.ts
@@ -1,0 +1,34 @@
+const FNV_OFFSET_BASIS = 0x811c9dc5;
+const FNV_PRIME = 0x01000193;
+
+/* eslint-disable no-bitwise, no-plusplus -- FNV-1a hash requires bitwise operations */
+export const generateStableExternalIdHash = (input: string): string => {
+    let hash1 = FNV_OFFSET_BASIS;
+    let hash2 = FNV_OFFSET_BASIS;
+    let hash3 = FNV_OFFSET_BASIS;
+    let hash4 = FNV_OFFSET_BASIS;
+
+    for (let index = 0; index < input.length; index++) {
+        const charCode = input.charCodeAt(index);
+
+        hash1 ^= charCode;
+        hash1 = Math.imul(hash1, FNV_PRIME);
+
+        hash2 ^= charCode ^ (index & 0xff);
+        hash2 = Math.imul(hash2, FNV_PRIME);
+
+        hash3 ^= (charCode + index) & 0xff;
+        hash3 = Math.imul(hash3, FNV_PRIME);
+
+        hash4 ^= charCode ^ ((index * 31) & 0xff);
+        hash4 = Math.imul(hash4, FNV_PRIME);
+    }
+
+    const part1 = (hash1 >>> 0).toString(16).padStart(8, '0');
+    const part2 = (hash2 >>> 0).toString(16).padStart(8, '0');
+    const part3 = (hash3 >>> 0).toString(16).padStart(8, '0');
+    const part4 = (hash4 >>> 0).toString(16).padStart(8, '0');
+
+    return `${part1}${part2}${part3}${part4}`;
+};
+/* eslint-enable no-bitwise, no-plusplus */

--- a/packages/bank-sync/src/erste/mapper/erste.mapper.ts
+++ b/packages/bank-sync/src/erste/mapper/erste.mapper.ts
@@ -6,6 +6,7 @@ import { getErrorMessage, isNotEmptyString } from '@rnw-community/shared';
 import { BankAccountTypeEnum } from '../../core/enum/bank-account-type.enum';
 import { BankProviderEnum } from '../../core/enum/bank-provider.enum';
 import { BankTransactionTypeEnum } from '../../core/enum/bank-transaction-type.enum';
+import { generateStableExternalIdHash } from '../../core/util/generate-stable-external-id-hash.util';
 import { ERSTE_CURRENCY_CODE_EUR, ERSTE_EXTERNAL_ID_LENGTH } from '../constant/erste.constant';
 
 import type { BankAccountInterface } from '../../core/interface/bank-account.interface';
@@ -14,11 +15,6 @@ import type { ErsteAccountInfoInterface } from '../interface/erste-account-info.
 import type { ErsteRowInterface } from '../interface/erste-row.interface';
 
 class ErsteMapper {
-    // eslint-disable-next-line @typescript-eslint/no-magic-numbers -- FNV-1a 32-bit constants from RFC
-    private static readonly FNV_OFFSET_BASIS = 0x811c9dc5;
-    // eslint-disable-next-line @typescript-eslint/no-magic-numbers -- FNV-1a 32-bit constants from RFC
-    private static readonly FNV_PRIME = 0x01000193;
-
     @Log(
         account => `enter iban=${account.iban} newBalance=${account.newBalance}`,
         (result, account) => `done iban=${account.iban} accountId=${result.id}`,
@@ -86,7 +82,7 @@ class ErsteMapper {
             '|'
         );
 
-        return this.fnv1aHash(seed).slice(0, ERSTE_EXTERNAL_ID_LENGTH);
+        return generateStableExternalIdHash(seed).slice(0, ERSTE_EXTERNAL_ID_LENGTH);
     }
 
     private generateLegacyExternalId(row: ErsteRowInterface, iban: string): string {
@@ -101,7 +97,7 @@ class ErsteMapper {
             row.countryAlpha2 ?? ''
         ].join('|');
 
-        return this.fnv1aHash(seed).slice(0, ERSTE_EXTERNAL_ID_LENGTH);
+        return generateStableExternalIdHash(seed).slice(0, ERSTE_EXTERNAL_ID_LENGTH);
     }
 
     private buildStatementDateKey(date: Date): string {
@@ -111,40 +107,6 @@ class ErsteMapper {
 
         return `${year}-${month}-${day}`;
     }
-
-    /* jscpd:ignore-start */
-    /* eslint-disable no-bitwise, no-plusplus, max-statements -- FNV-1a hash requires bitwise operations */
-    private fnv1aHash(input: string): string {
-        let hash1 = ErsteMapper.FNV_OFFSET_BASIS;
-        let hash2 = ErsteMapper.FNV_OFFSET_BASIS;
-        let hash3 = ErsteMapper.FNV_OFFSET_BASIS;
-        let hash4 = ErsteMapper.FNV_OFFSET_BASIS;
-
-        for (let index = 0; index < input.length; index++) {
-            const charCode = input.charCodeAt(index);
-
-            hash1 ^= charCode;
-            hash1 = Math.imul(hash1, ErsteMapper.FNV_PRIME);
-
-            hash2 ^= charCode ^ (index & 0xff);
-            hash2 = Math.imul(hash2, ErsteMapper.FNV_PRIME);
-
-            hash3 ^= (charCode + index) & 0xff;
-            hash3 = Math.imul(hash3, ErsteMapper.FNV_PRIME);
-
-            hash4 ^= charCode ^ ((index * 31) & 0xff);
-            hash4 = Math.imul(hash4, ErsteMapper.FNV_PRIME);
-        }
-
-        const part1 = (hash1 >>> 0).toString(16).padStart(8, '0');
-        const part2 = (hash2 >>> 0).toString(16).padStart(8, '0');
-        const part3 = (hash3 >>> 0).toString(16).padStart(8, '0');
-        const part4 = (hash4 >>> 0).toString(16).padStart(8, '0');
-
-        return `${part1}${part2}${part3}${part4}`;
-    }
-    /* eslint-enable no-bitwise, no-plusplus, max-statements */
-    /* jscpd:ignore-end */
 }
 
 export const ersteMapper = new ErsteMapper();

--- a/packages/bank-sync/src/privatbank/util/generate-privatbank-external-id.util.ts
+++ b/packages/bank-sync/src/privatbank/util/generate-privatbank-external-id.util.ts
@@ -1,44 +1,10 @@
+import { generateStableExternalIdHash } from '../../core/util/generate-stable-external-id-hash.util';
 import { PRIVATBANK_EXTERNAL_ID_LENGTH } from '../constant/privatbank.constant';
 
 import type { PrivatbankExternalIdInputInterface } from '../interface/privatbank-external-id-input.interface';
 
-const FNV_OFFSET_BASIS = 0x811c9dc5;
-const FNV_PRIME = 0x01000193;
-
-/* eslint-disable no-bitwise, no-plusplus, max-statements -- FNV-1a hash requires bitwise operations */
-const fnv1aHash = (input: string): string => {
-    let hash1 = FNV_OFFSET_BASIS;
-    let hash2 = FNV_OFFSET_BASIS;
-    let hash3 = FNV_OFFSET_BASIS;
-    let hash4 = FNV_OFFSET_BASIS;
-
-    for (let index = 0; index < input.length; index++) {
-        const charCode = input.charCodeAt(index);
-
-        hash1 ^= charCode;
-        hash1 = Math.imul(hash1, FNV_PRIME);
-
-        hash2 ^= charCode ^ (index & 0xff);
-        hash2 = Math.imul(hash2, FNV_PRIME);
-
-        hash3 ^= (charCode + index) & 0xff;
-        hash3 = Math.imul(hash3, FNV_PRIME);
-
-        hash4 ^= charCode ^ ((index * 31) & 0xff);
-        hash4 = Math.imul(hash4, FNV_PRIME);
-    }
-
-    const part1 = (hash1 >>> 0).toString(16).padStart(8, '0');
-    const part2 = (hash2 >>> 0).toString(16).padStart(8, '0');
-    const part3 = (hash3 >>> 0).toString(16).padStart(8, '0');
-    const part4 = (hash4 >>> 0).toString(16).padStart(8, '0');
-
-    return `${part1}${part2}${part3}${part4}`;
-};
-/* eslint-enable no-bitwise, no-plusplus, max-statements */
-
 export const generatePrivatbankExternalId = (input: PrivatbankExternalIdInputInterface): string =>
-    fnv1aHash(
+    generateStableExternalIdHash(
         [
             input.rawDate,
             input.card,
@@ -51,7 +17,7 @@ export const generatePrivatbankExternalId = (input: PrivatbankExternalIdInputInt
     ).slice(0, PRIVATBANK_EXTERNAL_ID_LENGTH);
 
 export const generatePrivatbankLegacyExternalId = (input: PrivatbankExternalIdInputInterface): string =>
-    fnv1aHash(
+    generateStableExternalIdHash(
         [
             input.rawDate,
             input.card,


### PR DESCRIPTION
## Summary

- Extract the shared stable external-id hash used by Erste and PrivatBank into one bank-sync utility.
- Replace duplicate mapper-local hash implementations with the shared helper.

## Why

The merged dedupe fix introduced the same FNV-based stable hash implementation in two bank import paths. Keeping one implementation makes the generated external-id algorithm consistent across file import mappers and removes duplicated low-level bitwise code without changing the generated IDs.

## Validation

- `PATH=/opt/homebrew/bin:$PATH yarn workspace @budgie-at/bank-sync-tests test src/scenarios/import/imported-batch-idempotence.test.ts src/scenarios/privatbank/external-id.test.ts src/scenarios/erste/external-id.test.ts src/scenarios/erste/file-import-idempotency.test.ts src/scenarios/privatbank/duplicate-repair.test.ts`
- `PATH=/opt/homebrew/bin:$PATH yarn ts`
- `PATH=/opt/homebrew/bin:$PATH yarn lint`
- `PATH=/opt/homebrew/bin:$PATH yarn deadcode`
- `PATH=/opt/homebrew/bin:$PATH yarn cpd`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated transaction ID generation logic across bank sync modules to use a unified, deterministic hashing mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->