### PR TITLE
ci: avoid GitHub-hosted runners

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,7 +20,7 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux-ci]
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux-ci]
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,9 +27,8 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    # Budgie is public, so standard GitHub-hosted runners are free. Keep CodeQL
-    # off the scarce Mac Mini/Tartelet lane so native builds can start sooner.
-    runs-on: ${{ matrix.runner }}
+    # Keep CodeQL on the self-hosted Linux lane so GitHub-hosted minutes are not used.
+    runs-on: ${{ fromJSON(matrix.runner) }}
     permissions:
       # required for all workflows
       security-events: write
@@ -47,10 +46,10 @@ jobs:
         include:
         - language: actions
           build-mode: none
-          runner: ubuntu-latest
+          runner: '["self-hosted","linux-ci"]'
         - language: javascript-typescript
           build-mode: none
-          runner: ubuntu-latest
+          runner: '["self-hosted","linux-ci"]'
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both

--- a/.github/workflows/native-dev-build.yml
+++ b/.github/workflows/native-dev-build.yml
@@ -57,6 +57,10 @@ jobs:
 
       - name: Build iOS app locally
         working-directory: packages/app
+        env:
+          EXPO_USE_PRECOMPILED_MODULES: "1"
+          RCT_USE_PREBUILT_RNCORE: "1"
+          RCT_USE_RN_DEP: "1"
         run: |
           mkdir -p ../../artifacts
           eas build --platform ios --profile development --local --non-interactive --output ../../artifacts/budgie-development.ipa

--- a/.github/workflows/native-publish.yml
+++ b/.github/workflows/native-publish.yml
@@ -57,6 +57,10 @@ jobs:
 
       - name: Build iOS app locally
         working-directory: packages/app
+        env:
+          EXPO_USE_PRECOMPILED_MODULES: "1"
+          RCT_USE_PREBUILT_RNCORE: "1"
+          RCT_USE_RN_DEP: "1"
         run: |
           mkdir -p ../../artifacts
           eas build --platform ios --profile production --local --non-interactive --output ../../artifacts/budgie-production.ipa

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -122,6 +122,9 @@ jobs:
     env:
       APP_VARIANT: e2e
       EXPO_PUBLIC_AI_DISABLE: "true"
+      EXPO_USE_PRECOMPILED_MODULES: "1"
+      RCT_USE_PREBUILT_RNCORE: "1"
+      RCT_USE_RN_DEP: "1"
       IOS_DERIVED_DATA: ${{ github.workspace }}/.ci-cache/DerivedData/budgie-e2e
       USE_CCACHE: "1"
       CCACHE_DIR: ${{ github.workspace }}/.ci-cache/ccache
@@ -222,8 +225,6 @@ jobs:
         env:
           APP_VARIANT: e2e
           EXPO_PUBLIC_AI_DISABLE: "true"
-          RCT_USE_PREBUILT_RNCORE: "1"
-          RCT_USE_RN_DEP: "1"
         run: npx expo prebuild -p ios --clean
 
       - name: Sync CocoaPods

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -72,7 +72,7 @@ jobs:
 
   eas-update-preview:
     name: EAS Update Preview
-    runs-on: [self-hosted, linux-ci]
+    runs-on: [self-hosted, macOS, ARM64, macos-tartelet]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -72,7 +72,7 @@ jobs:
 
   eas-update-preview:
     name: EAS Update Preview
-    runs-on: [self-hosted, macOS, ARM64, macos-tartelet]
+    runs-on: [self-hosted, linux-ci]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -398,7 +398,7 @@ jobs:
       - name: Start iOS Simulator log capture
         run: |
           ARTIFACT_DIR="$GITHUB_WORKSPACE/tests/app-tests/artifacts/simulator"
-          xcrun simctl spawn "$SIMULATOR_UDID" log stream --style compact --level debug > "$ARTIFACT_DIR/simulator.log" 2>&1 &
+          xcrun simctl spawn "$SIMULATOR_UDID" log stream --style compact --level default > "$ARTIFACT_DIR/simulator.log" 2>&1 &
           echo $! > "$ARTIFACT_DIR/simulator-log.pid"
 
       - name: Run Maestro UI tests
@@ -422,6 +422,11 @@ jobs:
 
           if [ -f "$ARTIFACT_DIR/simulator-log.pid" ]; then
             kill "$(cat "$ARTIFACT_DIR/simulator-log.pid")" || true
+          fi
+
+          if [ -f "$ARTIFACT_DIR/simulator.log" ]; then
+            tail -n 20000 "$ARTIFACT_DIR/simulator.log" > "$ARTIFACT_DIR/simulator.log.tail" || true
+            mv "$ARTIFACT_DIR/simulator.log.tail" "$ARTIFACT_DIR/simulator.log" || true
           fi
 
           find "$HOME/Library/Logs/DiagnosticReports" -maxdepth 1 -type f \

--- a/packages/app/app.config.js
+++ b/packages/app/app.config.js
@@ -113,10 +113,10 @@ export default ({ config }) => ({
         [
             'expo-build-properties',
             {
-                buildReactNativeFromSource: true,
                 useHermesV1: true,
                 ios: {
-                    ccacheEnabled: true
+                    ccacheEnabled: true,
+                    usePrecompiledModules: true
                 }
             }
         ],


### PR DESCRIPTION
## Summary\n- move Claude workflows from GitHub-hosted Ubuntu to the self-hosted linux-ci lane\n- move CodeQL matrix jobs to self-hosted linux-ci via fromJSON runner labels\n- remove the stale note that GitHub-hosted runners should be used for CodeQL\n\n## Validation\n- parsed all local workflow YAML files successfully\n- verified no ubuntu-latest, macos-latest, or windows-latest labels remain in local workflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS build and test reliability by aligning workflows with precompiled components and updated runner settings.
  * Reduced noisy simulator logging during end-to-end test runs and trimmed saved logs to keep them manageable.

* **Chores**
  * Updated several automation jobs to use self-hosted Linux runners for CI and review tasks.
  * Adjusted iOS project configuration to better support precompiled module usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->