### PR TITLE
fix(app): stabilize imports, balances, and consolidation

### DIFF
--- a/packages/app/src/account/service/account-balance-incremental.service.ts
+++ b/packages/app/src/account/service/account-balance-incremental.service.ts
@@ -7,7 +7,7 @@ import { getErrorMessage, isDefined, isEmptyArray } from '@rnw-community/shared'
 import { accountBalanceRepository, accountRepository } from '../../@generic/drizzle/db/db';
 import { ACCOUNT_BALANCE_INCREMENTAL_TASK } from '../constant/account-balance-incremental-task.constant';
 
-import type { AccountBalanceCreateEntityInterface, AccountBalanceEntityInterface, DB } from '@budgie/contracts';
+import type { AccountBalanceCreateEntityInterface, AccountBalanceEntityInterface, AccountEntityInterface, DB } from '@budgie/contracts';
 
 class AccountBalanceIncrementalService {
     private static readonly BACKGROUND_TASK_MINIMUM_INTERVAL_MINUTES = 7 * 24 * 60;
@@ -19,6 +19,45 @@ class AccountBalanceIncrementalService {
     )
     async updateAllBalances(truncate: boolean, tx?: DB): Promise<void> {
         const accounts = await accountRepository.getAllActiveAccounts(tx);
+        await this.upsertLatestBalances(accounts, truncate, tx);
+    }
+
+    @Log(
+        (accountIds, tx) => `enter accountIds=${accountIds.join(',')} tx=${String(isDefined(tx))}`,
+        (_, accountIds, tx) => `done accountIds=${accountIds.join(',')} tx=${String(isDefined(tx))}`,
+        (error, accountIds, tx) => `throw accountIds=${accountIds.join(',')} tx=${String(isDefined(tx))} error=${getErrorMessage(error)}`
+    )
+    async updateBalancesByAccountIds(accountIds: number[], tx?: DB): Promise<void> {
+        const uniqueAccountIds = [...new Set(accountIds)];
+
+        if (isEmptyArray(uniqueAccountIds)) {
+            return;
+        }
+
+        const accounts = await accountRepository.findByIds(uniqueAccountIds, tx);
+        if (isEmptyArray(accounts)) {
+            return;
+        }
+
+        const activeAccountIds = accounts.map(({ id }) => id);
+
+        await accountBalanceRepository.deleteByAccountIds(activeAccountIds, tx);
+        await this.upsertLatestBalances(accounts, false, tx);
+    }
+
+    @Log('enter', result => `done result=${String(result)}`, error => `throw error=${getErrorMessage(error)}`)
+    async registerBackgroundTask(): Promise<void> {
+        const isRegistered = await TaskManager.isTaskRegisteredAsync(ACCOUNT_BALANCE_INCREMENTAL_TASK);
+        if (isRegistered) {
+            return;
+        }
+
+        await BackgroundTask.registerTaskAsync(ACCOUNT_BALANCE_INCREMENTAL_TASK, {
+            minimumInterval: AccountBalanceIncrementalService.BACKGROUND_TASK_MINIMUM_INTERVAL_MINUTES
+        });
+    }
+
+    private async upsertLatestBalances(accounts: AccountEntityInterface[], truncate: boolean, tx?: DB): Promise<void> {
         if (isEmptyArray(accounts)) {
             return;
         }
@@ -34,18 +73,6 @@ class AccountBalanceIncrementalService {
         const balancesToInsert = accounts.map(account => this.buildBalanceInput(account.id, balancesMap, deltaMap));
 
         await this.upsertBalances(balancesToInsert, tx);
-    }
-
-    @Log('enter', result => `done result=${String(result)}`, error => `throw error=${getErrorMessage(error)}`)
-    async registerBackgroundTask(): Promise<void> {
-        const isRegistered = await TaskManager.isTaskRegisteredAsync(ACCOUNT_BALANCE_INCREMENTAL_TASK);
-        if (isRegistered) {
-            return;
-        }
-
-        await BackgroundTask.registerTaskAsync(ACCOUNT_BALANCE_INCREMENTAL_TASK, {
-            minimumInterval: AccountBalanceIncrementalService.BACKGROUND_TASK_MINIMUM_INTERVAL_MINUTES
-        });
     }
 
     private buildBalancesMap(balances: AccountBalanceEntityInterface[]) {

--- a/packages/app/src/ai/hook/use-embedding-generator.hook.ts
+++ b/packages/app/src/ai/hook/use-embedding-generator.hook.ts
@@ -7,20 +7,16 @@ import { embeddingProgressStore } from '../store/embedding-progress.store';
 
 const logger = getLogger('useEmbeddingGenerator');
 
-interface MarkParamsInterface {
-    readonly transactionId: number;
-}
-
 interface UseEmbeddingGeneratorReturnInterface {
-    readonly markForEmbedding: (params: MarkParamsInterface) => void;
+    readonly markForEmbedding: (transactionId: number) => void;
     readonly markManyForEmbedding: (transactionIds: readonly number[]) => void;
 }
 
 export const useEmbeddingGenerator = (): UseEmbeddingGeneratorReturnInterface => {
-    const markForEmbedding = (params: MarkParamsInterface): void => {
-        logger.log('embed:defer:mark', { transactionId: params.transactionId });
+    const markForEmbedding = (transactionId: number): void => {
+        logger.log('embed:defer:mark', { transactionId });
         transactionRepository
-            .updateById(params.transactionId, { needsEmbedding: true })
+            .markForEmbeddingByIds([transactionId])
             .then(() => embeddingProgressStore.refresh())
             .catch(emptyFn);
     };
@@ -34,7 +30,8 @@ export const useEmbeddingGenerator = (): UseEmbeddingGeneratorReturnInterface =>
 
         logger.log('embed:defer:markMany', { count: ids.length, transactionIds: ids });
 
-        Promise.all(ids.map(id => transactionRepository.updateById(id, { needsEmbedding: true })))
+        transactionRepository
+            .markForEmbeddingByIds(ids)
             .then(() => embeddingProgressStore.refresh())
             .catch(emptyFn);
     };

--- a/packages/app/src/app/(main)/create-transaction/income.tsx
+++ b/packages/app/src/app/(main)/create-transaction/income.tsx
@@ -29,7 +29,7 @@ export default function CreateIncomeTransactionPage() {
     const { form, handleSubmit } = useCreateTransactionForm({
         onSubmit: async data => {
             const result = await transactionService.createInternal(data);
-            markForEmbedding({ transactionId: result.id });
+            markForEmbedding(result.id);
 
             return result;
         },

--- a/packages/app/src/app/(main)/create-transaction/transfer.tsx
+++ b/packages/app/src/app/(main)/create-transaction/transfer.tsx
@@ -34,7 +34,7 @@ export default function CreateTransferTransactionPage() {
     const { form, handleSubmit } = useCreateTransactionForm({
         onSubmit: async data => {
             const result = await transactionService.createInternalTransfer(data);
-            markForEmbedding({ transactionId: result.id });
+            markForEmbedding(result.id);
 
             return result;
         },

--- a/packages/app/src/app/(main)/transactions/[id]/expense.tsx
+++ b/packages/app/src/app/(main)/transactions/[id]/expense.tsx
@@ -38,7 +38,7 @@ const UpdateExpenseForm = ({ transaction, transactionId }: UpdateTransactionForm
         transaction: convertTransactionToInput(transaction),
         schema: ExpenseTransactionCreateInputSchema,
         id: transactionId,
-        onAfterSubmit: () => void markForEmbedding({ transactionId })
+        onAfterSubmit: () => void markForEmbedding(transactionId)
     });
 
     const fromAccountId = useWatch({ control: form.control, name: 'fromAccountId' });

--- a/packages/app/src/app/(main)/transactions/[id]/income.tsx
+++ b/packages/app/src/app/(main)/transactions/[id]/income.tsx
@@ -35,7 +35,7 @@ const UpdateIncomeForm = ({ transaction, transactionId }: UpdateTransactionFormP
         transaction: convertTransactionToInput(transaction),
         schema: IncomeTransactionCreateInputSchema,
         id: transactionId,
-        onAfterSubmit: () => void markForEmbedding({ transactionId })
+        onAfterSubmit: () => void markForEmbedding(transactionId)
     });
 
     const toAccountId = useWatch({ control: form.control, name: 'toAccountId' });

--- a/packages/app/src/app/(main)/transactions/[id]/transfer.tsx
+++ b/packages/app/src/app/(main)/transactions/[id]/transfer.tsx
@@ -47,7 +47,7 @@ const UpdateTransferForm = ({ transaction, transactionId }: UpdateTransactionFor
         transaction: transactionInput,
         schema: TransferTransactionCreateInputSchema,
         id: transactionId,
-        onAfterSubmit: () => void markForEmbedding({ transactionId })
+        onAfterSubmit: () => void markForEmbedding(transactionId)
     });
 
     const [fromAccountId, amount] = useWatch({

--- a/packages/app/src/sync/service/base-file-bank-sync.service.ts
+++ b/packages/app/src/sync/service/base-file-bank-sync.service.ts
@@ -77,7 +77,7 @@ export abstract class BaseFileBankSyncService {
                 .map(account => account.id)
                 .join(',')} existingKeys=${[...context.existingTransactionIdMap.keys()].join(',')}`,
         (result, client, bankAccount, context) =>
-            `done accountId=${bankAccount.id} newImportedCount=${result} accountIds=${client
+            `done accountId=${bankAccount.id} importedCount=${result} accountIds=${client
                 .getAccounts()
                 .map(account => account.id)
                 .join(',')} existingKeys=${[...context.existingTransactionIdMap.keys()].join(',')}`,
@@ -114,7 +114,9 @@ export abstract class BaseFileBankSyncService {
             await accountBalanceIncrementalService.updateBalancesByAccountIds([account.id], context.tx);
         }
 
-        return this.queueRulesForNewlyImportedTransactions(prepared.transactionInputs, upsertedTransactions, prepared.externalIdMap);
+        this.queueRulesForNewlyImportedTransactions(prepared.transactionInputs, upsertedTransactions, prepared.externalIdMap);
+
+        return upsertedTransactions.length;
     }
 
     @Log(
@@ -130,20 +132,20 @@ export abstract class BaseFileBankSyncService {
                 transactionService.findIdMapByExternalSource(this.provider)
             ]);
 
-            const newImportedCounts: number[] = [];
+            const importedCounts: number[] = [];
 
             await transactionAsync(db, async tx => {
                 const context: ImportContextInterface = { mccCategoryLookupMap, existingTransactionIdMap, tx };
 
                 for (const bankAccount of bankAccounts) {
-                    newImportedCounts.push(await this.importAccountTransactions(client, bankAccount, context));
+                    importedCounts.push(await this.importAccountTransactions(client, bankAccount, context));
                     await microPause();
                 }
             });
 
-            const newImportedCount = newImportedCounts.reduce((total, count) => total + count, 0);
+            const importedCount = importedCounts.reduce((total, count) => total + count, 0);
 
-            if (isPositiveNumber(newImportedCount)) {
+            if (isPositiveNumber(importedCount)) {
                 transferConsolidationDrainerService.enqueue(TransferConsolidationDrainReasonEnum.FILE_IMPORT);
             }
         };
@@ -223,16 +225,16 @@ export abstract class BaseFileBankSyncService {
         transactionInputs: TransactionCreateInputInterface[],
         upsertedTransactions: TransactionEntityInterface[],
         existingTransactionIdMap: Map<string, number>
-    ): number {
+    ): void {
         const wasNotPreviouslyImported = ({ externalId }: { externalId: string | null }) =>
             !isDefined(externalId) || !existingTransactionIdMap.has(externalId);
 
         const newInputs = transactionInputs.filter(wasNotPreviouslyImported);
         const newTransactionIds = upsertedTransactions.filter(wasNotPreviouslyImported).map(transaction => transaction.id);
 
-        ruleApplicationDrainerService.enqueueTransactions(newTransactionIds, newInputs);
-
-        return newTransactionIds.length;
+        if (isNotEmptyArray(newTransactionIds)) {
+            ruleApplicationDrainerService.enqueueTransactions(newTransactionIds, newInputs);
+        }
     }
 
     protected abstract parseFile(uri: string): Promise<ParsedFileResultInterface>;

--- a/packages/app/src/sync/service/base-file-bank-sync.service.ts
+++ b/packages/app/src/sync/service/base-file-bank-sync.service.ts
@@ -21,6 +21,7 @@ import { getOrCreateBankAccount } from '../util/get-or-create-bank-account.util'
 import { mapBankAccountsToPreview } from '../util/map-bank-accounts-to-preview.util';
 import { mapBankTransactionToCreateInput } from '../util/map-bank-transaction-to-create-input.util';
 
+import { syncWorkloadService } from './sync-workload.service';
 import { transferConsolidationDrainerService } from './transfer-consolidation-drainer.service';
 
 import type { FileBasedBankSyncClientInterface } from '../interface/file-based-bank-sync-client.interface';
@@ -118,29 +119,33 @@ export abstract class BaseFileBankSyncService {
             `throw bankAccountIds=${bankAccounts.map(account => account.id).join(',')} error=${getErrorMessage(error)}`
     )
     private async executeImport(client: FileBasedBankSyncClientInterface, bankAccounts: BankAccountInterface[]): Promise<void> {
-        const [mccCategoryLookupMap, existingTransactionIdMap] = await Promise.all([
-            this.resolveMccCategoryIdMap(client, bankAccounts),
-            transactionService.findIdMapByExternalSource(this.provider)
-        ]);
+        const importWork = async (): Promise<void> => {
+            const [mccCategoryLookupMap, existingTransactionIdMap] = await Promise.all([
+                this.resolveMccCategoryIdMap(client, bankAccounts),
+                transactionService.findIdMapByExternalSource(this.provider)
+            ]);
 
-        const newImportedCounts: number[] = [];
+            const newImportedCounts: number[] = [];
 
-        await transactionAsync(db, async tx => {
-            const context: ImportContextInterface = { mccCategoryLookupMap, existingTransactionIdMap, tx };
+            await transactionAsync(db, async tx => {
+                const context: ImportContextInterface = { mccCategoryLookupMap, existingTransactionIdMap, tx };
 
-            for (const bankAccount of bankAccounts) {
-                newImportedCounts.push(await this.importAccountTransactions(client, bankAccount, context));
-                await microPause();
+                for (const bankAccount of bankAccounts) {
+                    newImportedCounts.push(await this.importAccountTransactions(client, bankAccount, context));
+                    await microPause();
+                }
+
+                await transactionService.updateAllBalances(tx);
+            });
+
+            const newImportedCount = newImportedCounts.reduce((total, count) => total + count, 0);
+
+            if (isPositiveNumber(newImportedCount)) {
+                transferConsolidationDrainerService.enqueue(TransferConsolidationDrainReasonEnum.FILE_IMPORT);
             }
+        };
 
-            await transactionService.updateAllBalances(tx);
-        });
-
-        const newImportedCount = newImportedCounts.reduce((total, count) => total + count, 0);
-
-        if (isPositiveNumber(newImportedCount)) {
-            transferConsolidationDrainerService.enqueue(TransferConsolidationDrainReasonEnum.FILE_IMPORT);
-        }
+        await syncWorkloadService.run(`${this.provider}-file-import`, importWork);
     }
 
     private async executeImportForSelectedAccountsInner(uri: string, selectedAccountIds: string[]): Promise<void> {

--- a/packages/app/src/sync/service/base-file-bank-sync.service.ts
+++ b/packages/app/src/sync/service/base-file-bank-sync.service.ts
@@ -12,6 +12,7 @@ import { emptyFn, getErrorMessage, isDefined, isNotEmptyArray, isPositiveNumber 
 
 import { accountRepository, bankSyncRepository, db } from '../../@generic/drizzle/db/db';
 import { microPause } from '../../@generic/utils/micro-pause.util';
+import { accountBalanceIncrementalService } from '../../account/service/account-balance-incremental.service';
 import { ruleApplicationDrainerService } from '../../rule/service/rule-application-drainer.service';
 import { transactionImportService } from '../../transaction/service/transaction-import.service';
 import { transactionService } from '../../transaction/service/transaction.service';
@@ -109,6 +110,10 @@ export abstract class BaseFileBankSyncService {
             shouldUpdateBalances: false
         });
 
+        if (isNotEmptyArray(upsertedTransactions)) {
+            await accountBalanceIncrementalService.updateBalancesByAccountIds([account.id], context.tx);
+        }
+
         return this.queueRulesForNewlyImportedTransactions(prepared.transactionInputs, upsertedTransactions, prepared.externalIdMap);
     }
 
@@ -134,8 +139,6 @@ export abstract class BaseFileBankSyncService {
                     newImportedCounts.push(await this.importAccountTransactions(client, bankAccount, context));
                     await microPause();
                 }
-
-                await transactionService.updateAllBalances(tx);
             });
 
             const newImportedCount = newImportedCounts.reduce((total, count) => total + count, 0);

--- a/packages/app/src/transaction/components/update-adjustment-transaction/update-adjustment-transaction.tsx
+++ b/packages/app/src/transaction/components/update-adjustment-transaction/update-adjustment-transaction.tsx
@@ -117,7 +117,7 @@ export const UpdateAdjustmentTransaction = ({ transaction, transactionId }: Prop
         try {
             setIsSubmitting(true);
             await transactionService.updateById(transactionId, buildAdjustmentUpdateInput(transaction, details, numericValue, isIncrease));
-            void markForEmbedding({ transactionId });
+            void markForEmbedding(transactionId);
             goBackOrReplace('/');
         } catch (error: unknown) {
             Toast.show({

--- a/packages/app/src/transaction/service/transaction-import.service.ts
+++ b/packages/app/src/transaction/service/transaction-import.service.ts
@@ -84,7 +84,7 @@ class TransactionImportService {
         );
 
         if (shouldUpdateBalances && isNotEmptyArray(transactions)) {
-            await accountBalanceIncrementalService.updateAllBalances(true, tx);
+            await accountBalanceIncrementalService.updateBalancesByAccountIds(this.getAccountIdsFromInputs(stampedInputs), tx);
         }
 
         return transactions;
@@ -271,6 +271,10 @@ class TransactionImportService {
         return new Map(
             existingTransactions.map((transaction): [number, TransactionWithEntriesEntityInterface] => [transaction.id, transaction])
         );
+    }
+
+    private getAccountIdsFromInputs(inputs: readonly TransactionCreateInputInterface[]): number[] {
+        return [...new Set(inputs.flatMap(input => input.entries.map(entry => entry.accountId)))];
     }
 }
 

--- a/packages/app/src/transaction/service/transaction-transfer.service.ts
+++ b/packages/app/src/transaction/service/transaction-transfer.service.ts
@@ -103,7 +103,10 @@ class TransactionTransferService {
                 tx
             );
 
-            await accountBalanceIncrementalService.updateAllBalances(true, tx);
+            await accountBalanceIncrementalService.updateBalancesByAccountIds(
+                [conversion.creditAccountId, conversion.debitAccountId, ...conversion.feeEntries.map(entry => entry.accountId)],
+                tx
+            );
 
             return updated;
         });

--- a/packages/app/src/transaction/service/transaction.service.ts
+++ b/packages/app/src/transaction/service/transaction.service.ts
@@ -32,7 +32,8 @@ import type {
     TransactionCreateInputInterface,
     TransactionEntityInterface,
     TransactionEntryCreateInputInterface,
-    TransactionUpdateServiceInputInterface
+    TransactionUpdateServiceInputInterface,
+    TransactionWithEntriesEntityInterface
 } from '@budgie/contracts';
 
 class TransactionService {
@@ -63,7 +64,7 @@ class TransactionService {
         );
 
         if (isNotEmptyArray(transactions)) {
-            await accountBalanceIncrementalService.updateAllBalances(true, tx);
+            await accountBalanceIncrementalService.updateBalancesByAccountIds(this.getAccountIdsFromInputs(inputs), tx);
         }
 
         return transactions;
@@ -83,17 +84,18 @@ class TransactionService {
     @Log(id => `enter id=${id}`, 'done', (error, id) => `throw id=${id} error=${getErrorMessage(error)}`)
     async deleteById(id: number): Promise<void> {
         await transactionAsync(db, async tx => {
-            const transaction = await transactionRepository.getByIdRaw(id, tx);
+            const transaction = await transactionRepository.getByIdWithEntries(id, tx);
+            const accountIds = this.getAccountIdsFromTransactions(isDefined(transaction) ? [transaction] : []);
 
             if (isDefined(transaction?.consolidationType)) {
                 await unconsolidateByIdInTransaction(id, tx);
+                await accountBalanceIncrementalService.updateAllBalances(true, tx);
             } else {
                 await transactionRepository.deleteById(id, tx);
                 await transactionTagsRepository.deleteByTransactionId(id, tx);
                 await transactionEntryRepository.deleteByTransactionId(id, tx);
+                await accountBalanceIncrementalService.updateBalancesByAccountIds(accountIds, tx);
             }
-
-            await accountBalanceIncrementalService.updateAllBalances(true, tx);
         });
     }
 
@@ -223,7 +225,7 @@ class TransactionService {
                 await transactionTagsRepository.bulkCreate(transactionMapTagIdsToCreateEntities(input.tagIds, transaction.id), tx);
             }
 
-            await accountBalanceIncrementalService.updateAllBalances(true, tx);
+            await accountBalanceIncrementalService.updateBalancesByAccountIds(this.getAccountIdsFromInputs([input]), tx);
 
             return transaction;
         });
@@ -231,7 +233,7 @@ class TransactionService {
 
     async updateById(id: number, input: TransactionUpdateServiceInputInterface): Promise<TransactionEntityInterface> {
         return await transactionAsync(db, async tx => {
-            const existingTransaction = await transactionRepository.getByIdRaw(id, tx);
+            const existingTransaction = await transactionRepository.getByIdWithEntries(id, tx);
             const isConsolidated = isDefined(existingTransaction?.consolidationType);
             const transaction = await transactionRepository.updateById(
                 id,
@@ -250,10 +252,24 @@ class TransactionService {
 
             await upsertTransactionEntriesAndTags({ transactionId: id, input, operatedAt: transaction.operatedAt, isConsolidated }, tx);
 
-            await accountBalanceIncrementalService.updateAllBalances(true, tx);
+            await accountBalanceIncrementalService.updateBalancesByAccountIds(
+                [
+                    ...this.getAccountIdsFromTransactions(isDefined(existingTransaction) ? [existingTransaction] : []),
+                    ...this.getAccountIdsFromInputs([input])
+                ],
+                tx
+            );
 
             return transaction;
         });
+    }
+
+    private getAccountIdsFromInputs(inputs: readonly Pick<TransactionCreateInputInterface, 'entries'>[]): number[] {
+        return [...new Set(inputs.flatMap(input => input.entries.map(entry => entry.accountId)))];
+    }
+
+    private getAccountIdsFromTransactions(transactions: readonly TransactionWithEntriesEntityInterface[]): number[] {
+        return [...new Set(transactions.flatMap(transaction => transaction.entries.map(entry => entry.accountId)))];
     }
 
     private findPrimaryEntries(entries: TransactionEntryCreateInputInterface[], fromAccountId: number | null, toAccountId: number | null) {

--- a/packages/contracts/src/account-balance/repository/account-balance.repository.ts
+++ b/packages/contracts/src/account-balance/repository/account-balance.repository.ts
@@ -109,6 +109,10 @@ export class AccountBalanceRepository {
             .where(inArray(AccountBalanceEntityTable.accountId, accountIds));
     }
 
+    async deleteByAccountIds(accountIds: number[], tx?: DB): Promise<void> {
+        await (tx ?? this.db).delete(AccountBalanceEntityTable).where(inArray(AccountBalanceEntityTable.accountId, accountIds));
+    }
+
     getHomeAccountRows(defaultInstrumentId: number) {
         const balanceSql = this.getAccountBalanceWithTransactionsSql();
         const convertedBalanceSql = sql<number>`COALESCE((${balanceSql}) * ${this.buildNetWorthExchangeRateConversionSql(defaultInstrumentId)}, 0)`;

--- a/packages/contracts/src/account/repository/account.repository.ts
+++ b/packages/contracts/src/account/repository/account.repository.ts
@@ -101,12 +101,12 @@ export class AccountRepository {
         });
     }
 
-    async findByIds(ids: number[]): Promise<AccountEntityInterface[]> {
+    async findByIds(ids: number[], tx?: DB): Promise<AccountEntityInterface[]> {
         if (!isNotEmptyArray(ids)) {
             return [];
         }
 
-        return await this.db.query.AccountEntityTable.findMany({
+        return await (tx ?? this.db).query.AccountEntityTable.findMany({
             where: and(inArray(AccountEntityTable.id, ids), isNull(AccountEntityTable.deletedAt))
         });
     }

--- a/packages/contracts/src/transaction/repository/transaction.repository.ts
+++ b/packages/contracts/src/transaction/repository/transaction.repository.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- Transaction repository is the kitchen sink for tx queries + filter builders + bank-sync helpers */
 import { Log } from '@budgie/logger';
-import { SQL, and, count, eq, gte, inArray, isNotNull, isNull, lt, ne, or, sql } from 'drizzle-orm';
+import { SQL, and, count, eq, gte, inArray, isNotNull, isNull, lt, ne, notInArray, or, sql } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/sqlite-core';
 
 import { getErrorMessage, isDefined, isEmptyArray, isNotEmptyArray, isPositiveNumber } from '@rnw-community/shared';
@@ -31,6 +31,11 @@ import type { TransactionUpdateInputInterface } from '../input/transaction-updat
 import type { ConsolidationSourceRowInterface } from '../interface/consolidation-source-row.interface';
 
 export class TransactionRepository extends BaseTransactionFilterRepository {
+    private static readonly NON_INDEXABLE_EMBEDDING_TYPES: TransactionTypeEnum[] = [
+        TransactionTypeEnum.TRANSFER,
+        TransactionTypeEnum.ADJUSTMENT
+    ];
+
     private entriesWithMccCategoryRelations = {
         [TransactionAssociationEnum.ENTRIES]: {
             with: { [TransactionEntryAssociationEnum.MCC_CATEGORY]: true }
@@ -486,6 +491,24 @@ export class TransactionRepository extends BaseTransactionFilterRepository {
 
     async markAllForEmbedding(tx?: DB): Promise<void> {
         await (tx ?? this.db).update(TransactionEntityTable).set({ needsEmbedding: true }).where(isNull(TransactionEntityTable.deletedAt));
+    }
+
+    async markForEmbeddingByIds(ids: number[], tx?: DB): Promise<void> {
+        if (isEmptyArray(ids)) {
+            return;
+        }
+
+        await (tx ?? this.db)
+            .update(TransactionEntityTable)
+            .set({ needsEmbedding: true })
+            .where(
+                and(
+                    inArray(TransactionEntityTable.id, ids),
+                    eq(TransactionEntityTable.needsEmbedding, false),
+                    isNull(TransactionEntityTable.deletedAt),
+                    notInArray(TransactionEntityTable.type, TransactionRepository.NON_INDEXABLE_EMBEDDING_TYPES)
+                )
+            );
     }
 
     async clearNeedsEmbedding(ids: number[], tx?: DB): Promise<void> {

--- a/tests/bank-sync-tests/src/scenarios/account/account-balance-scope.test.ts
+++ b/tests/bank-sync-tests/src/scenarios/account/account-balance-scope.test.ts
@@ -1,0 +1,81 @@
+import { eq } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+
+import {
+    AccountBalanceEntityTable,
+    AccountTypeEnum,
+    TransactionEntityTable,
+    TransactionEntryEntityTable,
+    TransactionEntryTypeEnum,
+    TransactionTypeEnum
+} from '@budgie/contracts';
+
+import { accountBalanceRepository } from '@app/@generic/drizzle/db/db';
+import { accountBalanceIncrementalService } from '@app/account/service/account-balance-incremental.service';
+
+import { seed, testDb } from '../../harness';
+import { insertOne } from '../../harness/db/insert-one';
+
+const OLD_BALANCE_UPDATED_AT = new Date(2026, 0, 1);
+
+const seedExpenseEntry = (accountId: number, amount: number): void => {
+    const transaction = insertOne(TransactionEntityTable, {
+        type: TransactionTypeEnum.EXPENSE,
+        title: 'Scoped expense',
+        externalId: null,
+        comment: '',
+        toAccountId: null,
+        fromAccountId: accountId,
+        exchangeRate: 1,
+        externalSource: null,
+        updatedBy: null,
+        needsEmbedding: false
+    });
+
+    insertOne(TransactionEntryEntityTable, {
+        transactionId: transaction.id,
+        accountId,
+        type: TransactionEntryTypeEnum.CREDIT,
+        amount,
+        categoryId: null,
+        mccCategoryId: null,
+        externalId: null,
+        exchangeRate: 1,
+        baseInstrumentId: null,
+        baseExchangeRate: null,
+        baseAmount: null,
+        toIban: null,
+        originalTransactionId: null
+    });
+};
+
+const fetchBalanceRow = (accountId: number) =>
+    testDb.select().from(AccountBalanceEntityTable).where(eq(AccountBalanceEntityTable.accountId, accountId)).get();
+
+describe('account/account-balance-scope', () => {
+    it('rebuilds only requested account balances', async () => {
+        const changedAccount = seed.account({ type: AccountTypeEnum.BANK, instrumentId: 1 });
+        const untouchedAccount = seed.account({ type: AccountTypeEnum.CASH, instrumentId: 1 });
+
+        insertOne(AccountBalanceEntityTable, {
+            accountId: changedAccount.id,
+            amount: 10_000,
+            updatedAt: OLD_BALANCE_UPDATED_AT
+        });
+        insertOne(AccountBalanceEntityTable, {
+            accountId: untouchedAccount.id,
+            amount: 50_000,
+            updatedAt: OLD_BALANCE_UPDATED_AT
+        });
+        seedExpenseEntry(changedAccount.id, 12_000);
+
+        await accountBalanceIncrementalService.updateBalancesByAccountIds([changedAccount.id]);
+
+        const changedBalance = accountBalanceRepository.getByAccountId(changedAccount.id).get();
+        const untouchedBalance = fetchBalanceRow(untouchedAccount.id);
+
+        expect(changedBalance?.balance).toBe(-12_000);
+        expect(untouchedBalance?.amount).toBe(50_000);
+        expect(untouchedBalance?.updatedAt).toEqual(OLD_BALANCE_UPDATED_AT);
+    });
+});

--- a/tests/bank-sync-tests/src/scenarios/consolidation/privatbank-file-import-triggers-consolidation.test.ts
+++ b/tests/bank-sync-tests/src/scenarios/consolidation/privatbank-file-import-triggers-consolidation.test.ts
@@ -79,7 +79,7 @@ describe('consolidation/privatbank-file-import-triggers-consolidation', () => {
         expect(transferConsolidationDrainerService.enqueue).toHaveBeenCalledWith(TransferConsolidationDrainReasonEnum.FILE_IMPORT);
     });
 
-    it('does not enqueue consolidation when a re-import introduces no new transactions', async () => {
+    it('enqueues consolidation after a re-import so the drainer can process existing confident candidates', async () => {
         seedPrivatbankAccount();
         const syncService = buildPrivatbankSyncService([buildPrivatbankTransaction()]);
 
@@ -88,6 +88,7 @@ describe('consolidation/privatbank-file-import-triggers-consolidation', () => {
 
         await syncService.executeImportForSelectedAccounts(PRIVATBANK_STATEMENT_URI, [PRIVATBANK_CARD_ID]);
 
-        expect(transferConsolidationDrainerService.enqueue).not.toHaveBeenCalled();
+        expect(transferConsolidationDrainerService.enqueue).toHaveBeenCalledTimes(1);
+        expect(transferConsolidationDrainerService.enqueue).toHaveBeenCalledWith(TransferConsolidationDrainReasonEnum.FILE_IMPORT);
     });
 });

--- a/tests/bank-sync-tests/src/scenarios/embedding/mark-for-embedding.test.ts
+++ b/tests/bank-sync-tests/src/scenarios/embedding/mark-for-embedding.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { TransactionEntityTable, TransactionTypeEnum } from '@budgie/contracts';
+
+import { transactionRepository } from '@app/@generic/drizzle/db/db';
+
+import { fetchTransactionById } from '../../harness';
+import { insertOne } from '../../harness/db/insert-one';
+
+const seedTransaction = (type: TransactionTypeEnum, needsEmbedding: boolean) =>
+    insertOne(TransactionEntityTable, {
+        type,
+        title: 'Manual transaction',
+        externalId: null,
+        comment: '',
+        toAccountId: null,
+        fromAccountId: null,
+        exchangeRate: 1,
+        externalSource: null,
+        updatedBy: null,
+        needsEmbedding
+    });
+
+describe('embedding/mark-for-embedding', () => {
+    it('marks indexable transactions that are not already queued', async () => {
+        const transaction = seedTransaction(TransactionTypeEnum.INCOME, false);
+
+        await transactionRepository.markForEmbeddingByIds([transaction.id]);
+
+        expect(fetchTransactionById(transaction.id).needsEmbedding).toBe(true);
+    });
+
+    it('does not mark transfers for embedding', async () => {
+        const transaction = seedTransaction(TransactionTypeEnum.TRANSFER, false);
+
+        await transactionRepository.markForEmbeddingByIds([transaction.id]);
+
+        expect(fetchTransactionById(transaction.id).needsEmbedding).toBe(false);
+    });
+});

--- a/tests/bank-sync-tests/src/scenarios/erste/file-import-idempotency.test.ts
+++ b/tests/bank-sync-tests/src/scenarios/erste/file-import-idempotency.test.ts
@@ -4,10 +4,16 @@ import { describe, expect, it } from 'vitest';
 import { BankAccountTypeEnum, BankProviderEnum, BankTransactionTypeEnum } from '@budgie/bank-sync';
 import { ExternalSourceEnum, TransactionEntityTable } from '@budgie/contracts';
 
+import { isDefined } from '@rnw-community/shared';
+
 import { StubFileBankSyncService, testDb } from '../../harness';
 
+import { BaseFileBankSyncService } from '@app/sync/service/base-file-bank-sync.service';
+
 import type { FileBasedBankSyncClientInterface } from '@app/sync/interface/file-based-bank-sync-client.interface';
+import type { ParsedFileResultInterface } from '@app/sync/interface/parsed-file-result.interface';
 import type { BankAccountInterface, BankTransactionInterface } from '@budgie/bank-sync';
+import type { MccCategoryLookupInterface } from '@budgie/contracts';
 
 const ERSTE_ACCOUNT_ID = 'AT123';
 const ERSTE_EXTERNAL_ID = 'erste-transaction-1';
@@ -55,8 +61,69 @@ class StubErsteFileClient implements FileBasedBankSyncClientInterface {
     }
 }
 
+class TwoCallBarrier {
+    private static readonly FALLBACK_RELEASE_MS = 25;
+
+    private pendingResolvers: Array<() => void> = [];
+    private timer: ReturnType<typeof setTimeout> | null = null;
+
+    async wait(): Promise<void> {
+        return new Promise(resolve => {
+            this.pendingResolvers.push(resolve);
+
+            if (this.pendingResolvers.length === 2) {
+                this.release();
+            }
+
+            if (this.pendingResolvers.length === 1) {
+                this.timer = setTimeout(() => {
+                    this.release();
+                }, TwoCallBarrier.FALLBACK_RELEASE_MS);
+            }
+        });
+    }
+
+    private release(): void {
+        if (isDefined(this.timer)) {
+            clearTimeout(this.timer);
+            this.timer = null;
+        }
+
+        const resolvers = this.pendingResolvers;
+        this.pendingResolvers = [];
+        resolvers.forEach(resolve => {
+            resolve();
+        });
+    }
+}
+
+class BarrierErsteSyncService extends BaseFileBankSyncService {
+    constructor(
+        private readonly parseBarrier: TwoCallBarrier,
+        private readonly resolveBarrier: TwoCallBarrier,
+        private readonly client: FileBasedBankSyncClientInterface
+    ) {
+        super(ExternalSourceEnum.ERSTE);
+    }
+
+    protected override async parseFile(): Promise<ParsedFileResultInterface> {
+        await this.parseBarrier.wait();
+
+        return { client: this.client, bankAccounts: this.client.getAccounts() };
+    }
+
+    protected override async resolveMccCategoryIdMap(): Promise<Map<string, MccCategoryLookupInterface | null>> {
+        await this.resolveBarrier.wait();
+
+        return new Map();
+    }
+}
+
 const buildErsteSyncService = (): StubFileBankSyncService =>
     new StubFileBankSyncService(ExternalSourceEnum.ERSTE, new StubErsteFileClient());
+
+const buildBarrierErsteSyncService = (parseBarrier: TwoCallBarrier, resolveBarrier: TwoCallBarrier): BarrierErsteSyncService =>
+    new BarrierErsteSyncService(parseBarrier, resolveBarrier, new StubErsteFileClient());
 
 const fetchImportedErsteTransactionCount = (): number =>
     testDb
@@ -72,12 +139,24 @@ const fetchImportedErsteTransactionCount = (): number =>
 
 describe('erste/file-import-idempotency', () => {
     it('keeps one transaction when the same statement import starts twice', async () => {
-        const syncService = buildErsteSyncService();
+        const parseBarrier = new TwoCallBarrier();
+        const resolveBarrier = new TwoCallBarrier();
+        const firstSyncService = buildBarrierErsteSyncService(parseBarrier, resolveBarrier);
+        const secondSyncService = buildBarrierErsteSyncService(parseBarrier, resolveBarrier);
 
         await Promise.all([
-            syncService.executeImportForSelectedAccounts(ERSTE_STATEMENT_URI, [ERSTE_ACCOUNT_ID]),
-            syncService.executeImportForSelectedAccounts(ERSTE_STATEMENT_URI, [ERSTE_ACCOUNT_ID])
+            firstSyncService.executeImportForSelectedAccounts(ERSTE_STATEMENT_URI, [ERSTE_ACCOUNT_ID]),
+            secondSyncService.executeImportForSelectedAccounts(ERSTE_STATEMENT_URI, [ERSTE_ACCOUNT_ID])
         ]);
+
+        expect(fetchImportedErsteTransactionCount()).toBe(1);
+    });
+
+    it('keeps one transaction when the same statement is re-imported later', async () => {
+        const syncService = buildErsteSyncService();
+
+        await syncService.executeImportForSelectedAccounts(ERSTE_STATEMENT_URI, [ERSTE_ACCOUNT_ID]);
+        await syncService.executeImportForSelectedAccounts(ERSTE_STATEMENT_URI, [ERSTE_ACCOUNT_ID]);
 
         expect(fetchImportedErsteTransactionCount()).toBe(1);
     });


### PR DESCRIPTION
## Summary

- serialize file-based bank imports per provider through the foreground sync workload gate
- prevent duplicate statement imports when the same file import is triggered from separate service instances
- scope balance refreshes for manual transaction writes, transfer conversion, imported transaction upserts, and file imports to affected accounts instead of rebuilding every active account
- make embedding re-queueing idempotent and skip non-indexable transfer/adjustment transactions
- keep file-import transfer consolidation scheduled after imported rows are upserted, including re-import/update paths, so the drainer can process all confident candidates
- add regression coverage for concurrent file import idempotency, scoped balance refresh behavior, embedding marker behavior, and file-import consolidation scheduling

## Root Cause

Privat/Erste-style file imports could overlap across separate service instances. Each import resolved the existing external transaction map before inserting. When two imports started close together, both could see stale state and insert the same external transactions.

The app freeze was a separate foreground-work amplification issue. A single visible transaction write could still trigger a global balance cache rebuild. That path deleted/rebuilt balances for every active account and invalidated live account/balance queries while the account transaction list was also reacting to the new row. Manual transaction screens also forced `needsEmbedding` writes even for rows already queued or rows that should never be embedded, adding avoidable DB writes and live-query churn.

The consolidation regression was caused by file imports using the “new rows for rule application” count as the gate for transfer consolidation. Re-imports and alias/upsert paths can change imported bank rows while producing `newImportedCount=0`; in that case rule application should stay skipped, but transfer consolidation still needs to be enqueued because the drainer scans all confident candidates, including historical ATM cash-withdrawal matches.

## Changes

- `BaseFileBankSyncService` now wraps file import work in `syncWorkloadService.run(...)`, making provider file imports single-flight and foreground-aware.
- File imports refresh balances per imported local account and no longer call a full all-account balance rebuild at the end of the import transaction.
- File imports now enqueue `TransferConsolidationDrainReasonEnum.FILE_IMPORT` whenever rows are imported/upserted, while rule application remains limited to genuinely new rows.
- `AccountBalanceIncrementalService` has a scoped full-rebuild path for selected account IDs.
- Manual transaction create/update/delete and transfer conversion now refresh balances for the accounts touched by the changed entries. Consolidated delete/unconsolidate remains conservative with a full rebuild because it can affect source entries outside the visible canonical transaction.
- `TransactionRepository.markForEmbeddingByIds(...)` marks only unqueued, active, indexable rows and lets callers update many rows in one DB write.
- `useEmbeddingGenerator` now uses the repository batch marker instead of forcing `updateById(...needsEmbedding: true)` for each transaction.

## Validation

- `yarn format`
- `yarn workspace @budgie/contracts build`
- `yarn ts`
- `yarn lint` (passes with one pre-existing warning in `packages/app/src/ai/hook/use-suggestion-base.hook.ts`)
- `yarn deadcode`
- `yarn cpd`
- `yarn workspace @budgie-at/bank-sync-tests test src/scenarios/consolidation/privatbank-file-import-triggers-consolidation.test.ts`
- `yarn workspace @budgie-at/bank-sync-tests test src/scenarios/consolidation/privatbank-file-import-triggers-consolidation.test.ts src/scenarios/consolidation/privatbank-cash-withdrawal.test.ts src/scenarios/consolidation/atm-cash-withdrawal.test.ts src/scenarios/erste/file-import-idempotency.test.ts` (4 files, 11 tests)
- `yarn workspace @budgie-at/bank-sync-tests test` (34 files, 89 tests)

## CI Status

New head: `d8122a68abfe639b586452e651c9458db0ec6d00`.

Passing: CodeQL, Vercel Preview Comments, Analyze (actions), Analyze (javascript-typescript), Claude review, CodeRabbit, Vercel.

Skipped: Macroscope correctness check.

Pending at last check: Code quality checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized account balance calculations to update only affected accounts instead of recalculating all balances, improving efficiency during transaction operations and bank file imports.

* **Tests**
  * Added comprehensive test coverage for incremental balance updates, transaction embedding, and import idempotency scenarios to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->