### PR TITLE
ci: serialize deploy production runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,10 @@ env:
   EXPO_APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
   GH_TOKEN: ${{ secrets.PUSH_TO_PROTECTED_TOKEN }}
 
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
## Summary

`.github/workflows/main.yml` ("Deploy production", triggered on push to `main`) has no `concurrency` group. When two PRs merge back-to-back, two workflow runs race: each checks out `main`, runs `yarn release` (lerna, `chore: release` version-bump commit), then pushes to `main`. The second run's push is rejected as non-fast-forward because the first run already advanced `main` (real example: run `29069144469` on 2026-07-10, step "Push changes" of job "Publish a release" failed this way).

This adds a workflow-level `concurrency` block (`group: deploy-production`, `cancel-in-progress: false`) so the second run queues behind the first instead of racing and failing. `cancel-in-progress` is `false` (unlike `pr.yml`, which uses `true`) because a release run must run to completion — cancelling mid-`lerna publish` could leave a partial tag/publish state.

Note: a queued second run is redundant but harmless. `lerna publish --conventional-commits` computes version bumps from conventional-commit history since the last release tag; once the first run's release commit/tag lands on `main`, the second run's checkout of `main` has no new changed packages, so `lerna publish` reports nothing to publish and exits 0 without creating a new commit, tag, or push — no non-fast-forward error, no duplicate release.

## Test Plan

- [ ] merge two PRs back-to-back → second Deploy production run queues instead of failing with non-fast-forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved production deployment reliability by ensuring concurrent deployment runs are handled sequentially without canceling an in-progress deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->