### PR TITLE
fix: reclaim mis-consolidated transfer chains when bridge account syncs late

### DIFF
--- a/packages/app/src/sync/service/transfer-consolidation.service.ts
+++ b/packages/app/src/sync/service/transfer-consolidation.service.ts
@@ -204,6 +204,7 @@ class TransferConsolidationService {
             candidates.pairCandidates.length +
             candidates.ibanBridgeChainTransferCandidates.length +
             candidates.existingTransferBridgeCandidates.length +
+            candidates.existingTransferChainReclaimCandidates.length +
             candidates.ibanBridgeCanonicalDuplicateCandidates.length +
             candidates.existingTransferIncomeDuplicateCandidates.length +
             candidates.ibanBridgeTransferCandidates.length +

--- a/packages/consolidation/src/auto/interface/consolidation-candidate-dependencies.interface.ts
+++ b/packages/consolidation/src/auto/interface/consolidation-candidate-dependencies.interface.ts
@@ -8,6 +8,7 @@ export interface ConsolidationCandidateDependenciesInterface {
         | 'findAtmCashWithdrawalReviewCandidates'
         | 'findCandidates'
         | 'findExistingTransferBridgeCandidates'
+        | 'findExistingTransferChainReclaimCandidates'
         | 'findExistingTransferIncomeDuplicateCandidates'
         | 'findIbanBridgeCanonicalDuplicateCandidates'
         | 'findIbanBridgeChainTransferCandidates'

--- a/packages/consolidation/src/auto/interface/consolidation-candidate-groups.interface.ts
+++ b/packages/consolidation/src/auto/interface/consolidation-candidate-groups.interface.ts
@@ -2,6 +2,7 @@ import type {
     AtmCashWithdrawalCandidateInterface,
     AtmCashWithdrawalReviewCandidateInterface,
     ExistingTransferBridgeCandidateInterface,
+    ExistingTransferChainReclaimCandidateInterface,
     ExistingTransferIncomeDuplicateCandidateInterface,
     IbanBridgeCanonicalDuplicateCandidateInterface,
     IbanBridgeChainTransferCandidateInterface,
@@ -16,6 +17,7 @@ export interface ConsolidationCandidateGroupsInterface {
     readonly atmCashWithdrawalCandidates: AtmCashWithdrawalCandidateInterface[];
     readonly atmCashWithdrawalReviewCandidates: AtmCashWithdrawalReviewCandidateInterface[];
     readonly existingTransferBridgeCandidates: ExistingTransferBridgeCandidateInterface[];
+    readonly existingTransferChainReclaimCandidates: ExistingTransferChainReclaimCandidateInterface[];
     readonly existingTransferIncomeDuplicateCandidates: ExistingTransferIncomeDuplicateCandidateInterface[];
     readonly ibanBridgeCanonicalDuplicateCandidates: IbanBridgeCanonicalDuplicateCandidateInterface[];
     readonly ibanBridgeChainTransferCandidates: IbanBridgeChainTransferCandidateInterface[];

--- a/packages/consolidation/src/auto/service/consolidation-auto-candidate.service.ts
+++ b/packages/consolidation/src/auto/service/consolidation-auto-candidate.service.ts
@@ -7,6 +7,7 @@ import type { ConsolidationCandidateGroupsInterface } from '../interface/consoli
 import type {
     AtmCashWithdrawalCandidateInterface,
     ExistingTransferBridgeCandidateInterface,
+    ExistingTransferChainReclaimCandidateInterface,
     ExistingTransferIncomeDuplicateCandidateInterface,
     IbanBridgeCanonicalDuplicateCandidateInterface,
     IbanBridgeChainTransferCandidateInterface,
@@ -45,6 +46,12 @@ export class ConsolidationAutoCandidateService {
             'existingTransferBridge',
             candidates.existingTransferBridgeCandidates,
             entries => this.processExistingTransferBridgeCandidates(entries),
+            publishProgress
+        );
+        const existingTransferChainReclaimConsolidated = await this.profileConsolidationBatch(
+            'existingTransferChainReclaim',
+            candidates.existingTransferChainReclaimCandidates,
+            entries => this.processExistingTransferChainReclaimCandidates(entries),
             publishProgress
         );
         const bridgeDuplicateConsolidated = await this.profileConsolidationBatch(
@@ -87,6 +94,7 @@ export class ConsolidationAutoCandidateService {
         return (
             bridgeChainConsolidated +
             existingTransferBridgeConsolidated +
+            existingTransferChainReclaimConsolidated +
             bridgeDuplicateConsolidated +
             pairConsolidated +
             bridgeConsolidated +
@@ -136,6 +144,14 @@ export class ConsolidationAutoCandidateService {
     private async processExistingTransferBridgeCandidates(candidates: ExistingTransferBridgeCandidateInterface[]): Promise<number> {
         return this.reduceConsolidations(candidates, candidate =>
             this.consolidationExecutorService.consolidateExistingTransferBridge(candidate)
+        );
+    }
+
+    private async processExistingTransferChainReclaimCandidates(
+        candidates: ExistingTransferChainReclaimCandidateInterface[]
+    ): Promise<number> {
+        return this.reduceConsolidations(candidates, candidate =>
+            this.consolidationExecutorService.consolidateExistingTransferChainReclaim(candidate)
         );
     }
 

--- a/packages/consolidation/src/auto/service/consolidation-candidate.service.ts
+++ b/packages/consolidation/src/auto/service/consolidation-candidate.service.ts
@@ -8,6 +8,7 @@ import type {
     AtmCashWithdrawalCandidateInterface,
     AtmCashWithdrawalReviewCandidateInterface,
     ExistingTransferBridgeCandidateInterface,
+    ExistingTransferChainReclaimCandidateInterface,
     ExistingTransferIncomeDuplicateCandidateInterface,
     IbanBridgeCanonicalDuplicateCandidateInterface,
     IbanBridgeChainTransferCandidateInterface,
@@ -24,15 +25,17 @@ export class ConsolidationCandidateService {
     @Log(
         'enter',
         result =>
-            `done manualCount=${result.manualReviewCandidates.length} atmReviewCount=${result.atmCashWithdrawalReviewCandidates.length} pairCount=${result.pairCandidates.length} ibanBridgeChainCount=${result.ibanBridgeChainTransferCandidates.length} ibanBridgeDuplicateCount=${result.ibanBridgeCanonicalDuplicateCandidates.length} existingTransferBridgeCount=${result.existingTransferBridgeCandidates.length} existingTransferIncomeDuplicateCount=${result.existingTransferIncomeDuplicateCandidates.length} ibanBridgeCount=${result.ibanBridgeTransferCandidates.length} atmCount=${result.atmCashWithdrawalCandidates.length} refundCount=${result.refundCandidates.length} refundReviewCount=${result.refundReviewCandidates.length}`,
+            `done manualCount=${result.manualReviewCandidates.length} atmReviewCount=${result.atmCashWithdrawalReviewCandidates.length} pairCount=${result.pairCandidates.length} ibanBridgeChainCount=${result.ibanBridgeChainTransferCandidates.length} ibanBridgeDuplicateCount=${result.ibanBridgeCanonicalDuplicateCandidates.length} existingTransferBridgeCount=${result.existingTransferBridgeCandidates.length} existingTransferChainReclaimCount=${result.existingTransferChainReclaimCandidates.length} existingTransferIncomeDuplicateCount=${result.existingTransferIncomeDuplicateCandidates.length} ibanBridgeCount=${result.ibanBridgeTransferCandidates.length} atmCount=${result.atmCashWithdrawalCandidates.length} refundCount=${result.refundCandidates.length} refundReviewCount=${result.refundReviewCandidates.length}`,
         error => `throw error=${getErrorMessage(error)}`
     )
+    // eslint-disable-next-line max-statements -- Candidate orchestration loads one group per consolidation strategy
     async findGroups(): Promise<ConsolidationCandidateGroupsInterface> {
         const manualReviewCandidates = await this.findManualReviewCandidates();
         const atmCashWithdrawalReviewCandidates = await this.findAtmCashWithdrawalReviewCandidates();
         const ibanBridgeChainTransferCandidates = await this.findIbanBridgeChainTransferCandidates();
         const ibanBridgeCanonicalDuplicateCandidates = await this.findIbanBridgeCanonicalDuplicateCandidates();
         const existingTransferBridgeCandidates = await this.findExistingTransferBridgeCandidates();
+        const existingTransferChainReclaimCandidates = await this.findExistingTransferChainReclaimCandidates();
         const ibanBridgeTransferCandidates = this.filterIbanBridgeTransferCandidates(
             await this.findIbanBridgeTransferCandidates(),
             ibanBridgeChainTransferCandidates
@@ -41,15 +44,16 @@ export class ConsolidationCandidateService {
             await this.findExistingTransferIncomeDuplicateCandidates(),
             existingTransferBridgeCandidates
         );
-        const pairCandidates = this.filterPairCandidates(
-            await this.findPairCandidates(),
-            this.buildBridgeSourceTransactionIdSet(
-                ibanBridgeChainTransferCandidates,
-                existingTransferBridgeCandidates,
-                ibanBridgeTransferCandidates,
-                existingTransferIncomeDuplicateCandidates
-            )
+        const bridgeSourceTransactionIds = this.buildBridgeSourceTransactionIdSet(
+            ibanBridgeChainTransferCandidates,
+            existingTransferBridgeCandidates,
+            ibanBridgeTransferCandidates,
+            existingTransferIncomeDuplicateCandidates
         );
+
+        this.addChainReclaimSourceTransactionIds(bridgeSourceTransactionIds, existingTransferChainReclaimCandidates);
+
+        const pairCandidates = this.filterPairCandidates(await this.findPairCandidates(), bridgeSourceTransactionIds);
         const atmCashWithdrawalCandidates = await this.findAtmCashWithdrawalCandidates();
         const refundCandidates = await this.findRefundCandidates();
         const refundReviewCandidates = await this.findRefundReviewCandidates();
@@ -58,6 +62,7 @@ export class ConsolidationCandidateService {
             manualReviewCandidates,
             atmCashWithdrawalReviewCandidates,
             existingTransferBridgeCandidates,
+            existingTransferChainReclaimCandidates,
             existingTransferIncomeDuplicateCandidates,
             ibanBridgeCanonicalDuplicateCandidates,
             ibanBridgeChainTransferCandidates,
@@ -105,6 +110,10 @@ export class ConsolidationCandidateService {
 
     private async findExistingTransferBridgeCandidates(): Promise<ExistingTransferBridgeCandidateInterface[]> {
         return await this.dependencies.transferPairRepository.findExistingTransferBridgeCandidates();
+    }
+
+    private async findExistingTransferChainReclaimCandidates(): Promise<ExistingTransferChainReclaimCandidateInterface[]> {
+        return await this.dependencies.transferPairRepository.findExistingTransferChainReclaimCandidates();
     }
 
     private async findExistingTransferIncomeDuplicateCandidates(): Promise<ExistingTransferIncomeDuplicateCandidateInterface[]> {
@@ -183,6 +192,21 @@ export class ConsolidationCandidateService {
         }
 
         return sourceTransactionIds;
+    }
+
+    private addChainReclaimSourceTransactionIds(
+        sourceTransactionIds: Set<number>,
+        existingTransferChainReclaimCandidates: ExistingTransferChainReclaimCandidateInterface[]
+    ): void {
+        const chainReclaimSourceTransactionIds = existingTransferChainReclaimCandidates.flatMap(candidate => [
+            candidate.bridgeIncomeTransactionId,
+            candidate.bridgeExpenseTransactionId,
+            candidate.existingTransferId
+        ]);
+
+        for (const sourceTransactionId of chainReclaimSourceTransactionIds) {
+            sourceTransactionIds.add(sourceTransactionId);
+        }
     }
 
     private buildExistingTransferBridgeSourceTransactionIdSet(candidates: ExistingTransferBridgeCandidateInterface[]): Set<number> {

--- a/packages/consolidation/src/executor/interface/iban-bridge-chain-canonical-input.interface.ts
+++ b/packages/consolidation/src/executor/interface/iban-bridge-chain-canonical-input.interface.ts
@@ -1,0 +1,10 @@
+export interface IbanBridgeChainCanonicalInputInterface {
+    readonly title: string;
+    readonly operatedAt: number;
+    readonly fromAccountId: number;
+    readonly toAccountId: number;
+    readonly fromAmount: number;
+    readonly toAmount: number;
+    readonly exchangeRate: number;
+    readonly fromEntryToIban: string | null;
+}

--- a/packages/consolidation/src/executor/service/consolidation-executor.service.ts
+++ b/packages/consolidation/src/executor/service/consolidation-executor.service.ts
@@ -1,5 +1,11 @@
 /* eslint-disable max-lines -- Consolidation executor keeps per-candidate logs and the write path together for debugging */
-import { CategorySourceEnum, TransactionConsolidationTypeEnum, TransactionEntryTypeEnum, TransactionTypeEnum } from '@budgie/contracts';
+import {
+    CategorySourceEnum,
+    IBAN_BRIDGE_CHAIN_FX_TOLERANCE,
+    TransactionConsolidationTypeEnum,
+    TransactionEntryTypeEnum,
+    TransactionTypeEnum
+} from '@budgie/contracts';
 import { Log } from '@budgie/logger';
 
 import { getErrorMessage, isDefined, isPositiveNumber } from '@rnw-community/shared';
@@ -8,10 +14,12 @@ import { consolidationCopySourceTransactionTags } from '../../shared/utils/conso
 
 import type { CanonicalTransferInputInterface } from '../interface/canonical-transfer-input.interface';
 import type { ConsolidationExecutorDependenciesInterface } from '../interface/consolidation-executor-dependencies.interface';
+import type { IbanBridgeChainCanonicalInputInterface } from '../interface/iban-bridge-chain-canonical-input.interface';
 import type {
     AtmCashWithdrawalCandidateInterface,
     DB,
     ExistingTransferBridgeCandidateInterface,
+    ExistingTransferChainReclaimCandidateInterface,
     ExistingTransferIncomeDuplicateCandidateInterface,
     IbanBridgeCanonicalDuplicateCandidateInterface,
     IbanBridgeChainTransferCandidateInterface,
@@ -121,6 +129,20 @@ export class ConsolidationExecutorService {
     async consolidateIbanBridgeChainTransfer(candidate: IbanBridgeChainTransferCandidateInterface): Promise<boolean> {
         return await this.dependencies.transactionRunner.run(this.dependencies.database, async tx =>
             this.consolidateIbanBridgeChainTransferInner(candidate, tx)
+        );
+    }
+
+    @Log(
+        candidate =>
+            `enter existingTransferId=${candidate.existingTransferId} bridgeIncomeTransactionId=${candidate.bridgeIncomeTransactionId} bridgeExpenseTransactionId=${candidate.bridgeExpenseTransactionId} sourceAccountId=${candidate.sourceAccountId} bridgeAccountId=${candidate.bridgeAccountId} targetAccountId=${candidate.targetAccountId} sourceAmount=${candidate.sourceAmount} targetAmount=${candidate.targetAmount} exchangeRate=${candidate.exchangeRate}`,
+        (result, candidate) =>
+            `done result=${String(result)} existingTransferId=${candidate.existingTransferId} bridgeIncomeTransactionId=${candidate.bridgeIncomeTransactionId} bridgeExpenseTransactionId=${candidate.bridgeExpenseTransactionId} sourceAccountId=${candidate.sourceAccountId} bridgeAccountId=${candidate.bridgeAccountId} targetAccountId=${candidate.targetAccountId} sourceAmount=${candidate.sourceAmount} targetAmount=${candidate.targetAmount} exchangeRate=${candidate.exchangeRate}`,
+        (error, candidate) =>
+            `throw existingTransferId=${candidate.existingTransferId} bridgeIncomeTransactionId=${candidate.bridgeIncomeTransactionId} bridgeExpenseTransactionId=${candidate.bridgeExpenseTransactionId} sourceAccountId=${candidate.sourceAccountId} bridgeAccountId=${candidate.bridgeAccountId} targetAccountId=${candidate.targetAccountId} sourceAmount=${candidate.sourceAmount} targetAmount=${candidate.targetAmount} exchangeRate=${candidate.exchangeRate} error=${getErrorMessage(error)}`
+    )
+    async consolidateExistingTransferChainReclaim(candidate: ExistingTransferChainReclaimCandidateInterface): Promise<boolean> {
+        return await this.dependencies.transactionRunner.run(this.dependencies.database, async tx =>
+            this.consolidateExistingTransferChainReclaimInner(candidate, tx)
         );
     }
 
@@ -334,26 +356,147 @@ export class ConsolidationExecutorService {
             candidate.bridgeExpenseTransactionId,
             candidate.targetIncomeTransactionId
         ];
-        const canonicalInput: CanonicalTransferInputInterface = {
-            title:
-                candidate.bridgeExpenseTransactionTitle ??
-                candidate.sourceExpenseTransactionTitle ??
-                candidate.targetIncomeTransactionTitle ??
-                candidate.bridgeIncomeTransactionTitle ??
-                '',
+        const title =
+            candidate.bridgeExpenseTransactionTitle ??
+            candidate.sourceExpenseTransactionTitle ??
+            candidate.targetIncomeTransactionTitle ??
+            candidate.bridgeIncomeTransactionTitle ??
+            '';
+        const canonicalInput = this.buildIbanBridgeChainCanonicalInput({
+            title,
             operatedAt: candidate.operatedAt,
             fromAccountId: candidate.sourceAccountId,
             toAccountId: candidate.targetAccountId,
             fromAmount: candidate.sourceAmount,
             toAmount: candidate.targetAmount,
             exchangeRate: candidate.exchangeRate,
-            consolidationType: TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER,
-            fromEntryExchangeRate: candidate.exchangeRate,
-            toEntryExchangeRate: 1,
             fromEntryToIban: candidate.sourceExpenseEntryToIban
-        };
+        });
 
         return this.executeConsolidation(sourceTransactionIds, canonicalInput, tx);
+    }
+
+    private async consolidateExistingTransferChainReclaimInner(
+        candidate: ExistingTransferChainReclaimCandidateInterface,
+        tx: DB
+    ): Promise<boolean> {
+        const bridgeSourceTransactionIds = [candidate.bridgeIncomeTransactionId, candidate.bridgeExpenseTransactionId];
+
+        if (!(await this.isExistingTransferStillEligible(candidate.existingTransferId, tx))) {
+            return false;
+        }
+
+        if (!(await this.areCandidatesStillEligible(bridgeSourceTransactionIds, tx))) {
+            return false;
+        }
+
+        const existingTransfer = (await this.dependencies.transactionRepository.findByIds([candidate.existingTransferId], tx)).at(0);
+
+        if (!isDefined(existingTransfer)) {
+            return false;
+        }
+
+        if (this.isChainReclaimFastPathEligible(candidate, existingTransfer)) {
+            return this.absorbChainReclaimBridgeLegs(candidate, bridgeSourceTransactionIds, tx);
+        }
+
+        return this.rebuildChainReclaimCanonical(candidate, existingTransfer.title, tx);
+    }
+
+    private async absorbChainReclaimBridgeLegs(
+        candidate: ExistingTransferChainReclaimCandidateInterface,
+        bridgeSourceTransactionIds: number[],
+        tx: DB
+    ): Promise<boolean> {
+        await this.copySourceTags(bridgeSourceTransactionIds, candidate.existingTransferId, tx);
+        await this.moveSourcesToCanonical(bridgeSourceTransactionIds, candidate.existingTransferId, tx);
+        await this.dependencies.transactionRepository.setConsolidationType(
+            candidate.existingTransferId,
+            TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER,
+            tx
+        );
+
+        return true;
+    }
+
+    private async rebuildChainReclaimCanonical(
+        candidate: ExistingTransferChainReclaimCandidateInterface,
+        existingTransferTitle: string,
+        tx: DB
+    ): Promise<boolean> {
+        const sourceTransactionIds = [
+            candidate.bridgeIncomeTransactionId,
+            candidate.bridgeExpenseTransactionId,
+            candidate.existingTransferId
+        ];
+        const canonicalInput = this.buildIbanBridgeChainCanonicalInput({
+            title: existingTransferTitle,
+            operatedAt: candidate.operatedAt,
+            fromAccountId: candidate.sourceAccountId,
+            toAccountId: candidate.targetAccountId,
+            fromAmount: candidate.sourceAmount,
+            toAmount: candidate.targetAmount,
+            exchangeRate: candidate.exchangeRate,
+            fromEntryToIban: candidate.targetAccountIban
+        });
+
+        return this.executeConsolidation(sourceTransactionIds, canonicalInput, tx, [candidate.existingTransferId]);
+    }
+
+    private buildIbanBridgeChainCanonicalInput(input: IbanBridgeChainCanonicalInputInterface): CanonicalTransferInputInterface {
+        return {
+            title: input.title,
+            operatedAt: input.operatedAt,
+            fromAccountId: input.fromAccountId,
+            toAccountId: input.toAccountId,
+            fromAmount: input.fromAmount,
+            toAmount: input.toAmount,
+            exchangeRate: input.exchangeRate,
+            consolidationType: TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER,
+            fromEntryExchangeRate: input.exchangeRate,
+            toEntryExchangeRate: 1,
+            fromEntryToIban: input.fromEntryToIban
+        };
+    }
+
+    private isChainReclaimFastPathEligible(
+        candidate: ExistingTransferChainReclaimCandidateInterface,
+        existingTransfer: TransactionWithEntriesEntityInterface
+    ): boolean {
+        if (existingTransfer.fromAccountId !== candidate.sourceAccountId || existingTransfer.toAccountId !== candidate.targetAccountId) {
+            return false;
+        }
+
+        const liveEntries = existingTransfer.entries.filter(
+            entry => !isDefined(entry.deletedAt) && !isDefined(entry.originalTransactionId)
+        );
+        const fromCreditEntry = liveEntries.find(
+            entry => entry.accountId === candidate.sourceAccountId && entry.type === TransactionEntryTypeEnum.CREDIT
+        );
+        const toDebitEntry = liveEntries.find(
+            entry => entry.accountId === candidate.targetAccountId && entry.type === TransactionEntryTypeEnum.DEBIT
+        );
+
+        if (!isDefined(fromCreditEntry) || !isDefined(toDebitEntry)) {
+            return false;
+        }
+
+        return (
+            fromCreditEntry.amount === candidate.sourceAmount &&
+            toDebitEntry.amount === candidate.targetAmount &&
+            toDebitEntry.exchangeRate === 1 &&
+            fromCreditEntry.toIban === candidate.targetAccountIban &&
+            this.isWithinChainFxTolerance(fromCreditEntry.exchangeRate, candidate.exchangeRate) &&
+            this.isWithinChainFxTolerance(existingTransfer.exchangeRate, candidate.exchangeRate)
+        );
+    }
+
+    private isWithinChainFxTolerance(actualRate: number, expectedRate: number): boolean {
+        if (!isPositiveNumber(expectedRate)) {
+            return false;
+        }
+
+        return Math.abs(actualRate - expectedRate) / expectedRate <= IBAN_BRIDGE_CHAIN_FX_TOLERANCE;
     }
 
     private buildBridgeSourceTransactionIds(candidate: IbanBridgeTransferCandidateInterface): number[] {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -180,6 +180,7 @@ export { TransactionAssociationEnum } from './transaction/enum/transaction-assoc
 
 export { DEFAULT_TRANSACTION_FILTER } from './transaction/constant/default-transaction-filter.constant';
 export { TRANSFER_PAIR_TIME_WINDOW_SECONDS } from './transaction/constant/transfer-pair-time-window.constant';
+export { IBAN_BRIDGE_CHAIN_FX_TOLERANCE } from './transaction/constant/iban-bridge-chain-fx-tolerance.constant';
 export { REFUND_TIME_WINDOW_SECONDS } from './transaction/constant/refund-time-window.constant';
 
 export { TransactionEntityTable } from './transaction/table/transaction-entity.table';
@@ -256,6 +257,7 @@ export type { TransferPairReviewCandidateInterface } from './transaction/interfa
 export type { AtmCashWithdrawalCandidateInterface } from './transaction/interface/atm-cash-withdrawal-candidate.interface';
 export type { AtmCashWithdrawalReviewCandidateInterface } from './transaction/interface/atm-cash-withdrawal-review-candidate.interface';
 export type { ExistingTransferBridgeCandidateInterface } from './transaction/interface/existing-transfer-bridge-candidate.interface';
+export type { ExistingTransferChainReclaimCandidateInterface } from './transaction/interface/existing-transfer-chain-reclaim-candidate.interface';
 export type { ExistingTransferIncomeDuplicateCandidateInterface } from './transaction/interface/existing-transfer-income-duplicate-candidate.interface';
 export type { IbanBridgeCanonicalDuplicateCandidateInterface } from './transaction/interface/iban-bridge-canonical-duplicate-candidate.interface';
 export type { IbanBridgeChainTransferCandidateInterface } from './transaction/interface/iban-bridge-chain-transfer-candidate.interface';

--- a/packages/contracts/src/transaction/constant/iban-bridge-chain-fx-tolerance.constant.ts
+++ b/packages/contracts/src/transaction/constant/iban-bridge-chain-fx-tolerance.constant.ts
@@ -1,0 +1,1 @@
+export const IBAN_BRIDGE_CHAIN_FX_TOLERANCE = 0.01;

--- a/packages/contracts/src/transaction/interface/existing-transfer-chain-reclaim-candidate.interface.ts
+++ b/packages/contracts/src/transaction/interface/existing-transfer-chain-reclaim-candidate.interface.ts
@@ -1,0 +1,23 @@
+export interface ExistingTransferChainReclaimCandidateInterface {
+    readonly confidenceBucket: 'AUTO_EXISTING_TRANSFER_CHAIN_RECLAIM';
+    readonly existingTransferId: number;
+    readonly existingTransferTitle: string | null;
+    readonly bridgeIncomeTransactionId: number;
+    readonly bridgeIncomeTransactionTitle: string | null;
+    readonly bridgeIncomeEntryId: number;
+    readonly bridgeExpenseTransactionId: number;
+    readonly bridgeExpenseTransactionTitle: string | null;
+    readonly bridgeExpenseEntryId: number;
+    readonly sourceAccountId: number;
+    readonly sourceAccountTitle: string;
+    readonly bridgeAccountId: number;
+    readonly bridgeAccountTitle: string;
+    readonly targetAccountId: number;
+    readonly targetAccountTitle: string;
+    readonly targetAccountIban: string;
+    readonly sourceAmount: number;
+    readonly targetAmount: number;
+    readonly exchangeRate: number;
+    readonly operatedAt: number;
+    readonly timeDiff: number;
+}

--- a/packages/contracts/src/transaction/repository/sql-factory/transfer-pair-existing-transfer-chain-reclaim-sql.factory.ts
+++ b/packages/contracts/src/transaction/repository/sql-factory/transfer-pair-existing-transfer-chain-reclaim-sql.factory.ts
@@ -1,0 +1,167 @@
+import { TransactionEntryTypeEnum } from '../../../transaction-entry/enum/transaction-entry-type.enum';
+import { IBAN_BRIDGE_CHAIN_FX_TOLERANCE } from '../../constant/iban-bridge-chain-fx-tolerance.constant';
+import { TRANSFER_PAIR_FAST_TIME_WINDOW_SECONDS } from '../../constant/transfer-pair-fast-time-window.constant';
+import { TransactionConsolidationTypeEnum } from '../../enum/transaction-consolidation-type.enum';
+import { TransactionTypeEnum } from '../../enum/transaction-type.enum';
+
+export const EXISTING_TRANSFER_CHAIN_RECLAIM_CANDIDATES_SQL = `
+            SELECT
+                'AUTO_EXISTING_TRANSFER_CHAIN_RECLAIM' as confidenceBucket,
+                existingTransferId,
+                existingTransferTitle,
+                bridgeIncomeTransactionId,
+                bridgeIncomeTransactionTitle,
+                bridgeIncomeEntryId,
+                bridgeExpenseTransactionId,
+                bridgeExpenseTransactionTitle,
+                bridgeExpenseEntryId,
+                sourceAccountId,
+                sourceAccountTitle,
+                bridgeAccountId,
+                bridgeAccountTitle,
+                targetAccountId,
+                targetAccountTitle,
+                targetAccountIban,
+                sourceAmount,
+                targetAmount,
+                sourceAmount * 1.0 / targetAmount as exchangeRate,
+                operatedAt,
+                timeDiff
+            FROM (
+                SELECT
+                    existing_transfer.id as existingTransferId,
+                    existing_transfer.title as existingTransferTitle,
+                    bridge_income_tx.id as bridgeIncomeTransactionId,
+                    bridge_income_tx.title as bridgeIncomeTransactionTitle,
+                    bridge_income_entry.id as bridgeIncomeEntryId,
+                    bridge_expense_tx.id as bridgeExpenseTransactionId,
+                    bridge_expense_tx.title as bridgeExpenseTransactionTitle,
+                    bridge_expense_entry.id as bridgeExpenseEntryId,
+                    source_account.id as sourceAccountId,
+                    source_account.title as sourceAccountTitle,
+                    bridge_account.id as bridgeAccountId,
+                    bridge_account.title as bridgeAccountTitle,
+                    target_account.id as targetAccountId,
+                    target_account.title as targetAccountTitle,
+                    target_account.iban as targetAccountIban,
+                    existing_source_entry.amount as sourceAmount,
+                    existing_target_entry.amount as targetAmount,
+                    existing_transfer.operated_at as operatedAt,
+                    MAX(
+                        ABS(bridge_income_tx.operated_at - existing_transfer.operated_at),
+                        ABS(bridge_expense_tx.operated_at - existing_transfer.operated_at)
+                    ) as timeDiff,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY existing_transfer.id
+                        ORDER BY
+                            MAX(
+                                ABS(bridge_income_tx.operated_at - existing_transfer.operated_at),
+                                ABS(bridge_expense_tx.operated_at - existing_transfer.operated_at)
+                            ),
+                            bridge_income_tx.id,
+                            bridge_expense_tx.id
+                    ) as existingTransferRank,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY bridge_income_tx.id
+                        ORDER BY
+                            MAX(
+                                ABS(bridge_income_tx.operated_at - existing_transfer.operated_at),
+                                ABS(bridge_expense_tx.operated_at - existing_transfer.operated_at)
+                            ),
+                            existing_transfer.id,
+                            bridge_expense_tx.id
+                    ) as bridgeIncomeRank,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY bridge_expense_tx.id
+                        ORDER BY
+                            MAX(
+                                ABS(bridge_income_tx.operated_at - existing_transfer.operated_at),
+                                ABS(bridge_expense_tx.operated_at - existing_transfer.operated_at)
+                            ),
+                            existing_transfer.id,
+                            bridge_income_tx.id
+                    ) as bridgeExpenseRank
+                FROM transactions existing_transfer
+                INNER JOIN transaction_entries existing_source_entry ON
+                    existing_source_entry.transaction_id = existing_transfer.id
+                    AND existing_source_entry.deleted_at IS NULL
+                    AND existing_source_entry.original_transaction_id IS NULL
+                    AND existing_source_entry.account_id = existing_transfer.from_account_id
+                INNER JOIN accounts source_account ON
+                    source_account.id = existing_source_entry.account_id
+                    AND source_account.deleted_at IS NULL
+                    AND source_account.is_active = 1
+                    AND source_account.iban IS NOT NULL
+                    AND source_account.iban != ''
+                INNER JOIN transaction_entries existing_target_entry ON
+                    existing_target_entry.transaction_id = existing_transfer.id
+                    AND existing_target_entry.deleted_at IS NULL
+                    AND existing_target_entry.original_transaction_id IS NULL
+                    AND existing_target_entry.account_id = existing_transfer.to_account_id
+                INNER JOIN accounts target_account ON
+                    target_account.id = existing_target_entry.account_id
+                    AND target_account.deleted_at IS NULL
+                    AND target_account.is_active = 1
+                    AND target_account.iban IS NOT NULL
+                    AND target_account.iban != ''
+                INNER JOIN transaction_entries bridge_income_entry ON
+                    bridge_income_entry.deleted_at IS NULL
+                    AND bridge_income_entry.original_transaction_id IS NULL
+                    AND bridge_income_entry.amount = existing_target_entry.amount
+                    AND bridge_income_entry.exchange_rate > 0
+                    AND bridge_income_entry.to_iban = source_account.iban
+                INNER JOIN accounts bridge_account ON
+                    bridge_account.id = bridge_income_entry.account_id
+                    AND bridge_account.deleted_at IS NULL
+                    AND bridge_account.is_active = 1
+                    AND bridge_account.instrument_id = target_account.instrument_id
+                INNER JOIN transactions bridge_income_tx ON
+                    bridge_income_tx.id = bridge_income_entry.transaction_id
+                    AND bridge_income_tx.type = '${TransactionTypeEnum.INCOME}'
+                    AND bridge_income_tx.deleted_at IS NULL
+                    AND bridge_income_tx.consolidation_parent_transaction_id IS NULL
+                    AND ABS(bridge_income_tx.operated_at - existing_transfer.operated_at) <= ${TRANSFER_PAIR_FAST_TIME_WINDOW_SECONDS}
+                INNER JOIN transaction_entries bridge_expense_entry ON
+                    bridge_expense_entry.deleted_at IS NULL
+                    AND bridge_expense_entry.original_transaction_id IS NULL
+                    AND bridge_expense_entry.account_id = bridge_account.id
+                    AND bridge_expense_entry.amount = existing_target_entry.amount
+                    AND bridge_expense_entry.exchange_rate > 0
+                    AND bridge_expense_entry.to_iban = target_account.iban
+                INNER JOIN transactions bridge_expense_tx ON
+                    bridge_expense_tx.id = bridge_expense_entry.transaction_id
+                    AND bridge_expense_tx.type = '${TransactionTypeEnum.EXPENSE}'
+                    AND bridge_expense_tx.deleted_at IS NULL
+                    AND bridge_expense_tx.consolidation_parent_transaction_id IS NULL
+                    AND ABS(bridge_expense_tx.operated_at - existing_transfer.operated_at) <= ${TRANSFER_PAIR_FAST_TIME_WINDOW_SECONDS}
+                WHERE existing_transfer.type = '${TransactionTypeEnum.TRANSFER}'
+                    AND existing_transfer.deleted_at IS NULL
+                    AND existing_transfer.consolidation_parent_transaction_id IS NULL
+                    AND existing_transfer.from_account_id IS NOT NULL
+                    AND existing_transfer.to_account_id IS NOT NULL
+                    AND existing_transfer.consolidation_type = '${TransactionConsolidationTypeEnum.TRANSFER_PAIR}'
+                    AND source_account.id != bridge_account.id
+                    AND bridge_account.id != target_account.id
+                    AND source_account.id != target_account.id
+                    AND ABS(existing_source_entry.amount - (bridge_income_entry.amount / bridge_income_entry.exchange_rate)) / existing_source_entry.amount <= ${IBAN_BRIDGE_CHAIN_FX_TOLERANCE}
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM transaction_entries bridge_income_fee_entry
+                        WHERE bridge_income_fee_entry.transaction_id = bridge_income_tx.id
+                            AND bridge_income_fee_entry.deleted_at IS NULL
+                            AND bridge_income_fee_entry.original_transaction_id IS NULL
+                            AND bridge_income_fee_entry.type = '${TransactionEntryTypeEnum.FEE}'
+                    )
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM transaction_entries bridge_expense_fee_entry
+                        WHERE bridge_expense_fee_entry.transaction_id = bridge_expense_tx.id
+                            AND bridge_expense_fee_entry.deleted_at IS NULL
+                            AND bridge_expense_fee_entry.original_transaction_id IS NULL
+                            AND bridge_expense_fee_entry.type = '${TransactionEntryTypeEnum.FEE}'
+                    )
+            )
+            WHERE existingTransferRank = 1
+                AND bridgeIncomeRank = 1
+                AND bridgeExpenseRank = 1
+`;

--- a/packages/contracts/src/transaction/repository/sql-factory/transfer-pair-iban-bridge-chain-sql.factory.ts
+++ b/packages/contracts/src/transaction/repository/sql-factory/transfer-pair-iban-bridge-chain-sql.factory.ts
@@ -1,3 +1,4 @@
+import { IBAN_BRIDGE_CHAIN_FX_TOLERANCE } from '../../constant/iban-bridge-chain-fx-tolerance.constant';
 import { TRANSFER_MCC_GROUP_ID } from '../../constant/transfer-mcc-group-id.constant';
 import { TRANSFER_PAIR_FAST_TIME_WINDOW_SECONDS } from '../../constant/transfer-pair-fast-time-window.constant';
 import { TransactionTypeEnum } from '../../enum/transaction-type.enum';
@@ -182,7 +183,7 @@ export const IBAN_BRIDGE_CHAIN_TRANSFER_CANDIDATES_SQL = `
                     AND source_account.id != bridge_account.id
                     AND bridge_account.id != target_account.id
                     AND source_account.id != target_account.id
-                    AND ABS(source_expense_entry.amount - (bridge_income_entry.amount / bridge_income_entry.exchange_rate)) / source_expense_entry.amount <= 0.01
+                    AND ABS(source_expense_entry.amount - (bridge_income_entry.amount / bridge_income_entry.exchange_rate)) / source_expense_entry.amount <= ${IBAN_BRIDGE_CHAIN_FX_TOLERANCE}
                     AND (
                         source_expense_mcc.mcc_group_id = ${TRANSFER_MCC_GROUP_ID}
                         OR bridge_income_mcc.mcc_group_id = ${TRANSFER_MCC_GROUP_ID}

--- a/packages/contracts/src/transaction/repository/transfer-pair.repository.ts
+++ b/packages/contracts/src/transaction/repository/transfer-pair.repository.ts
@@ -11,6 +11,7 @@ import {
     buildAtmCashWithdrawalReviewCandidatesSql
 } from './sql-factory/transfer-pair-cash-withdrawal-sql.factory';
 import { EXISTING_TRANSFER_BRIDGE_CANDIDATES_SQL } from './sql-factory/transfer-pair-existing-transfer-bridge-sql.factory';
+import { EXISTING_TRANSFER_CHAIN_RECLAIM_CANDIDATES_SQL } from './sql-factory/transfer-pair-existing-transfer-chain-reclaim-sql.factory';
 import { EXISTING_TRANSFER_INCOME_DUPLICATE_CANDIDATES_SQL } from './sql-factory/transfer-pair-existing-transfer-income-duplicate-sql.factory';
 import { IBAN_BRIDGE_CANONICAL_DUPLICATE_CANDIDATES_SQL } from './sql-factory/transfer-pair-iban-bridge-canonical-duplicate-sql.factory';
 import { IBAN_BRIDGE_CHAIN_TRANSFER_CANDIDATES_SQL } from './sql-factory/transfer-pair-iban-bridge-chain-sql.factory';
@@ -20,6 +21,7 @@ import type { DB } from '../../@generic/type/db.type';
 import type { AtmCashWithdrawalCandidateInterface } from '../interface/atm-cash-withdrawal-candidate.interface';
 import type { AtmCashWithdrawalReviewCandidateInterface } from '../interface/atm-cash-withdrawal-review-candidate.interface';
 import type { ExistingTransferBridgeCandidateInterface } from '../interface/existing-transfer-bridge-candidate.interface';
+import type { ExistingTransferChainReclaimCandidateInterface } from '../interface/existing-transfer-chain-reclaim-candidate.interface';
 import type { ExistingTransferIncomeDuplicateCandidateInterface } from '../interface/existing-transfer-income-duplicate-candidate.interface';
 import type { IbanBridgeCanonicalDuplicateCandidateInterface } from '../interface/iban-bridge-canonical-duplicate-candidate.interface';
 import type { IbanBridgeChainTransferCandidateInterface } from '../interface/iban-bridge-chain-transfer-candidate.interface';
@@ -91,5 +93,12 @@ export class TransferPairRepository {
         const sql = IBAN_BRIDGE_CHAIN_TRANSFER_CANDIDATES_SQL;
 
         return this.db.$client.getAllAsync<IbanBridgeChainTransferCandidateInterface>(sql);
+    }
+
+    @Log('enter', result => `done count=${result.length}`, error => `throw error=${getErrorMessage(error)}`)
+    async findExistingTransferChainReclaimCandidates(): Promise<ExistingTransferChainReclaimCandidateInterface[]> {
+        const sql = EXISTING_TRANSFER_CHAIN_RECLAIM_CANDIDATES_SQL;
+
+        return this.db.$client.getAllAsync<ExistingTransferChainReclaimCandidateInterface>(sql);
     }
 }

--- a/tests/consolidation-tests/src/harness/chain-reclaim-fixture.ts
+++ b/tests/consolidation-tests/src/harness/chain-reclaim-fixture.ts
@@ -1,0 +1,52 @@
+import { PRECISION, TransactionConsolidationTypeEnum, TransactionTypeEnum } from '@budgie/contracts';
+import { expect } from 'vitest';
+
+import { runConsolidation } from './run-consolidation';
+import { testQueryService, testSeedService } from './test-context';
+
+import type { AccountEntityInterface, TransactionEntityInterface } from '@budgie/contracts';
+import type { ChainReclaimScenarioInputInterface } from '@budgie-at/test-kit';
+
+const CHAIN_RECLAIM_TARGET_UAH_UNITS = 4000;
+const CHAIN_RECLAIM_OPERATED_AT_YEAR = 2026;
+
+export const CHAIN_RECLAIM_SOURCE_AMOUNT = 100 * PRECISION;
+export const CHAIN_RECLAIM_TARGET_AMOUNT = CHAIN_RECLAIM_TARGET_UAH_UNITS * PRECISION;
+export const CHAIN_RECLAIM_BRIDGE_EXCHANGE_RATE = 40;
+export const CHAIN_RECLAIM_EXCHANGE_RATE = CHAIN_RECLAIM_SOURCE_AMOUNT / CHAIN_RECLAIM_TARGET_AMOUNT;
+export const CHAIN_RECLAIM_OPERATED_AT = new Date(CHAIN_RECLAIM_OPERATED_AT_YEAR, 0, 15, 12, 0, 0);
+
+type ChainReclaimFixtureOverrides = Omit<
+    ChainReclaimScenarioInputInterface,
+    'sourceAmount' | 'targetAmount' | 'bridgeExchangeRate' | 'operatedAt'
+>;
+
+export const seedChainReclaim = (overrides: ChainReclaimFixtureOverrides = {}) =>
+    testSeedService.chainReclaimScenario({
+        sourceAmount: CHAIN_RECLAIM_SOURCE_AMOUNT,
+        targetAmount: CHAIN_RECLAIM_TARGET_AMOUNT,
+        bridgeExchangeRate: CHAIN_RECLAIM_BRIDGE_EXCHANGE_RATE,
+        operatedAt: CHAIN_RECLAIM_OPERATED_AT,
+        ...overrides
+    });
+
+export const runChainReclaimAndExpectSingleCanonical = async (): Promise<TransactionEntityInterface> => {
+    const result = await runConsolidation();
+    expect(result.consolidated).toBe(1);
+
+    const canonicals = testQueryService.fetchCanonicalsOfType(TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER);
+    expect(canonicals).toHaveLength(1);
+
+    return canonicals[0];
+};
+
+export const expectChainCanonicalEndpoints = (
+    canonical: TransactionEntityInterface,
+    sourceAccount: AccountEntityInterface,
+    targetAccount: AccountEntityInterface
+): void => {
+    expect(canonical.type).toBe(TransactionTypeEnum.TRANSFER);
+    expect(canonical.fromAccountId).toBe(sourceAccount.id);
+    expect(canonical.toAccountId).toBe(targetAccount.id);
+    expect(canonical.exchangeRate).toBe(CHAIN_RECLAIM_EXCHANGE_RATE);
+};

--- a/tests/consolidation-tests/src/scenarios/existing-transfer-chain-reclaim-fast-path.test.ts
+++ b/tests/consolidation-tests/src/scenarios/existing-transfer-chain-reclaim-fast-path.test.ts
@@ -1,0 +1,66 @@
+import { TransactionConsolidationTypeEnum } from '@budgie/contracts';
+import { describe, expect, it } from 'vitest';
+
+import {
+    CHAIN_RECLAIM_EXCHANGE_RATE,
+    expectChainCanonicalEndpoints,
+    runChainReclaimAndExpectSingleCanonical,
+    seedChainReclaim
+} from '../harness/chain-reclaim-fixture';
+import { runConsolidation } from '../harness/run-consolidation';
+import { testDb, testQueryService, unconsolidationService } from '../harness/test-context';
+
+describe('consolidation/existing-transfer-chain-reclaim-fast-path', () => {
+    // eslint-disable-next-line max-statements -- Integration scenario: seed + consolidate + multi-assert
+    it('absorbs the orphaned bridge legs into the existing transfer keeping its identity', async () => {
+        const { sourceAccount, bridgeAccount, targetAccount, transfer, backingExpense, backingIncome, bridgeIncome, bridgeExpense } =
+            seedChainReclaim();
+
+        const sourceBalanceBefore = testQueryService.fetchLiveBalanceByAccount(sourceAccount.id);
+        const targetBalanceBefore = testQueryService.fetchLiveBalanceByAccount(targetAccount.id);
+        const bridgeBalanceBefore = testQueryService.fetchLiveBalanceByAccount(bridgeAccount.id);
+
+        const canonical = await runChainReclaimAndExpectSingleCanonical();
+        expect(canonical.id).toBe(transfer.id);
+        expectChainCanonicalEndpoints(canonical, sourceAccount, targetAccount);
+
+        expect(testQueryService.fetchTransactionById(bridgeIncome.id).consolidationParentTransactionId).toBe(transfer.id);
+        expect(testQueryService.fetchTransactionById(bridgeExpense.id).consolidationParentTransactionId).toBe(transfer.id);
+
+        expect(backingExpense).not.toBeNull();
+        expect(backingIncome).not.toBeNull();
+
+        const canonicalEntries = testQueryService.fetchEntriesByTransactionId(transfer.id);
+        const sourceIds = canonicalEntries.flatMap(entry => (entry.originalTransactionId ? [entry.originalTransactionId] : []));
+        expect(sourceIds.sort()).toEqual([backingExpense?.id, backingIncome?.id, bridgeIncome.id, bridgeExpense.id].sort());
+
+        const liveCanonicalEntries = canonicalEntries.filter(entry => entry.originalTransactionId === null);
+        expect(liveCanonicalEntries).toHaveLength(2);
+        const liveFromEntry = liveCanonicalEntries.find(entry => entry.accountId === sourceAccount.id);
+        const liveToEntry = liveCanonicalEntries.find(entry => entry.accountId === targetAccount.id);
+        expect(liveFromEntry?.exchangeRate).toBe(CHAIN_RECLAIM_EXCHANGE_RATE);
+        expect(liveToEntry?.exchangeRate).toBe(1);
+
+        expect(testQueryService.fetchLiveBalanceByAccount(sourceAccount.id)).toBe(sourceBalanceBefore);
+        expect(testQueryService.fetchLiveBalanceByAccount(targetAccount.id)).toBe(targetBalanceBefore);
+        expect(testQueryService.fetchLiveBalanceByAccount(bridgeAccount.id)).toBe(bridgeBalanceBefore);
+
+        const idempotentResult = await runConsolidation();
+        expect(idempotentResult.consolidated).toBe(0);
+        expect(idempotentResult.groups.existingTransferChainReclaimCandidates).toHaveLength(0);
+
+        await unconsolidationService.unconsolidateById(transfer.id, testDb);
+
+        expect(testQueryService.fetchCanonicalsOfType(TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER)).toHaveLength(0);
+
+        for (const restoredId of [backingExpense?.id, backingIncome?.id, bridgeIncome.id, bridgeExpense.id]) {
+            expect(restoredId).toBeDefined();
+            expect(testQueryService.fetchTransactionById(restoredId ?? 0).consolidationParentTransactionId).toBeNull();
+        }
+
+        expect(testQueryService.fetchEntryByExternalId('bridge-income').originalTransactionId).toBeNull();
+        expect(testQueryService.fetchEntryByExternalId('bridge-expense').originalTransactionId).toBeNull();
+        expect(testQueryService.fetchEntryByExternalId('transfer-backing-expense').originalTransactionId).toBeNull();
+        expect(testQueryService.fetchEntryByExternalId('transfer-backing-income').originalTransactionId).toBeNull();
+    });
+});

--- a/tests/consolidation-tests/src/scenarios/existing-transfer-chain-reclaim-negatives.test.ts
+++ b/tests/consolidation-tests/src/scenarios/existing-transfer-chain-reclaim-negatives.test.ts
@@ -1,0 +1,168 @@
+import { PRECISION, TransactionConsolidationTypeEnum } from '@budgie/contracts';
+import { describe, expect, it } from 'vitest';
+
+import {
+    CHAIN_RECLAIM_BRIDGE_EXCHANGE_RATE,
+    CHAIN_RECLAIM_EXCHANGE_RATE,
+    CHAIN_RECLAIM_OPERATED_AT,
+    CHAIN_RECLAIM_SOURCE_AMOUNT,
+    CHAIN_RECLAIM_TARGET_AMOUNT,
+    seedChainReclaim
+} from '../harness/chain-reclaim-fixture';
+import { runConsolidation } from '../harness/run-consolidation';
+import { testQueryService, testSeedService } from '../harness/test-context';
+
+const OUTSIDE_FAST_WINDOW_MS = 120_000;
+const LONE_INCOME_OFFSET_MS = 11_000;
+const HOP_B_INCOME_OFFSET_MS = 5_000;
+const HOP_B_EXPENSE_OFFSET_MS = 6_000;
+const HOP_C_INCOME_OFFSET_MS = 7_000;
+const HOP_C_EXPENSE_OFFSET_MS = 8_000;
+const BRIDGE_INCOME_OFFSET_MS = 10_000;
+const BRIDGE_EXPENSE_OFFSET_MS = 12_000;
+
+const expectNoReclaim = async (): Promise<void> => {
+    const result = await runConsolidation();
+    expect(result.groups.existingTransferChainReclaimCandidates).toHaveLength(0);
+    expect(testQueryService.fetchCanonicalsOfType(TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER)).toHaveLength(0);
+};
+
+// eslint-disable-next-line max-lines-per-function -- Integration scenario suite with many negative cases
+describe('consolidation/existing-transfer-chain-reclaim-negatives', () => {
+    it('does not reclaim when the bridge amounts differ from the transfer target amount', async () => {
+        seedChainReclaim({
+            bridgeIncomeAmount: CHAIN_RECLAIM_TARGET_AMOUNT + PRECISION,
+            bridgeExpenseAmount: CHAIN_RECLAIM_TARGET_AMOUNT + PRECISION
+        });
+
+        await expectNoReclaim();
+    });
+
+    it('does not reclaim when the bridge income to_iban is not the source account IBAN', async () => {
+        seedChainReclaim({ bridgeIncomeToIban: 'UA-WRONG' });
+
+        await expectNoReclaim();
+    });
+
+    it('does not reclaim when the bridge expense to_iban is not the target account IBAN', async () => {
+        seedChainReclaim({ bridgeExpenseToIban: 'UA-WRONG' });
+
+        await expectNoReclaim();
+    });
+
+    it('does not reclaim when the bridge instrument differs from the target instrument', async () => {
+        const eurInstrument = testSeedService.instrument({ code: 'EUR', name: 'Euro', symbol: '€' });
+        seedChainReclaim({ bridgeInstrumentId: eurInstrument.id });
+
+        await expectNoReclaim();
+    });
+
+    it('does not reclaim when the bridge legs fall outside the fast time window', async () => {
+        seedChainReclaim({ bridgeOperatedAtOffsetMs: OUTSIDE_FAST_WINDOW_MS });
+
+        await expectNoReclaim();
+    });
+
+    it('does not reclaim a lone same-amount income leg without a matching bridge expense', async () => {
+        const scenario = seedChainReclaim({ bridgeExpenseToIban: 'UA-WRONG' });
+        const transferMcc = testQueryService.findMccByCode('4829');
+        testSeedService.bankPairIncome(
+            { externalId: 'lone-income', operatedAt: new Date(CHAIN_RECLAIM_OPERATED_AT.getTime() + LONE_INCOME_OFFSET_MS) },
+            {
+                accountId: scenario.bridgeAccount.id,
+                amount: CHAIN_RECLAIM_TARGET_AMOUNT,
+                exchangeRate: CHAIN_RECLAIM_BRIDGE_EXCHANGE_RATE,
+                toIban: 'UA-SOURCE',
+                mccCategoryId: transferMcc.id
+            }
+        );
+
+        await expectNoReclaim();
+    });
+
+    it('does not reclaim across a three-hop chain where the bridge legs sit on different accounts', async () => {
+        const usdInstrument = testSeedService.instrument({ code: 'USD', name: 'Dollar', symbol: '$' });
+        const accountA = testSeedService.bankSyncAccount('A USD', null, 'UA-A', usdInstrument.id);
+        const accountB = testSeedService.bankSyncAccount('B UAH', null, 'UA-B', 1);
+        const accountC = testSeedService.bankSyncAccount('C UAH', null, 'UA-C', 1);
+        const accountD = testSeedService.bankSyncAccount('D UAH', null, 'UA-D', 1);
+
+        testSeedService.directTransfer({
+            fromAccountId: accountA.id,
+            toAccountId: accountD.id,
+            fromAmount: CHAIN_RECLAIM_SOURCE_AMOUNT,
+            toAmount: CHAIN_RECLAIM_TARGET_AMOUNT,
+            operatedAt: CHAIN_RECLAIM_OPERATED_AT,
+            exchangeRate: CHAIN_RECLAIM_EXCHANGE_RATE,
+            fromEntryExchangeRate: CHAIN_RECLAIM_EXCHANGE_RATE,
+            toEntryExchangeRate: 1,
+            fromEntryToIban: 'UA-D',
+            withBackingSources: true
+        });
+        testSeedService.bankPairIncome(
+            { externalId: 'hop-b-income', operatedAt: new Date(CHAIN_RECLAIM_OPERATED_AT.getTime() + HOP_B_INCOME_OFFSET_MS) },
+            {
+                accountId: accountB.id,
+                amount: CHAIN_RECLAIM_TARGET_AMOUNT,
+                exchangeRate: CHAIN_RECLAIM_BRIDGE_EXCHANGE_RATE,
+                toIban: 'UA-A'
+            }
+        );
+        testSeedService.bankPairExpense(
+            { externalId: 'hop-b-expense', operatedAt: new Date(CHAIN_RECLAIM_OPERATED_AT.getTime() + HOP_B_EXPENSE_OFFSET_MS) },
+            { accountId: accountB.id, amount: CHAIN_RECLAIM_TARGET_AMOUNT, exchangeRate: 1, toIban: 'UA-C' }
+        );
+        testSeedService.bankPairIncome(
+            { externalId: 'hop-c-income', operatedAt: new Date(CHAIN_RECLAIM_OPERATED_AT.getTime() + HOP_C_INCOME_OFFSET_MS) },
+            { accountId: accountC.id, amount: CHAIN_RECLAIM_TARGET_AMOUNT, exchangeRate: 1, toIban: 'UA-B' }
+        );
+        testSeedService.bankPairExpense(
+            { externalId: 'hop-c-expense', operatedAt: new Date(CHAIN_RECLAIM_OPERATED_AT.getTime() + HOP_C_EXPENSE_OFFSET_MS) },
+            { accountId: accountC.id, amount: CHAIN_RECLAIM_TARGET_AMOUNT, exchangeRate: 1, toIban: 'UA-D' }
+        );
+
+        await expectNoReclaim();
+    });
+
+    it('does not reclaim when a bridge leg carries a fee entry', async () => {
+        const scenario = seedChainReclaim();
+        testSeedService.feeEntry(scenario.bridgeIncome.id, scenario.bridgeAccount.id, 5 * PRECISION, 'bridge-income-fee');
+
+        await expectNoReclaim();
+    });
+
+    it('does not reclaim a bare hand-created direct transfer with no consolidation type', async () => {
+        const usdInstrument = testSeedService.instrument({ code: 'USD', name: 'Dollar', symbol: '$' });
+        const sourceAccount = testSeedService.bankSyncAccount('Source USD', null, 'UA-SOURCE', usdInstrument.id);
+        const bridgeAccount = testSeedService.bankSyncAccount('Bridge UAH', null, 'UA-BRIDGE', 1);
+        const targetAccount = testSeedService.bankSyncAccount('Target UAH', null, 'UA-TARGET', 1);
+
+        testSeedService.directTransfer({
+            fromAccountId: sourceAccount.id,
+            toAccountId: targetAccount.id,
+            fromAmount: CHAIN_RECLAIM_SOURCE_AMOUNT,
+            toAmount: CHAIN_RECLAIM_TARGET_AMOUNT,
+            operatedAt: CHAIN_RECLAIM_OPERATED_AT,
+            exchangeRate: CHAIN_RECLAIM_EXCHANGE_RATE,
+            fromEntryExchangeRate: CHAIN_RECLAIM_EXCHANGE_RATE,
+            toEntryExchangeRate: 1,
+            fromEntryToIban: 'UA-TARGET',
+            consolidationType: null
+        });
+        testSeedService.bankPairIncome(
+            { externalId: 'bridge-income', operatedAt: new Date(CHAIN_RECLAIM_OPERATED_AT.getTime() + BRIDGE_INCOME_OFFSET_MS) },
+            {
+                accountId: bridgeAccount.id,
+                amount: CHAIN_RECLAIM_TARGET_AMOUNT,
+                exchangeRate: CHAIN_RECLAIM_BRIDGE_EXCHANGE_RATE,
+                toIban: 'UA-SOURCE'
+            }
+        );
+        testSeedService.bankPairExpense(
+            { externalId: 'bridge-expense', operatedAt: new Date(CHAIN_RECLAIM_OPERATED_AT.getTime() + BRIDGE_EXPENSE_OFFSET_MS) },
+            { accountId: bridgeAccount.id, amount: CHAIN_RECLAIM_TARGET_AMOUNT, exchangeRate: 1, toIban: 'UA-TARGET' }
+        );
+
+        await expectNoReclaim();
+    });
+});

--- a/tests/consolidation-tests/src/scenarios/existing-transfer-chain-reclaim-rank-dedup.test.ts
+++ b/tests/consolidation-tests/src/scenarios/existing-transfer-chain-reclaim-rank-dedup.test.ts
@@ -1,0 +1,59 @@
+import { TransactionConsolidationTypeEnum } from '@budgie/contracts';
+import { describe, expect, it } from 'vitest';
+
+import {
+    CHAIN_RECLAIM_BRIDGE_EXCHANGE_RATE,
+    CHAIN_RECLAIM_OPERATED_AT,
+    CHAIN_RECLAIM_TARGET_AMOUNT,
+    seedChainReclaim
+} from '../harness/chain-reclaim-fixture';
+import { runConsolidation } from '../harness/run-consolidation';
+import { testQueryService, testSeedService } from '../harness/test-context';
+
+const SECOND_BRIDGE_INCOME_OFFSET_MS = 20_000;
+const SECOND_BRIDGE_EXPENSE_OFFSET_MS = 21_000;
+
+describe('consolidation/existing-transfer-chain-reclaim-rank-dedup', () => {
+    // eslint-disable-next-line max-statements -- Integration scenario: seed + consolidate + multi-assert
+    it('reclaims exactly one bridge pair when two pairs surround a single transfer', async () => {
+        const scenario = seedChainReclaim();
+        const { transfer, bridgeIncome: firstBridgeIncome, bridgeExpense: firstBridgeExpense } = scenario;
+        const secondBridgeAccount = testSeedService.bankSyncAccount('Bridge Two UAH', null, 'UA-BRIDGE-2', 1);
+        const secondBridgeIncome = testSeedService.bankPairIncome(
+            { externalId: 'bridge-two-income', operatedAt: new Date(CHAIN_RECLAIM_OPERATED_AT.getTime() + SECOND_BRIDGE_INCOME_OFFSET_MS) },
+            {
+                accountId: secondBridgeAccount.id,
+                amount: CHAIN_RECLAIM_TARGET_AMOUNT,
+                exchangeRate: CHAIN_RECLAIM_BRIDGE_EXCHANGE_RATE,
+                toIban: 'UA-SOURCE'
+            }
+        );
+        const secondBridgeExpense = testSeedService.bankPairExpense(
+            {
+                externalId: 'bridge-two-expense',
+                operatedAt: new Date(CHAIN_RECLAIM_OPERATED_AT.getTime() + SECOND_BRIDGE_EXPENSE_OFFSET_MS)
+            },
+            { accountId: secondBridgeAccount.id, amount: CHAIN_RECLAIM_TARGET_AMOUNT, exchangeRate: 1, toIban: 'UA-TARGET' }
+        );
+
+        const result = await runConsolidation();
+        expect(result.groups.existingTransferChainReclaimCandidates).toHaveLength(1);
+
+        const canonicals = testQueryService.fetchCanonicalsOfType(TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER);
+        expect(canonicals).toHaveLength(1);
+        expect(canonicals[0].id).toBe(transfer.id);
+
+        const reclaimedSourceIds = testQueryService
+            .fetchEntriesByTransactionId(transfer.id)
+            .flatMap(entry => (entry.originalTransactionId ? [entry.originalTransactionId] : []));
+        const firstPairReclaimed = reclaimedSourceIds.includes(firstBridgeIncome.id) && reclaimedSourceIds.includes(firstBridgeExpense.id);
+        const secondPairReclaimed =
+            reclaimedSourceIds.includes(secondBridgeIncome.id) && reclaimedSourceIds.includes(secondBridgeExpense.id);
+        expect(firstPairReclaimed !== secondPairReclaimed).toBe(true);
+
+        const orphanIncome = firstPairReclaimed ? secondBridgeIncome : firstBridgeIncome;
+        const orphanExpense = firstPairReclaimed ? secondBridgeExpense : firstBridgeExpense;
+        expect(testQueryService.fetchTransactionById(orphanIncome.id).consolidationParentTransactionId).toBeNull();
+        expect(testQueryService.fetchTransactionById(orphanExpense.id).consolidationParentTransactionId).toBeNull();
+    });
+});

--- a/tests/consolidation-tests/src/scenarios/existing-transfer-chain-reclaim-rebuild.test.ts
+++ b/tests/consolidation-tests/src/scenarios/existing-transfer-chain-reclaim-rebuild.test.ts
@@ -1,0 +1,71 @@
+import { TransactionConsolidationTypeEnum } from '@budgie/contracts';
+import { describe, expect, it } from 'vitest';
+
+import {
+    CHAIN_RECLAIM_EXCHANGE_RATE,
+    CHAIN_RECLAIM_SOURCE_AMOUNT,
+    CHAIN_RECLAIM_TARGET_AMOUNT,
+    expectChainCanonicalEndpoints,
+    runChainReclaimAndExpectSingleCanonical,
+    seedChainReclaim
+} from '../harness/chain-reclaim-fixture';
+import { runConsolidation } from '../harness/run-consolidation';
+import { testDb, testQueryService, unconsolidationService } from '../harness/test-context';
+
+const DIVERGENT_EXCHANGE_RATE = 0.5;
+
+describe('consolidation/existing-transfer-chain-reclaim-rebuild', () => {
+    // eslint-disable-next-line max-statements -- Integration scenario: seed + consolidate + multi-assert
+    it('rebuilds a fresh FX-correct canonical when the existing transfer ledger diverges', async () => {
+        const { sourceAccount, bridgeAccount, targetAccount, transfer, backingExpense, backingIncome, bridgeIncome, bridgeExpense } =
+            seedChainReclaim({
+                transferExchangeRate: DIVERGENT_EXCHANGE_RATE,
+                transferFromEntryExchangeRate: DIVERGENT_EXCHANGE_RATE,
+                transferToEntryExchangeRate: 2,
+                transferFromEntryToIban: 'UA-WRONG'
+            });
+
+        const canonical = await runChainReclaimAndExpectSingleCanonical();
+        expect(canonical.id).not.toBe(transfer.id);
+        expectChainCanonicalEndpoints(canonical, sourceAccount, targetAccount);
+
+        const rebuiltId = canonical.id;
+        expect(testQueryService.fetchTransactionById(transfer.id).consolidationParentTransactionId).toBe(rebuiltId);
+        expect(testQueryService.fetchTransactionById(bridgeIncome.id).consolidationParentTransactionId).toBe(rebuiltId);
+        expect(testQueryService.fetchTransactionById(bridgeExpense.id).consolidationParentTransactionId).toBe(rebuiltId);
+
+        const rebuiltEntries = testQueryService.fetchEntriesByTransactionId(rebuiltId);
+        const liveEntries = rebuiltEntries.filter(entry => entry.originalTransactionId === null);
+        expect(liveEntries).toHaveLength(2);
+        const liveFromEntry = liveEntries.find(entry => entry.accountId === sourceAccount.id);
+        const liveToEntry = liveEntries.find(entry => entry.accountId === targetAccount.id);
+        expect(liveFromEntry?.amount).toBe(CHAIN_RECLAIM_SOURCE_AMOUNT);
+        expect(liveFromEntry?.exchangeRate).toBe(CHAIN_RECLAIM_EXCHANGE_RATE);
+        expect(liveFromEntry?.toIban).toBe('UA-TARGET');
+        expect(liveToEntry?.amount).toBe(CHAIN_RECLAIM_TARGET_AMOUNT);
+        expect(liveToEntry?.exchangeRate).toBe(1);
+
+        expect(testQueryService.fetchLiveBalanceByAccount(sourceAccount.id)).toBe(-CHAIN_RECLAIM_SOURCE_AMOUNT);
+        expect(testQueryService.fetchLiveBalanceByAccount(targetAccount.id)).toBe(CHAIN_RECLAIM_TARGET_AMOUNT);
+        expect(testQueryService.fetchLiveBalanceByAccount(bridgeAccount.id)).toBe(0);
+
+        const idempotentResult = await runConsolidation();
+        expect(idempotentResult.consolidated).toBe(0);
+        expect(idempotentResult.groups.existingTransferChainReclaimCandidates).toHaveLength(0);
+
+        await unconsolidationService.unconsolidateById(rebuiltId, testDb);
+
+        expect(testQueryService.fetchCanonicalsOfType(TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER)).toHaveLength(0);
+
+        const restoredTransfer = testQueryService.fetchTransactionById(transfer.id);
+        expect(restoredTransfer.consolidationParentTransactionId).toBeNull();
+        expect(restoredTransfer.consolidationType).toBe(TransactionConsolidationTypeEnum.TRANSFER_PAIR);
+        expect(testQueryService.fetchTransactionById(bridgeIncome.id).consolidationParentTransactionId).toBeNull();
+        expect(testQueryService.fetchTransactionById(bridgeExpense.id).consolidationParentTransactionId).toBeNull();
+
+        expect(backingExpense).not.toBeNull();
+        expect(backingIncome).not.toBeNull();
+        expect(testQueryService.fetchTransactionById(backingExpense?.id ?? 0).consolidationParentTransactionId).toBe(transfer.id);
+        expect(testQueryService.fetchTransactionById(backingIncome?.id ?? 0).consolidationParentTransactionId).toBe(transfer.id);
+    });
+});

--- a/tests/test-kit/src/index.ts
+++ b/tests/test-kit/src/index.ts
@@ -6,5 +6,6 @@ export { TestQueryService } from './query/service/test-query.service';
 export { TestSeedService } from './seed/service/test-seed.service';
 export { createTestInlineShimPlugin, createTestVitestConfig } from './vitest/create-test-inline-shim-plugin';
 export type { ExpoLikeApiInterface } from './db/expo-like-api.interface';
+export type { ChainReclaimScenarioInputInterface } from './seed/interface/chain-reclaim-scenario-input.interface';
 export type { SeedBankPairEntryInputType } from './seed/interface/seed-bank-pair-entry-input.type';
 export type { TestInlineShimPluginInterface } from './vitest/interface/test-inline-shim-plugin.interface';

--- a/tests/test-kit/src/query/service/test-query.service.ts
+++ b/tests/test-kit/src/query/service/test-query.service.ts
@@ -1,6 +1,11 @@
-import { eq } from 'drizzle-orm';
-
-import { MccCategoryEntityTable, TransactionEntityTable, TransactionEntryEntityTable, TransactionTagsEntityTable } from '@budgie/contracts';
+import {
+    MccCategoryEntityTable,
+    TransactionEntityTable,
+    TransactionEntryEntityTable,
+    TransactionEntryTypeEnum,
+    TransactionTagsEntityTable
+} from '@budgie/contracts';
+import { and, eq, isNull } from 'drizzle-orm';
 
 import { isDefined } from '@rnw-community/shared';
 
@@ -24,7 +29,7 @@ export class TestQueryService {
     }
 
     fetchTransactionById(id: number): TransactionEntityInterface {
-        const row = this.database.select().from(TransactionEntityTable).where(eq(TransactionEntityTable.id, id)).all()[0];
+        const [row] = this.database.select().from(TransactionEntityTable).where(eq(TransactionEntityTable.id, id)).all();
 
         if (!isDefined(row)) {
             throw new Error(`Transaction ${id} not found`);
@@ -42,11 +47,11 @@ export class TestQueryService {
     }
 
     fetchEntryByExternalId(externalId: string): TransactionEntryEntityInterface {
-        const row = this.database
+        const [row] = this.database
             .select()
             .from(TransactionEntryEntityTable)
             .where(eq(TransactionEntryEntityTable.externalId, externalId))
-            .all()[0];
+            .all();
 
         if (!isDefined(row)) {
             throw new Error(`Transaction entry ${externalId} not found`);
@@ -64,8 +69,30 @@ export class TestQueryService {
             .map(row => row.tagId);
     }
 
+    fetchLiveBalanceByAccount(accountId: number): number {
+        const rows = this.database
+            .select({ type: TransactionEntryEntityTable.type, amount: TransactionEntryEntityTable.amount })
+            .from(TransactionEntryEntityTable)
+            .where(
+                and(
+                    eq(TransactionEntryEntityTable.accountId, accountId),
+                    isNull(TransactionEntryEntityTable.deletedAt),
+                    isNull(TransactionEntryEntityTable.originalTransactionId)
+                )
+            )
+            .all();
+
+        return rows.reduce((balance, row) => {
+            if (row.type === TransactionEntryTypeEnum.DEBIT) {
+                return balance + row.amount;
+            }
+
+            return balance - row.amount;
+        }, 0);
+    }
+
     findMccByCode(mcc: string): Pick<MccCategoryEntityInterface, 'id' | 'mccGroupId'> {
-        const row = this.database.select().from(MccCategoryEntityTable).where(eq(MccCategoryEntityTable.mcc, mcc)).all()[0];
+        const [row] = this.database.select().from(MccCategoryEntityTable).where(eq(MccCategoryEntityTable.mcc, mcc)).all();
 
         if (!isDefined(row)) {
             throw new Error(`MCC ${mcc} not found`);

--- a/tests/test-kit/src/seed/interface/chain-reclaim-scenario-input.interface.ts
+++ b/tests/test-kit/src/seed/interface/chain-reclaim-scenario-input.interface.ts
@@ -1,0 +1,16 @@
+export interface ChainReclaimScenarioInputInterface {
+    readonly sourceAmount: number;
+    readonly targetAmount: number;
+    readonly bridgeExchangeRate: number;
+    readonly operatedAt: Date;
+    readonly transferExchangeRate?: number;
+    readonly transferFromEntryExchangeRate?: number;
+    readonly transferToEntryExchangeRate?: number;
+    readonly transferFromEntryToIban?: string;
+    readonly bridgeInstrumentId?: number;
+    readonly bridgeIncomeAmount?: number;
+    readonly bridgeExpenseAmount?: number;
+    readonly bridgeIncomeToIban?: string;
+    readonly bridgeExpenseToIban?: string;
+    readonly bridgeOperatedAtOffsetMs?: number;
+}

--- a/tests/test-kit/src/seed/service/test-seed.service.ts
+++ b/tests/test-kit/src/seed/service/test-seed.service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Cohesive shared test seed harness */
 import {
     AccountEntityTable,
     AccountNatureEnum,
@@ -10,6 +11,7 @@ import {
     InstrumentTypeEnum,
     MccCategoryEntityTable,
     TagEntityTable,
+    TransactionConsolidationTypeEnum,
     TransactionEntityTable,
     TransactionEntryEntityTable,
     TransactionEntryTypeEnum,
@@ -21,6 +23,7 @@ import { eq } from 'drizzle-orm';
 
 import { isDefined } from '@rnw-community/shared';
 
+import type { ChainReclaimScenarioInputInterface } from '../interface/chain-reclaim-scenario-input.interface';
 import type { SeedBankPairEntryInputType } from '../interface/seed-bank-pair-entry-input.type';
 import type {
     AccountCreateEntityInterface,
@@ -34,13 +37,17 @@ import type {
     MccCategoryEntityInterface,
     TransactionCreateEntityInterface,
     TransactionEntityInterface,
-    TransactionEntryCreateEntityInterface
+    TransactionEntryCreateEntityInterface,
+    TransactionEntryEntityInterface
 } from '@budgie/contracts';
+
+const SECONDS_PER_DAY = 86_400;
+const DEFAULT_BASE_YEAR = 2026;
 
 export class TestSeedService {
     private static readonly DEFAULT_REFUND_TITLE = 'STARBUCKS #1234';
-    private static readonly DEFAULT_REFUND_DELAY_SECONDS = 86_400;
-    private static readonly DEFAULT_TRANSFER_OPERATED_AT = new Date(2026, 0, 15, 12, 0, 0);
+    private static readonly DEFAULT_REFUND_DELAY_SECONDS = SECONDS_PER_DAY;
+    private static readonly DEFAULT_TRANSFER_OPERATED_AT = new Date(DEFAULT_BASE_YEAR, 0, 15, 12, 0, 0);
     private static readonly DEFAULT_BASE_INSTRUMENT_ID = 1;
 
     constructor(private readonly database: DB) {}
@@ -80,6 +87,7 @@ export class TestSeedService {
         return this.requireInserted(rows, 'accounts');
     }
 
+    // eslint-disable-next-line @typescript-eslint/max-params -- Existing test seed helper keeps positional arguments
     bankSyncAccount(
         title: string,
         externalSource: ExternalSourceEnum | null,
@@ -203,6 +211,137 @@ export class TestSeedService {
         );
 
         return { fromAccount, toAccount, expense, income };
+    }
+
+    // eslint-disable-next-line max-statements -- Multi-step test seed helper builds transaction + entries
+    directTransfer(input: {
+        readonly fromAccountId: number;
+        readonly toAccountId: number;
+        readonly fromAmount: number;
+        readonly toAmount: number;
+        readonly operatedAt?: Date;
+        readonly exchangeRate?: number;
+        readonly fromEntryExchangeRate?: number;
+        readonly toEntryExchangeRate?: number;
+        readonly fromEntryToIban?: string | null;
+        readonly externalIdPrefix?: string;
+        readonly title?: string;
+        readonly consolidationType?: TransactionConsolidationTypeEnum | null;
+        readonly withBackingSources?: boolean;
+    }): {
+        readonly transfer: TransactionEntityInterface;
+        readonly fromEntry: TransactionEntryEntityInterface;
+        readonly toEntry: TransactionEntryEntityInterface;
+        readonly backingExpense: TransactionEntityInterface | null;
+        readonly backingIncome: TransactionEntityInterface | null;
+    } {
+        const operatedAt = input.operatedAt ?? TestSeedService.DEFAULT_TRANSFER_OPERATED_AT;
+        const externalIdPrefix = input.externalIdPrefix ?? 'transfer';
+        const consolidationType = 'consolidationType' in input ? input.consolidationType : TransactionConsolidationTypeEnum.TRANSFER_PAIR;
+        const transferRows = this.database
+            .insert(TransactionEntityTable)
+            .values({
+                type: TransactionTypeEnum.TRANSFER,
+                title: input.title ?? 'Direct Transfer',
+                externalId: `${externalIdPrefix}-transfer`,
+                externalSource: ExternalSourceEnum.MONOBANK,
+                operatedAt,
+                exchangeRate: input.exchangeRate ?? 1,
+                fromAccountId: input.fromAccountId,
+                toAccountId: input.toAccountId,
+                comment: '',
+                consolidationType,
+                updatedBy: null
+            } satisfies TransactionCreateEntityInterface)
+            .returning()
+            .all();
+        const transfer = this.requireInserted(transferRows, 'transactions');
+        const fromEntry = this.insertTransferEntry(transfer.id, TransactionEntryTypeEnum.CREDIT, `${externalIdPrefix}-from`, {
+            accountId: input.fromAccountId,
+            amount: input.fromAmount,
+            exchangeRate: input.fromEntryExchangeRate ?? 1,
+            toIban: input.fromEntryToIban ?? null
+        });
+        const toEntry = this.insertTransferEntry(transfer.id, TransactionEntryTypeEnum.DEBIT, `${externalIdPrefix}-to`, {
+            accountId: input.toAccountId,
+            amount: input.toAmount,
+            exchangeRate: input.toEntryExchangeRate ?? 1,
+            toIban: null
+        });
+
+        if (input.withBackingSources !== true) {
+            return { transfer, fromEntry, toEntry, backingExpense: null, backingIncome: null };
+        }
+
+        const backingExpense = this.bankPairExpense(
+            { externalId: `${externalIdPrefix}-backing-expense`, operatedAt },
+            { accountId: input.fromAccountId, amount: input.fromAmount, exchangeRate: input.fromEntryExchangeRate ?? 1 }
+        );
+        const backingIncome = this.bankPairIncome(
+            { externalId: `${externalIdPrefix}-backing-income`, operatedAt },
+            { accountId: input.toAccountId, amount: input.toAmount, exchangeRate: input.toEntryExchangeRate ?? 1 }
+        );
+
+        this.moveEntryIntoCanonical(`${externalIdPrefix}-backing-expense`, backingExpense.id, transfer.id);
+        this.moveEntryIntoCanonical(`${externalIdPrefix}-backing-income`, backingIncome.id, transfer.id);
+        this.setConsolidationParent(backingExpense.id, transfer.id);
+        this.setConsolidationParent(backingIncome.id, transfer.id);
+
+        return { transfer, fromEntry, toEntry, backingExpense, backingIncome };
+    }
+
+    feeEntry(transactionId: number, accountId: number, amount: number, externalId: string): TransactionEntryEntityInterface {
+        return this.insertTransferEntry(transactionId, TransactionEntryTypeEnum.FEE, externalId, { accountId, amount });
+    }
+
+    chainReclaimScenario(input: ChainReclaimScenarioInputInterface): {
+        readonly sourceAccount: AccountEntityInterface;
+        readonly bridgeAccount: AccountEntityInterface;
+        readonly targetAccount: AccountEntityInterface;
+        readonly transfer: TransactionEntityInterface;
+        readonly backingExpense: TransactionEntityInterface | null;
+        readonly backingIncome: TransactionEntityInterface | null;
+        readonly bridgeIncome: TransactionEntityInterface;
+        readonly bridgeExpense: TransactionEntityInterface;
+    } {
+        const usdInstrument = this.instrument({ code: 'USD', name: 'Dollar', symbol: '$' });
+        const sourceAccount = this.bankSyncAccount('Source USD', null, 'UA-SOURCE', usdInstrument.id);
+        const bridgeAccount = this.bankSyncAccount('Bridge UAH', null, 'UA-BRIDGE', input.bridgeInstrumentId ?? 1);
+        const targetAccount = this.bankSyncAccount('Target UAH', null, 'UA-TARGET', 1);
+        const bridgeOffset = input.bridgeOperatedAtOffsetMs ?? 10_000;
+        const gateMatchingExchangeRate = input.sourceAmount / input.targetAmount;
+        const { transfer, backingExpense, backingIncome } = this.directTransfer({
+            fromAccountId: sourceAccount.id,
+            toAccountId: targetAccount.id,
+            fromAmount: input.sourceAmount,
+            toAmount: input.targetAmount,
+            operatedAt: input.operatedAt,
+            exchangeRate: input.transferExchangeRate ?? gateMatchingExchangeRate,
+            fromEntryExchangeRate: input.transferFromEntryExchangeRate ?? gateMatchingExchangeRate,
+            toEntryExchangeRate: input.transferToEntryExchangeRate ?? 1,
+            fromEntryToIban: input.transferFromEntryToIban ?? 'UA-TARGET',
+            withBackingSources: true
+        });
+        const bridgeIncome = this.bankPairIncome(
+            { externalId: 'bridge-income', operatedAt: new Date(input.operatedAt.getTime() + bridgeOffset) },
+            {
+                accountId: bridgeAccount.id,
+                amount: input.bridgeIncomeAmount ?? input.targetAmount,
+                exchangeRate: input.bridgeExchangeRate,
+                toIban: input.bridgeIncomeToIban ?? 'UA-SOURCE'
+            }
+        );
+        const bridgeExpense = this.bankPairExpense(
+            { externalId: 'bridge-expense', operatedAt: new Date(input.operatedAt.getTime() + bridgeOffset + 2_000) },
+            {
+                accountId: bridgeAccount.id,
+                amount: input.bridgeExpenseAmount ?? input.targetAmount,
+                exchangeRate: 1,
+                toIban: input.bridgeExpenseToIban ?? 'UA-TARGET'
+            }
+        );
+
+        return { sourceAccount, bridgeAccount, targetAccount, transfer, backingExpense, backingIncome, bridgeIncome, bridgeExpense };
     }
 
     refundedExpense(input: {
@@ -340,6 +479,7 @@ export class TestSeedService {
         return inserted;
     }
 
+    // eslint-disable-next-line @typescript-eslint/max-params -- Existing test seed helper keeps positional arguments
     private insertTransaction(
         type: TransactionTypeEnum.EXPENSE | TransactionTypeEnum.INCOME,
         transaction: Pick<TransactionCreateEntityInterface, 'externalId' | 'operatedAt' | 'title'>,
@@ -374,6 +514,46 @@ export class TestSeedService {
         externalId: string | null,
         entry: SeedBankPairEntryInputType
     ): void {
+        this.insertTransferEntry(transactionId, entryType, externalId, {
+            accountId: entry.accountId,
+            amount: entry.amount,
+            exchangeRate: entry.exchangeRate,
+            toIban: entry.toIban,
+            mccCategoryId: entry.mccCategoryId
+        });
+    }
+
+    private moveEntryIntoCanonical(entryExternalId: string, sourceTransactionId: number, canonicalTransactionId: number): void {
+        this.database
+            .update(TransactionEntryEntityTable)
+            .set({
+                transactionId: canonicalTransactionId,
+                originalTransactionId: sourceTransactionId
+            })
+            .where(eq(TransactionEntryEntityTable.externalId, entryExternalId))
+            .run();
+    }
+
+    private setConsolidationParent(sourceTransactionId: number, canonicalTransactionId: number): void {
+        this.database
+            .update(TransactionEntityTable)
+            .set({ consolidationParentTransactionId: canonicalTransactionId })
+            .where(eq(TransactionEntityTable.id, sourceTransactionId))
+            .run();
+    }
+
+    private insertTransferEntry(
+        transactionId: number,
+        entryType: TransactionEntryTypeEnum,
+        externalId: string | null,
+        entry: {
+            readonly accountId: number;
+            readonly amount: number;
+            readonly exchangeRate?: number;
+            readonly toIban?: string | null;
+            readonly mccCategoryId?: number | null;
+        }
+    ): TransactionEntryEntityInterface {
         const entryRows = this.database
             .insert(TransactionEntryEntityTable)
             .values({
@@ -394,11 +574,11 @@ export class TestSeedService {
             .returning()
             .all();
 
-        this.requireInserted(entryRows, 'transaction_entries');
+        return this.requireInserted(entryRows, 'transaction_entries');
     }
 
     private requireInserted<T>(rows: readonly T[], tableName: string): T {
-        const row = rows[0];
+        const [row] = rows;
 
         if (!isDefined(row)) {
             throw new Error(`Failed to insert into ${tableName}`);


### PR DESCRIPTION
Closes #556

## Problem

A same-day **source → bridge → target** transfer chain was mis-consolidated into a direct **source → target** `TRANSFER_PAIR` when the bridge account synced after the source/target accounts. The greedy matcher paired the chain's first expense with its last income (via a false IBAN match), stranding the bridge account's income + expense legs — consolidation never re-evaluated them.

On a real device backup: **56 orphaned incomes + 56 orphaned expenses** on the Fop UAH bridge account (`Fop USD → Fop UAH → Black`), with the same class affecting `Fop UAH → White`.

## Fix

New **chain-reclaim** repair strategy. Detects an existing direct `TRANSFER_PAIR` whose two now-present orphaned bridge legs match (dual-IBAN, equal amounts, FX-consistent within `IBAN_BRIDGE_CHAIN_FX_TOLERANCE`, same-day window) and folds them in:

- **Fast path** — identity-preserving in-place absorb when the existing transfer's stored ledger already equals the chain-computed values (no ledger rewrite). Mirrors `consolidateIbanBridgeCanonicalDuplicateInner`.
- **Rebuild fallback** — fresh FX-correct canonical for divergent cross-currency cases. Mirrors `consolidateExistingTransferBridgeInner` (`executeConsolidation(..., [existingTransferId])`).

Key safety properties:
- Anchored on `consolidation_type = 'TRANSFER_PAIR'` **only** (not `NULL`) — a source-less hand-created transfer can never be fast-path absorbed and destroyed on revert.
- `IBAN_BRIDGE_CHAIN_FX_TOLERANCE = 0.01` is the **single source of truth** for chain FX equivalence (shared by the executor gate and the IBAN bridge chain detection SQL).
- Fast path never routes the existing transfer through `findEligibleSourceTransactions`, sidestepping the `hasMovedSourceEntries` guard; rebuild passes `allowedMovedSourceTransactionIds`.

## Changes

- **contracts**: new `IBAN_BRIDGE_CHAIN_FX_TOLERANCE` constant, `ExistingTransferChainReclaimCandidateInterface`, `EXISTING_TRANSFER_CHAIN_RECLAIM_CANDIDATES_SQL` factory (anchor + dual-IBAN + fee-leg exclusion + rank-1 dedup on existing-transfer/bridge-income/bridge-expense), repo finder, index exports.
- **consolidation**: candidate group + loader, executor `consolidateExistingTransferChainReclaim` (fast-path gate + rebuild), wired into `processGroups` after `existingTransferBridge`.
- **app**: candidate-service group + count wiring.
- **tests/consolidation-tests** + **tests/test-kit**: fast-path, rebuild, 9 negatives (incl. `NULL`-type revert-safety), transfer-FX / idempotency / revert assertions.

## Validation

- Detection against the real backup: **56/56** matched chains (all fast path, zero coverage loss), rank-1 dedup no double-claims, EXPLAIN fully indexed.
- `tests/consolidation-tests`: **54 tests pass**.
- Gate: `yarn ts`, `yarn lint`, `yarn deadcode`, `yarn cpd` all green.

> Note: the `tests/*` packages have no `lint` script (they are outside `yarn lint`'s turbo scope) and the existing suite pre-dates lint enforcement. The test files added/modified in this PR are fully lint-clean (real fixes for magic-numbers/destructuring; CLAUDE.md-sanctioned justified disables for max-statements/max-lines/max-params on the test harness), so the commit passes the pre-commit hook normally — no `--no-verify`. Bringing the rest of the pre-existing test suite under lint enforcement is tracked separately, out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consolidation engine now detects and reclaims orphaned bridge legs into existing transfers, with a fast-path that preserves existing transfer identity when safe.

* **Behavioral Improvements**
  * Improved exchange-rate tolerance and validation for chain-reclaim scenarios to reduce false positives.

* **Tests**
  * Added extensive integration tests covering fast-path, rebuild, ranking/deduplication, negatives, and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
