### PR TITLE
ci: enable precompiled iOS Expo modules

### DIFF
--- a/.github/workflows/native-dev-build.yml
+++ b/.github/workflows/native-dev-build.yml
@@ -57,6 +57,10 @@ jobs:
 
       - name: Build iOS app locally
         working-directory: packages/app
+        env:
+          EXPO_USE_PRECOMPILED_MODULES: "1"
+          RCT_USE_PREBUILT_RNCORE: "1"
+          RCT_USE_RN_DEP: "1"
         run: |
           mkdir -p ../../artifacts
           eas build --platform ios --profile development --local --non-interactive --output ../../artifacts/budgie-development.ipa

--- a/.github/workflows/native-publish.yml
+++ b/.github/workflows/native-publish.yml
@@ -57,6 +57,10 @@ jobs:
 
       - name: Build iOS app locally
         working-directory: packages/app
+        env:
+          EXPO_USE_PRECOMPILED_MODULES: "1"
+          RCT_USE_PREBUILT_RNCORE: "1"
+          RCT_USE_RN_DEP: "1"
         run: |
           mkdir -p ../../artifacts
           eas build --platform ios --profile production --local --non-interactive --output ../../artifacts/budgie-production.ipa

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -122,6 +122,9 @@ jobs:
     env:
       APP_VARIANT: e2e
       EXPO_PUBLIC_AI_DISABLE: "true"
+      EXPO_USE_PRECOMPILED_MODULES: "1"
+      RCT_USE_PREBUILT_RNCORE: "1"
+      RCT_USE_RN_DEP: "1"
       IOS_DERIVED_DATA: ${{ github.workspace }}/.ci-cache/DerivedData/budgie-e2e
       USE_CCACHE: "1"
       CCACHE_DIR: ${{ github.workspace }}/.ci-cache/ccache
@@ -222,8 +225,6 @@ jobs:
         env:
           APP_VARIANT: e2e
           EXPO_PUBLIC_AI_DISABLE: "true"
-          RCT_USE_PREBUILT_RNCORE: "1"
-          RCT_USE_RN_DEP: "1"
         run: npx expo prebuild -p ios --clean
 
       - name: Sync CocoaPods

--- a/packages/app/app.config.js
+++ b/packages/app/app.config.js
@@ -113,10 +113,10 @@ export default ({ config }) => ({
         [
             'expo-build-properties',
             {
-                buildReactNativeFromSource: true,
                 useHermesV1: true,
                 ios: {
-                    ccacheEnabled: true
+                    ccacheEnabled: true,
+                    usePrecompiledModules: true
                 }
             }
         ],


### PR DESCRIPTION
## What changed

- Removes the Expo build-properties override that forced React Native to build from source.
- Explicitly enables iOS precompiled Expo modules in `app.config.js`.
- Passes precompiled-module / prebuilt-RN env through local iOS development, production, and PR iOS E2E workflows.

## Why

The first local iOS development build succeeded, but the EAS local build log showed:

> `EXPO_USE_PRECOMPILED_MODULES=1 was set, but React Native is configured to build from source ... every Expo module will be built from source`

Expo SDK 56 enables precompiled Expo Modules on iOS, but Budgie's `buildReactNativeFromSource: true` setting prevented that path from being used.

## Validation

- Confirmed run `28001021242` succeeded but built Expo modules from source because of the config override.
- Checked Expo SDK 56 docs for precompiled iOS Expo Modules and build-properties behavior.
- Ran `git diff --check`.
- Ran `node --check packages/app/app.config.js`.

## Expected CI signal

A rerun of the local iOS development build should no longer print the warning about every Expo module being built from source.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS build configuration and environment settings to optimize build performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->