### PR TITLE
feat(landing): per-build ios-dev releases with IPA redirect route

### DIFF
--- a/.github/workflows/native-dev-build.yml
+++ b/.github/workflows/native-dev-build.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Ensure GitHub CLI is available
         run: command -v gh >/dev/null 2>&1 || brew install gh
 
-      - name: Publish rolling iOS dev prerelease
+      - name: Publish iOS dev prerelease
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/native-dev-build.yml
+++ b/.github/workflows/native-dev-build.yml
@@ -89,6 +89,7 @@ jobs:
           BRANCH_NAME="${GITHUB_REF_NAME}"
           BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          TAG="ios-dev-${GITHUB_RUN_NUMBER}"
 
           NOTES_FILE=$(mktemp)
           {
@@ -101,12 +102,45 @@ jobs:
             echo "Workflow run: ${RUN_URL}"
           } > "$NOTES_FILE"
 
-          gh release delete ios-dev --repo "${GITHUB_REPOSITORY}" --yes --cleanup-tag || true
+          gh release create "$TAG" artifacts/budgie-development.ipa --repo "${GITHUB_REPOSITORY}" --draft --prerelease --target "${GITHUB_SHA}" --title "Budgie iOS Dev Build v${VERSION} (${SHORT_SHA})" --notes-file "$NOTES_FILE"
 
-          gh release create ios-dev artifacts/budgie-development.ipa --repo "${GITHUB_REPOSITORY}" --draft --prerelease --target "${GITHUB_SHA}" --title "Budgie iOS Dev Build v${VERSION} (${SHORT_SHA})" --notes-file "$NOTES_FILE"
-
-          RELEASE_ID=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --jq '[.[] | select(.draft and .tag_name == "ios-dev")][0].id')
+          RELEASE_ID=$(gh api "repos/${GITHUB_REPOSITORY}/releases" | jq -r --arg tag "$TAG" '[.[] | select(.draft and .tag_name == $tag)][0].id')
 
           gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" -F draft=false > /dev/null
 
           rm -f "$NOTES_FILE"
+
+      - name: Prune old iOS dev releases
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          KEEP_COUNT=5
+
+          RELEASES_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate --jq '.')
+
+          PRUNE_PUBLISHED_TAGS=$(echo "$RELEASES_JSON" | jq -r --argjson keep "$KEEP_COUNT" '
+            [.[] | select(.draft == false) | select(.tag_name | test("^ios-dev-[0-9]+$"))]
+            | sort_by(.tag_name | capture("^ios-dev-(?<run>[0-9]+)$").run | tonumber)
+            | reverse
+            | .[$keep:]
+            | .[].tag_name
+          ')
+
+          for tag in $PRUNE_PUBLISHED_TAGS; do
+            echo "Pruning old published release: $tag"
+            gh release delete "$tag" --repo "${GITHUB_REPOSITORY}" --yes --cleanup-tag || echo "Failed to delete $tag"
+          done
+
+          STALE_DRAFT_TAGS=$(echo "$RELEASES_JSON" | jq -r --arg currentRun "${GITHUB_RUN_NUMBER}" '
+            [.[] | select(.draft == true) | select(.tag_name | test("^ios-dev-[0-9]+$"))]
+            | .[]
+            | select((.tag_name | capture("^ios-dev-(?<run>[0-9]+)$").run | tonumber) < ($currentRun | tonumber))
+            | .tag_name
+          ')
+
+          for tag in $STALE_DRAFT_TAGS; do
+            echo "Pruning stale draft release: $tag"
+            gh release delete "$tag" --repo "${GITHUB_REPOSITORY}" --yes --cleanup-tag || echo "Failed to delete draft $tag"
+          done

--- a/packages/landing/public/ota/manifest.plist
+++ b/packages/landing/public/ota/manifest.plist
@@ -11,7 +11,7 @@
                     <key>kind</key>
                     <string>software-package</string>
                     <key>url</key>
-                    <string>https://github.com/budgie-at/budgie/releases/download/ios-dev/budgie-development.ipa</string>
+                    <string>https://budgie.at/api/beta/ipa</string>
                 </dict>
             </array>
             <key>metadata</key>

--- a/packages/landing/src/app/[lang]/beta/page.tsx
+++ b/packages/landing/src/app/[lang]/beta/page.tsx
@@ -5,15 +5,11 @@ import { isDefined } from '@rnw-community/shared';
 
 import { BetaEmptyState } from '../../../beta/component/beta-empty-state/beta-empty-state';
 import { BetaReleaseCard } from '../../../beta/component/beta-release-card/beta-release-card';
-import { IosDevReleaseSchema } from '../../../beta/constant/ios-dev-release-schema.constant';
+import { iosDevReleaseFetchApi } from '../../../beta/util/ios-dev-release-fetch.util';
 import { getI18nInstance } from '../../../i18n/app-router-i18n';
 import { PageLangParam, initLingui } from '../../../i18n/init-lingui';
 
-import type { IosDevRelease } from '../../../beta/constant/ios-dev-release-schema.constant';
 import type { Metadata } from 'next';
-
-const IOS_DEV_RELEASE_URL = 'https://api.github.com/repos/budgie-at/budgie/releases/tags/ios-dev';
-const IOS_DEV_IPA_ASSET_NAME = 'budgie-development.ipa';
 
 // eslint-disable-next-line func-style
 export async function generateMetadata(props: PageLangParam): Promise<Metadata> {
@@ -27,35 +23,10 @@ export async function generateMetadata(props: PageLangParam): Promise<Metadata> 
     };
 }
 
-const iosDevReleaseFetchApi = async (): Promise<IosDevRelease | null> => {
-    try {
-        const response = await fetch(IOS_DEV_RELEASE_URL, { next: { revalidate: 60 } });
-
-        if (!response.ok) {
-            return null;
-        }
-
-        const releaseJson: unknown = await response.json();
-        const parseResult = IosDevReleaseSchema.safeParse(releaseJson);
-
-        if (!parseResult.success) {
-            return null;
-        }
-
-        if (!parseResult.data.assets.some(asset => asset.name === IOS_DEV_IPA_ASSET_NAME)) {
-            return null;
-        }
-
-        return parseResult.data;
-    } catch {
-        return null;
-    }
-};
-
 export default async function BetaPage(props: PageLangParam) {
     const { lang } = await props.params;
     initLingui(lang);
-    const release = await iosDevReleaseFetchApi();
+    const release = await iosDevReleaseFetchApi({ next: { revalidate: 60 } });
 
     return (
         <main className="flex-1">

--- a/packages/landing/src/app/api/beta/ipa/route.ts
+++ b/packages/landing/src/app/api/beta/ipa/route.ts
@@ -1,0 +1,31 @@
+/* eslint-disable lingui/no-unlocalized-strings */
+import { NextResponse } from 'next/server';
+
+import { isDefined } from '@rnw-community/shared';
+
+import { findIosDevIpaDownloadUrl } from '../../../../beta/util/find-ios-dev-ipa-download-url.util';
+import { iosDevReleaseFetchApi } from '../../../../beta/util/ios-dev-release-fetch.util';
+
+const NO_STORE_CACHE_CONTROL_HEADER = 'no-store';
+const REDIRECT_STATUS = 302;
+const NOT_FOUND_STATUS = 404;
+
+export const dynamic = 'force-dynamic';
+
+// eslint-disable-next-line func-style,no-implicit-globals -- Next.js route handlers must be exported functions
+export async function GET(): Promise<NextResponse> {
+    const release = await iosDevReleaseFetchApi({ cache: 'no-store' });
+    const ipaDownloadUrl = isDefined(release) ? findIosDevIpaDownloadUrl(release) : null;
+
+    if (!isDefined(ipaDownloadUrl)) {
+        return NextResponse.json(
+            { error: 'No iOS dev build is available yet' },
+            { status: NOT_FOUND_STATUS, headers: { 'Cache-Control': NO_STORE_CACHE_CONTROL_HEADER } }
+        );
+    }
+
+    const redirectResponse = NextResponse.redirect(ipaDownloadUrl, { status: REDIRECT_STATUS });
+    redirectResponse.headers.set('Cache-Control', NO_STORE_CACHE_CONTROL_HEADER);
+
+    return redirectResponse;
+}

--- a/packages/landing/src/beta/constant/ios-dev-release-schema.constant.ts
+++ b/packages/landing/src/beta/constant/ios-dev-release-schema.constant.ts
@@ -1,10 +1,16 @@
 import { z } from 'zod';
 
 export const IosDevReleaseSchema = z.object({
+    tag_name: z.string(),
     name: z.string(),
     body: z.string(),
     published_at: z.string(),
-    assets: z.array(z.object({ name: z.string() }))
+    assets: z.array(
+        z.object({
+            name: z.string(),
+            browser_download_url: z.string()
+        })
+    )
 });
 
 export type IosDevRelease = z.infer<typeof IosDevReleaseSchema>;

--- a/packages/landing/src/beta/util/find-ios-dev-ipa-download-url.util.ts
+++ b/packages/landing/src/beta/util/find-ios-dev-ipa-download-url.util.ts
@@ -1,0 +1,11 @@
+import { isDefined } from '@rnw-community/shared';
+
+import type { IosDevRelease } from '../constant/ios-dev-release-schema.constant';
+
+const IOS_DEV_IPA_ASSET_SUFFIX = '.ipa';
+
+export const findIosDevIpaDownloadUrl = (release: IosDevRelease): string | null => {
+    const ipaAsset = release.assets.find(asset => asset.name.endsWith(IOS_DEV_IPA_ASSET_SUFFIX));
+
+    return isDefined(ipaAsset) ? ipaAsset.browser_download_url : null;
+};

--- a/packages/landing/src/beta/util/ios-dev-release-fetch.util.ts
+++ b/packages/landing/src/beta/util/ios-dev-release-fetch.util.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+import { isDefined, isNotEmptyArray } from '@rnw-community/shared';
+
+import { IosDevReleaseSchema } from '../constant/ios-dev-release-schema.constant';
+
+import { findIosDevIpaDownloadUrl } from './find-ios-dev-ipa-download-url.util';
+
+import type { IosDevRelease } from '../constant/ios-dev-release-schema.constant';
+
+const IOS_DEV_RELEASES_URL = 'https://api.github.com/repos/budgie-at/budgie/releases?per_page=20';
+const IOS_DEV_TAG_PATTERN = /^ios-dev-(\d+)$/u;
+
+const parseIosDevRunNumber = (tagName: string): number => {
+    const match = IOS_DEV_TAG_PATTERN.exec(tagName);
+
+    return isDefined(match) ? Number(match[1]) : 0;
+};
+
+export const iosDevReleaseFetchApi = async (requestInit: RequestInit): Promise<IosDevRelease | null> => {
+    try {
+        const response = await fetch(IOS_DEV_RELEASES_URL, requestInit);
+
+        if (!response.ok) {
+            return null;
+        }
+
+        const releasesJson: unknown = await response.json();
+        const parseResult = z.array(IosDevReleaseSchema).safeParse(releasesJson);
+
+        if (!parseResult.success) {
+            return null;
+        }
+
+        const iosDevReleases = parseResult.data
+            .filter(release => IOS_DEV_TAG_PATTERN.test(release.tag_name) && isDefined(findIosDevIpaDownloadUrl(release)))
+            .sort((releaseA, releaseB) => parseIosDevRunNumber(releaseB.tag_name) - parseIosDevRunNumber(releaseA.tag_name));
+
+        return isNotEmptyArray(iosDevReleases) ? iosDevReleases[0] : null;
+    } catch {
+        return null;
+    }
+};


### PR DESCRIPTION
## Summary

- The repo has GitHub immutable releases active: a published release freezes its assets, and while deletion works, a published tag name is permanently consumed on delete. The rolling `ios-dev` tag design can never publish a second build once the first one's tag is burned.
- CI (`native-dev-build.yml`) now publishes `ios-dev-<run_number>` per run via the existing draft-then-publish flow (fresh tag each run avoids the immutability wall; draft→publish is still required because publishing non-draft and *then* uploading assets 422s on this repo). A new non-fatal prune step keeps only the 5 newest published `ios-dev-*` releases and cleans up stale drafts left by failed publishes.
- Landing can no longer point `manifest.plist` at a fixed asset URL, so a shared `iosDevReleaseFetchApi` helper (`packages/landing/src/beta/util/ios-dev-release-fetch.util.ts`) fetches the releases list, filters to `ios-dev-<n>` releases carrying an `.ipa` asset, and returns the newest. The `/beta` page uses it with `next: { revalidate: 60 }` (ISR-cached); a new `force-dynamic` route `GET /api/beta/ipa` uses it uncached and 302-redirects to the resolved asset with `Cache-Control: no-store`. `manifest.plist`'s `software-package` URL now points at `https://budgie.at/api/beta/ipa`, which stays static.
- A leftover draft release (`ios-dev`, id `352003348`) is now garbage under the new tag scheme; it is intentionally left for manual cleanup, not deleted from CI.

## Test plan

- [x] `yarn ts`, `yarn lint`, `yarn deadcode`, `yarn cpd`, `yarn format` all clean
- [x] Workflow YAML parses; both `run:` scripts pass `shellcheck` with no findings
- [x] Landing dev server: `/en/beta` → 200 (empty state, no `ios-dev-*` releases exist yet); `/api/beta/ipa` → 404 with `Cache-Control: no-store` (correct, no releases yet); `/ota/manifest.plist` → 200, `text/xml`, contains the new `/api/beta/ipa` URL, no redirect
- [ ] Merge, trigger "Build Development build" workflow, confirm an `ios-dev-<n>` release appears
- [ ] `/api/beta/ipa` 302s to that release's `.ipa` asset
- [ ] `budgie.at/beta` shows the new build card
- [ ] Safari OTA install works end-to-end on a registered device

🤖 Generated with [Claude Code](https://claude.com/claude-code)