### PR TITLE
fix(contracts): keep market query builders undecorated

### DIFF
--- a/packages/contracts/AGENTS.md
+++ b/packages/contracts/AGENTS.md
@@ -202,6 +202,29 @@ private async processBatchInner(batch: InputInterface[], tx: Transaction) {
 
 ### Query API Preference
 
+### Red Flag: Do Not Decorate Query Builders
+
+Repository methods that return Drizzle query builders must not use `@Log`. Drizzle query builders are thenable, so log decorators can mistake them for promises and wrap them. `useLiveQuery` expects the original query object so it can read table metadata; a wrapped builder can crash at runtime with `Cannot read property 'table' of undefined`.
+
+Keep `@Log` on methods that execute work themselves, especially `async` methods that `await` the database call. Leave builder-returning methods undecorated:
+
+```typescript
+// Good
+findRecent(accountId: number) {
+    return this.db.query.AccountEntityTable.findMany({
+        where: eq(AccountEntityTable.id, accountId)
+    });
+}
+
+// Bad
+@Log(...)
+findRecent(accountId: number) {
+    return this.db.query.AccountEntityTable.findMany({
+        where: eq(AccountEntityTable.id, accountId)
+    });
+}
+```
+
 **Prefer:**
 ```typescript
 this.db.query.AccountEntityTable.findMany({

--- a/packages/contracts/src/instrument-daily-market-price/repository/instrument-daily-market-price.repository.ts
+++ b/packages/contracts/src/instrument-daily-market-price/repository/instrument-daily-market-price.repository.ts
@@ -83,14 +83,6 @@ export class InstrumentDailyMarketPriceRepository {
         });
     }
 
-    @Log(
-        (instrumentId, quoteInstrumentId, limit, tx) =>
-            `enter lookup=recent-prices instrumentId=${instrumentId} quoteInstrumentId=${quoteInstrumentId} limit=${limit} hasTx=${String(isDefined(tx))}`,
-        (result, ...[instrumentId, quoteInstrumentId, limit, tx]) =>
-            `done lookup=recent-prices instrumentId=${instrumentId} quoteInstrumentId=${quoteInstrumentId} limit=${limit} hasTx=${String(isDefined(tx))} queryBuilt=${String(isDefined(result))}`,
-        (error, ...[instrumentId, quoteInstrumentId, limit, tx]) =>
-            `throw lookup=recent-prices instrumentId=${instrumentId} quoteInstrumentId=${quoteInstrumentId} limit=${limit} hasTx=${String(isDefined(tx))} error=${getErrorMessage(error)}`
-    )
     findRecent(instrumentId: number, quoteInstrumentId: number, limit: number, tx?: DB) {
         return (tx ?? this.db).query.InstrumentDailyMarketPriceEntityTable.findMany({
             where: this.buildInstrumentQuoteCondition(instrumentId, quoteInstrumentId),
@@ -99,14 +91,6 @@ export class InstrumentDailyMarketPriceRepository {
         });
     }
 
-    @Log(
-        (instrumentId, quoteInstrumentId, tx) =>
-            `enter lookup=price-count instrumentId=${instrumentId} quoteInstrumentId=${quoteInstrumentId} hasTx=${String(isDefined(tx))}`,
-        (result, instrumentId, quoteInstrumentId, tx) =>
-            `done lookup=price-count instrumentId=${instrumentId} quoteInstrumentId=${quoteInstrumentId} hasTx=${String(isDefined(tx))} queryBuilt=${String(isDefined(result))}`,
-        (error, instrumentId, quoteInstrumentId, tx) =>
-            `throw lookup=price-count instrumentId=${instrumentId} quoteInstrumentId=${quoteInstrumentId} hasTx=${String(isDefined(tx))} error=${getErrorMessage(error)}`
-    )
     countByInstrumentAndQuote(instrumentId: number, quoteInstrumentId: number, tx?: DB) {
         return (tx ?? this.db)
             .select({ count: count() })

--- a/packages/contracts/src/instrument-market-data-job/repository/instrument-market-data-job.repository.ts
+++ b/packages/contracts/src/instrument-market-data-job/repository/instrument-market-data-job.repository.ts
@@ -122,14 +122,6 @@ export class InstrumentMarketDataJobRepository {
             .where(eq(InstrumentMarketDataJobEntityTable.id, jobId));
     }
 
-    @Log(
-        (instrumentId, quoteInstrumentId, tx) =>
-            `enter lookup=latest-job instrumentId=${instrumentId} quoteInstrumentId=${quoteInstrumentId} hasTx=${String(isDefined(tx))}`,
-        (result, instrumentId, quoteInstrumentId, tx) =>
-            `done lookup=latest-job instrumentId=${instrumentId} quoteInstrumentId=${quoteInstrumentId} hasTx=${String(isDefined(tx))} queryBuilt=${String(isDefined(result))}`,
-        (error, instrumentId, quoteInstrumentId, tx) =>
-            `throw lookup=latest-job instrumentId=${instrumentId} quoteInstrumentId=${quoteInstrumentId} hasTx=${String(isDefined(tx))} error=${getErrorMessage(error)}`
-    )
     findLatestByInstrumentAndQuote(instrumentId: number, quoteInstrumentId: number, tx?: DB) {
         return (tx ?? this.db).query.InstrumentMarketDataJobEntityTable.findFirst({
             where: this.buildInstrumentQuoteCondition(instrumentId, quoteInstrumentId),

--- a/packages/contracts/src/transaction-entry/repository/transaction-entry-position.repository.ts
+++ b/packages/contracts/src/transaction-entry/repository/transaction-entry-position.repository.ts
@@ -1,7 +1,4 @@
-import { Log } from '@budgie/logger';
 import { and, asc, eq, inArray, isNull, or, sql } from 'drizzle-orm';
-
-import { getErrorMessage, isDefined } from '@rnw-community/shared';
 
 import { AccountTypeEnum } from '../../account/enum/account-type.enum';
 import { AccountEntityTable } from '../../account/table/account-entity.table';
@@ -23,14 +20,6 @@ export class TransactionEntryPositionRepository {
 
     constructor(private db: DB) {}
 
-    @Log(
-        (instrumentId, baseInstrumentId) =>
-            `enter lookup=crypto-position-entries instrumentId=${instrumentId} baseInstrumentId=${baseInstrumentId}`,
-        (result, instrumentId, baseInstrumentId) =>
-            `done lookup=crypto-position-entries instrumentId=${instrumentId} baseInstrumentId=${baseInstrumentId} queryBuilt=${String(isDefined(result))}`,
-        (error, instrumentId, baseInstrumentId) =>
-            `throw lookup=crypto-position-entries instrumentId=${instrumentId} baseInstrumentId=${baseInstrumentId} error=${getErrorMessage(error)}`
-    )
     findCryptoPositionEntries(instrumentId: number, baseInstrumentId: number) {
         return this.db
             .select({


### PR DESCRIPTION
## Summary

- Remove `@Log` from market-data repository methods that return Drizzle query builders for `useLiveQuery`.
- Keep async repository methods logged while preserving raw query-builder return values for live-query consumers.
- Cover the same thenable-wrapper issue in crypto position query building.

## Root Cause

The recent crypto market history flow added Drizzle query-builder methods used by `useLiveQuery`. Drizzle relational queries are thenable (`QueryPromise`). The `@Log` decorator treats thenables as promises, so decorating these builder-returning methods converted the builder into a real `Promise`.

`useLiveQuery` then received a `Promise` instead of a Drizzle query and crashed while reading table metadata (`query.config.table`), surfacing in the app as `Cannot read property 'table' of undefined` from `CryptoCurrencyGroupCard`.

This was not caused by missing market-data migrations: `0029_add_instrument_market_data_jobs` and `0030_seed_top_crypto_market_prices` are present in `packages/app/drizzle/migrations.js`.

## Validation

- Targeted scan: no decorated non-async repository builders remain.
- `yarn format`
- `yarn ts`
- `yarn lint`
- `yarn deadcode` with Node 22.22.0
- `yarn cpd` with Node 22.22.0

Note: `yarn deadcode` fails under Node 18.20.8 because current Knip imports `node:util.styleText`; rerunning with Node 22.22.0 passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed internal logging instrumentation from several repository methods to simplify behavior and dependencies.
* **Documentation**
  * Added guidance warning against decorating query-builder–returning repository methods, with examples of correct vs incorrect usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->