### PR TITLE
ci: harden release checkout on linux runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,8 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: false
-          fetch-depth: 0
+          fetch-depth: 1
+          fetch-tags: true
           ref: main
 
       - name: Setup Node
@@ -38,7 +39,8 @@ jobs:
           git config user.email "vitalyiegorov@gmail.com"
           git remote rm origin
           git remote add origin https://vitalyiegorov:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          git fetch origin main --tags
+          git fetch --force --prune --tags --unshallow origin +refs/heads/main:refs/remotes/origin/main || \
+            git fetch --force --prune --tags origin +refs/heads/main:refs/remotes/origin/main
           git switch main
           git branch --set-upstream-to=origin/main main
 


### PR DESCRIPTION
## Summary
- keep the production release job on the Budgie Linux runner
- make checkout shallow by default, then fetch only main history and tags needed by Lerna release
- avoid the heavyweight all-branches fetch that failed on the ephemeral runner

## Verification
- ruby YAML parse for .github/workflows/main.yml
- runner health check passes with 0 failures
