### PR TITLE
ci: skip mobile jobs on PRs when app is unaffected

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,6 +17,73 @@ concurrency:
 on: pull_request
 
 jobs:
+    detect-mobile-impact:
+        name: Detect mobile impact
+        runs-on: [self-hosted, linux-ci]
+        permissions:
+            contents: read
+        outputs:
+            mobile: ${{ steps.gate.outputs.mobile }}
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v5
+              with:
+                  fetch-depth: 0
+
+            - name: Setup Node
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 22.x
+                  cache: yarn
+
+            - name: Install dependencies
+              run: yarn install
+
+            - name: Compute mobile-impact gate
+              id: gate
+              run: |
+                  MOBILE=true
+
+                  if ! command -v jq >/dev/null 2>&1; then
+                    echo "::warning::jq is not available on this runner; defaulting to mobile=true"
+                    echo "mobile=$MOBILE" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+
+                  git fetch --no-tags origin main:refs/remotes/origin/main || true
+
+                  MERGE_BASE="$(git merge-base origin/main HEAD 2>/dev/null || true)"
+
+                  if [ -z "$MERGE_BASE" ]; then
+                    echo "::warning::Could not determine merge-base with origin/main; defaulting to mobile=true"
+                    echo "mobile=$MOBILE" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+
+                  echo "Merge base: $MERGE_BASE"
+
+                  TURBO_EXIT=0
+                  TURBO_OUTPUT="$(yarn turbo query affected --packages --base "$MERGE_BASE" --no-update-notifier 2>turbo-query.log)" || TURBO_EXIT=$?
+
+                  if [ "$TURBO_EXIT" -ne 0 ]; then
+                    echo "::warning::yarn turbo query affected failed; defaulting to mobile=true"
+                    cat turbo-query.log || true
+                    MOBILE=true
+                  elif echo "$TURBO_OUTPUT" | jq -e '.data.affectedPackages.items[] | select(.name == "@budgie-at/app")' >/dev/null 2>&1; then
+                    MOBILE=true
+                  else
+                    MOBILE=false
+                  fi
+
+                  if [ "$MOBILE" = "false" ]; then
+                    if git diff --name-only "$MERGE_BASE" HEAD | grep -qE '^(tests/app-tests/|\.github/workflows/pr\.yml$)'; then
+                      MOBILE=true
+                    fi
+                  fi
+
+                  echo "Mobile affected: $MOBILE"
+                  echo "mobile=$MOBILE" >> "$GITHUB_OUTPUT"
+
     code-quality:
         name: Code quality checks
         runs-on: [self-hosted, linux-ci]
@@ -75,6 +142,8 @@ jobs:
                   use_oidc: true
 
     eas-update-preview:
+        if: needs.detect-mobile-impact.outputs.mobile == 'true'
+        needs: [detect-mobile-impact]
         name: EAS Update Preview
         runs-on: [self-hosted, macOS, ARM64, macos-tartelet]
         permissions:
@@ -120,7 +189,8 @@ jobs:
                   eas update --skip-bundler --input-dir dist --channel development --message "PR #${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}"
 
     build-ios-e2e-app:
-        needs: [code-quality, eas-update-preview]
+        if: needs.detect-mobile-impact.outputs.mobile == 'true'
+        needs: [detect-mobile-impact, code-quality, eas-update-preview]
         name: Build iOS E2E app
         runs-on: [self-hosted, macOS, ARM64, macos-tartelet]
         permissions:
@@ -304,7 +374,8 @@ jobs:
                   key: ccache-${{ runner.os }}-xcode26_4_1-e2e-${{ hashFiles('yarn.lock', 'packages/app/package.json', 'packages/app/app.config.js', 'packages/app/ios/Podfile.properties.json') }}
 
     e2e-ios:
-        needs: [build-ios-e2e-app]
+        if: needs.detect-mobile-impact.outputs.mobile == 'true'
+        needs: [detect-mobile-impact, build-ios-e2e-app]
         name: E2E Tests on iOS (shard ${{ matrix.shard }})
         runs-on: [self-hosted, macOS, ARM64, macos-tartelet]
         permissions:
@@ -475,8 +546,8 @@ jobs:
                   if-no-files-found: warn
 
     e2e-android:
-        if: false
-        needs: [code-quality, eas-update-preview]
+        if: false && needs.detect-mobile-impact.outputs.mobile == 'true'
+        needs: [detect-mobile-impact, code-quality, eas-update-preview]
         name: E2E Tests on Android
         runs-on: [self-hosted, linux-ci]
         permissions:


### PR DESCRIPTION
## Summary
- New `detect-mobile-impact` job in `pr.yml` decides per-PR whether the mobile chain must run, using Turborepo's dependency graph: `turbo query affected --packages --base <merge-base>` checked for `@budgie-at/app` (covers app + contracts/ai/bank-sync/budget/consolidation/logger + per-package lockfile effects), plus a diff overlay for out-of-graph inputs (`tests/app-tests/**`, `pr.yml` itself)
- `eas-update-preview`, `build-ios-e2e-app`, and the 4-shard `e2e-ios` matrix now skip on PRs that don't affect the app (e.g. landing-only or docs-only changes); `e2e-android` is pre-wired with the same gate for when it's re-enabled
- Fail-open by construction: missing `jq`, unfetchable merge base, or a turbo failure all emit a `::warning::` and default to running the mobile jobs; every failure path was traced against bash `errexit` semantics to ensure the gate can never hard-fail the job
- `code-quality` is untouched and runs in parallel; `main` has no required status checks, so skipped jobs cannot block merges

## Test Plan
- [x] Gate script dry-run against a landing-only diff → `mobile=false` (turbo reported only `//` + `@budgie-at/landing`)
- [x] Dry-run against a contracts commit → `mobile=true` via `DependencyChanged` propagation to `@budgie-at/app`
- [x] Dry-run against a Maestro-flow commit → `mobile=true` via the path overlay
- [ ] Self-test on this PR: it touches `pr.yml`, so the overlay must force `mobile=true` and all mobile jobs must still run
- [ ] Follow-up landing-only PR shows `eas-update-preview` / `build-ios-e2e-app` / `e2e-ios` as skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release pipeline checks to better detect when mobile-related changes should trigger mobile builds and end-to-end tests.
  * Mobile preview, iOS, and Android test jobs now run only when relevant app changes are detected, reducing unnecessary CI runs.
  * Changes to app tests or the workflow itself will also trigger the mobile pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->