### PR TITLE
ci: route hosted checks to Mac mini runners

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,6 +3,8 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
+    paths-ignore:
+      - ".github/workflows/**"
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,7 +18,7 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux-burst]
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux-burst]
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ fromJSON(matrix.runner) }}
     permissions:
       # required for all workflows
       security-events: write
@@ -45,8 +45,10 @@ jobs:
         include:
         - language: actions
           build-mode: none
+          runner: '["self-hosted","linux-burst"]'
         - language: javascript-typescript
           build-mode: none
+          runner: '["self-hosted","linux-burst"]'
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,10 +45,10 @@ jobs:
         include:
         - language: actions
           build-mode: none
-          runner: '["self-hosted","linux-burst"]'
+          runner: '["self-hosted","macOS","ARM64","macos-tartelet"]'
         - language: javascript-typescript
           build-mode: none
-          runner: '["self-hosted","linux-burst"]'
+          runner: '["self-hosted","macOS","ARM64","macos-tartelet"]'
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both


### PR DESCRIPTION
Routes remaining Linux-capable hosted checks to the Mac mini self-hosted runner pool.\n\n- Move Claude workflows to linux-burst\n- Move CodeQL matrix entries to explicit linux-burst runner labels\n- Keep existing Tartelet macOS jobs unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations to use self-hosted runners for improved performance and resource management.

---

**Note:** This release contains no user-facing feature changes or bug fixes. Updates are limited to internal continuous integration infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->