### PR TITLE
ci: publish ios-dev prerelease via draft flow for immutable releases

### DIFF
--- a/.github/workflows/native-dev-build.yml
+++ b/.github/workflows/native-dev-build.yml
@@ -90,10 +90,6 @@ jobs:
           BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
-          gh release create ios-dev --repo "${GITHUB_REPOSITORY}" --prerelease --title "Budgie iOS Dev Build" --notes "Bootstrap release. Waiting for the first build upload." || true
-
-          gh release upload ios-dev artifacts/budgie-development.ipa --repo "${GITHUB_REPOSITORY}" --clobber
-
           NOTES_FILE=$(mktemp)
           {
             echo "Budgie iOS development build"
@@ -105,6 +101,12 @@ jobs:
             echo "Workflow run: ${RUN_URL}"
           } > "$NOTES_FILE"
 
-          gh release edit ios-dev --repo "${GITHUB_REPOSITORY}" --title "Budgie iOS Dev Build v${VERSION} (${SHORT_SHA})" --notes-file "$NOTES_FILE"
+          gh release delete ios-dev --repo "${GITHUB_REPOSITORY}" --yes --cleanup-tag || true
+
+          gh release create ios-dev artifacts/budgie-development.ipa --repo "${GITHUB_REPOSITORY}" --draft --prerelease --target "${GITHUB_SHA}" --title "Budgie iOS Dev Build v${VERSION} (${SHORT_SHA})" --notes-file "$NOTES_FILE"
+
+          RELEASE_ID=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --jq '[.[] | select(.draft and .tag_name == "ios-dev")][0].id')
+
+          gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" -F draft=false > /dev/null
 
           rm -f "$NOTES_FILE"


### PR DESCRIPTION
## Summary

- The "Publish rolling iOS dev prerelease" step in `.github/workflows/native-dev-build.yml` failed in production (run 29073979069) with `HTTP 422: Cannot upload assets to an immutable release` — this repo has GitHub immutable releases active, so once a release is published its assets are frozen and can no longer be uploaded/clobbered.
- Empirically verified that immutable releases can still be **deleted** (`gh release delete --cleanup-tag` removes both the release and its tag), which unblocks a rolling-release pattern.
- Rewrote the step to a delete → create-as-draft-with-asset → publish flow:
  1. `gh release delete ios-dev ... --cleanup-tag || true` (only allowed failure — handles the first-ever run when no release exists yet)
  2. `gh release create ios-dev artifacts/budgie-development.ipa ... --draft --prerelease --target "${GITHUB_SHA}"` — uploads the asset while the release is still a mutable draft, and pins the tag to the exact built commit
  3. Looks up the draft's numeric release id via `gh api repos/.../releases --jq '...'` (drafts have no tag yet, so `gh release edit`/`gh release view` can't address them by tag name)
  4. `gh api --method PATCH .../releases/${RELEASE_ID} -F draft=false` publishes the release — at this point it freezes as immutable, but now *with* the asset already attached
- If the release-id lookup ever comes back empty, the publish `PATCH` call fails the step outright (no `|| true`) — that's intentional fail-loud behavior so a broken publish is visible in CI rather than silently no-op'ing.
- The stuck empty `ios-dev` release from the failed run was already deleted manually.

## Test Plan

- [ ] Merge this PR into `main`
- [ ] Re-run the "Build Development build" workflow (`native-dev-build.yml`) via `workflow_dispatch`
- [ ] Confirm the `ios-dev` GitHub release is created, published, and contains `budgie-development.ipa`
- [ ] Confirm `budgie.at/beta` shows the new build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the iOS development prerelease publishing workflow.
  * New iOS development prereleases are created directly from the build artifact with release notes and version details.
  * Existing development prereleases are replaced automatically, and newly created releases are published after creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->