### PR TITLE
ci: repack iOS app across two Maestro shards

### DIFF
--- a/.github/workflows/ios-native-cache.yml
+++ b/.github/workflows/ios-native-cache.yml
@@ -1,0 +1,189 @@
+name: Seed iOS native app cache
+
+on:
+    workflow_dispatch:
+    push:
+        branches: [main]
+
+concurrency:
+    group: ios-native-cache-main
+    cancel-in-progress: false
+
+permissions:
+    contents: read
+
+env:
+    EAS_CLI_VERSION: '20.5.1'
+    APP_VARIANT: e2e
+    EXPO_PUBLIC_AI_DISABLE: 'true'
+    EXPO_PUBLIC_LOGGING_DISABLE: 'true'
+    EXPO_USE_PRECOMPILED_MODULES: '1'
+    RCT_USE_PREBUILT_RNCORE: '1'
+    RCT_USE_RN_DEP: '1'
+    IOS_DERIVED_DATA: ${{ github.workspace }}/.ci-cache/DerivedData/budgie-e2e
+    USE_CCACHE: '1'
+    CCACHE_DIR: ${{ github.workspace }}/.ci-cache/ccache
+    CCACHE_BASEDIR: ${{ github.workspace }}
+    CCACHE_COMPRESS: 'true'
+    CCACHE_MAXSIZE: 2G
+    CCACHE_NOHASHDIR: 'true'
+
+jobs:
+    seed:
+        name: Seed fingerprinted native app
+        runs-on: [self-hosted, macOS, ARM64, macos-tartelet]
+        timeout-minutes: 120
+        steps:
+            - uses: actions/checkout@v5
+
+            - uses: actions/setup-node@v6
+              with:
+                  node-version: 22.x
+
+            - name: Install dependencies
+              run: yarn install
+
+            - name: Build internal workspace packages
+              run: yarn turbo build --filter=@budgie/contracts --filter=@budgie/ai --filter=@budgie/bank-sync --filter=@budgie/consolidation --filter=@budgie/budget
+
+            - name: Setup EAS CLI
+              uses: expo/expo-github-action@v8
+              with:
+                  eas-version: ${{ env.EAS_CLI_VERSION }}
+                  token: ${{ secrets.EXPO_TOKEN }}
+
+            - name: Generate native fingerprint
+              id: fingerprint
+              working-directory: packages/app
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  eas fingerprint:generate \
+                    --build-profile e2e \
+                    --platform ios \
+                    --json \
+                    --non-interactive > "$RUNNER_TEMP/ios-fingerprint.json"
+                  hash=$(jq -er '.hash' "$RUNNER_TEMP/ios-fingerprint.json")
+                  echo "hash=$hash" >> "$GITHUB_OUTPUT"
+                  echo "Native fingerprint: $hash"
+
+            - name: Restore canonical native app
+              id: native-app-cache
+              uses: actions/cache/restore@v5
+              with:
+                  path: .ci-cache/ios-native-app
+                  key: ios-native-app-${{ runner.os }}-arm64-xcode26_4_1-${{ steps.fingerprint.outputs.hash }}
+
+            - name: Report cache hit
+              if: steps.native-app-cache.outputs.cache-hit == 'true'
+              run: echo 'Canonical native app already exists for this fingerprint.'
+
+            - name: Select Xcode 26.4.1
+              if: steps.native-app-cache.outputs.cache-hit != 'true'
+              run: |
+                  if [ -d /Applications/Xcode_26.4.1.app ]; then
+                    XCODE_APP=/Applications/Xcode_26.4.1.app
+                  elif [ -d /Applications/Xcode.app ]; then
+                    XCODE_APP=/Applications/Xcode.app
+                  else
+                    echo '::error::A supported Xcode installation was not found.'
+                    exit 1
+                  fi
+                  echo "DEVELOPER_DIR=$XCODE_APP/Contents/Developer" >> "$GITHUB_ENV"
+                  "$XCODE_APP/Contents/Developer/usr/bin/xcodebuild" -version
+
+            - name: Restore CocoaPods cache
+              if: steps.native-app-cache.outputs.cache-hit != 'true'
+              uses: actions/cache/restore@v5
+              with:
+                  path: |
+                      ~/Library/Caches/CocoaPods
+                      ~/.cocoapods
+                  key: pods-${{ runner.os }}-xcode26_4_1-${{ hashFiles('yarn.lock', 'packages/app/package.json', 'packages/app/app.config.js', 'packages/app/ios/Podfile.properties.json') }}
+                  restore-keys: |
+                      pods-${{ runner.os }}-xcode26_4_1-
+                      pods-${{ runner.os }}-
+
+            - name: Setup ccache
+              if: steps.native-app-cache.outputs.cache-hit != 'true'
+              run: |
+                  export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
+                  mkdir -p "$CCACHE_DIR" "$IOS_DERIVED_DATA"
+                  if ! command -v ccache >/dev/null; then
+                    command -v brew >/dev/null || {
+                      echo '::error::ccache is not installed and Homebrew is unavailable.'
+                      exit 1
+                    }
+                    brew list ccache >/dev/null 2>&1 || brew install ccache
+                  fi
+                  ccache --zero-stats || true
+                  if command -v brew >/dev/null; then
+                    echo "$(brew --prefix ccache)/libexec" >> "$GITHUB_PATH"
+                  fi
+
+            - name: Restore ccache
+              if: steps.native-app-cache.outputs.cache-hit != 'true'
+              uses: actions/cache/restore@v5
+              with:
+                  path: ${{ env.CCACHE_DIR }}
+                  key: ccache-${{ runner.os }}-xcode26_4_1-e2e-${{ hashFiles('yarn.lock', 'packages/app/package.json', 'packages/app/app.config.js', 'packages/app/ios/Podfile.properties.json') }}
+                  restore-keys: |
+                      ccache-${{ runner.os }}-xcode26_4_1-e2e-
+                      ccache-${{ runner.os }}-
+
+            - name: Generate native project
+              if: steps.native-app-cache.outputs.cache-hit != 'true'
+              working-directory: packages/app
+              run: npx expo prebuild -p ios --clean
+
+            - name: Install pods
+              if: steps.native-app-cache.outputs.cache-hit != 'true'
+              working-directory: packages/app/ios
+              run: pod install
+
+            - name: Build native Release base
+              if: steps.native-app-cache.outputs.cache-hit != 'true'
+              working-directory: packages/app/ios
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  workspace=$(find . -maxdepth 1 -name '*.xcworkspace' -print -quit)
+                  scheme=$(basename "$workspace" .xcworkspace)
+                  test -n "$workspace"
+                  xcodebuild build \
+                    -workspace "$workspace" \
+                    -scheme "$scheme" \
+                    -sdk iphonesimulator \
+                    -configuration Release \
+                    -derivedDataPath "$IOS_DERIVED_DATA" \
+                    -destination 'generic/platform=iOS Simulator' \
+                    -jobs 5 \
+                    CODE_SIGN_IDENTITY='-' \
+                    AD_HOC_CODE_SIGNING_ALLOWED=YES \
+                    PROVISIONING_PROFILE_SPECIFIER='' \
+                    COMPILER_INDEX_STORE_ENABLE=NO \
+                    ONLY_ACTIVE_ARCH=YES \
+                    ARCHS=arm64 \
+                    EXCLUDED_ARCHS=x86_64
+
+            - name: Validate and package native base
+              if: steps.native-app-cache.outputs.cache-hit != 'true'
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  app_path=$(find "$IOS_DERIVED_DATA" -name '*.app' -path '*Release-iphonesimulator*' -print -quit)
+                  test -n "$app_path"
+                  test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$app_path/Info.plist")" = 'com.vitalyiegorov.budgie.e2e'
+                  if /usr/libexec/PlistBuddy -c 'Print :DEV_CLIENT_DEFAULT_LAUNCHER_URL' "$app_path/Info.plist" >/dev/null 2>&1; then
+                    echo '::error::Native E2E base unexpectedly contains a development-client launch URL.'
+                    exit 1
+                  fi
+                  mkdir -p .ci-cache/ios-native-app
+                  tar -C "$(dirname "$app_path")" -czf .ci-cache/ios-native-app/base.app.tar.gz "$(basename "$app_path")"
+
+            - name: Save canonical native app
+              if: steps.native-app-cache.outputs.cache-hit != 'true'
+              uses: actions/cache/save@v5
+              with:
+                  path: .ci-cache/ios-native-app
+                  key: ios-native-app-${{ runner.os }}-arm64-xcode26_4_1-${{ steps.fingerprint.outputs.hash }}

--- a/.github/workflows/ios-native-cache.yml
+++ b/.github/workflows/ios-native-cache.yml
@@ -72,7 +72,7 @@ jobs:
               uses: actions/cache/restore@v5
               with:
                   path: .ci-cache/ios-native-app
-                  key: ios-native-app-${{ runner.os }}-arm64-xcode26_4_1-${{ steps.fingerprint.outputs.hash }}
+                  key: ios-native-v1-budgie-e2e-${{ runner.os }}-arm64-xcode26_4_1-17E202-${{ steps.fingerprint.outputs.hash }}
 
             - name: Report cache hit
               if: steps.native-app-cache.outputs.cache-hit == 'true'
@@ -81,16 +81,16 @@ jobs:
             - name: Select Xcode 26.4.1
               if: steps.native-app-cache.outputs.cache-hit != 'true'
               run: |
-                  if [ -d /Applications/Xcode_26.4.1.app ]; then
-                    XCODE_APP=/Applications/Xcode_26.4.1.app
-                  elif [ -d /Applications/Xcode.app ]; then
-                    XCODE_APP=/Applications/Xcode.app
-                  else
-                    echo '::error::A supported Xcode installation was not found.'
+                  XCODE_APP=/Applications/Xcode_26.4.1.app
+                  if [ ! -d "$XCODE_APP" ]; then
+                    echo '::error::Xcode 26.4.1 is not installed on this runner.'
                     exit 1
                   fi
                   echo "DEVELOPER_DIR=$XCODE_APP/Contents/Developer" >> "$GITHUB_ENV"
-                  "$XCODE_APP/Contents/Developer/usr/bin/xcodebuild" -version
+                  xcode_version=$("$XCODE_APP/Contents/Developer/usr/bin/xcodebuild" -version)
+                  printf '%s\n' "$xcode_version"
+                  grep -qx 'Xcode 26.4.1' <<< "$xcode_version"
+                  grep -qx 'Build version 17E202' <<< "$xcode_version"
 
             - name: Restore CocoaPods cache
               if: steps.native-app-cache.outputs.cache-hit != 'true'
@@ -178,12 +178,13 @@ jobs:
                     echo '::error::Native E2E base unexpectedly contains a development-client launch URL.'
                     exit 1
                   fi
+                  find "$app_path" -name 'main.jsbundle' -type f -print -quit | grep -q .
                   mkdir -p .ci-cache/ios-native-app
-                  tar -C "$(dirname "$app_path")" -czf .ci-cache/ios-native-app/base.app.tar.gz "$(basename "$app_path")"
+                  ditto "$app_path" .ci-cache/ios-native-app/Base.app
 
             - name: Save canonical native app
               if: steps.native-app-cache.outputs.cache-hit != 'true'
               uses: actions/cache/save@v5
               with:
                   path: .ci-cache/ios-native-app
-                  key: ios-native-app-${{ runner.os }}-arm64-xcode26_4_1-${{ steps.fingerprint.outputs.hash }}
+                  key: ios-native-v1-budgie-e2e-${{ runner.os }}-arm64-xcode26_4_1-17E202-${{ steps.fingerprint.outputs.hash }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -205,6 +205,7 @@ jobs:
         env:
             APP_VARIANT: e2e
             EXPO_PUBLIC_AI_DISABLE: 'true'
+            EXPO_PUBLIC_LOGGING_DISABLE: 'true'
             EXPO_USE_PRECOMPILED_MODULES: '1'
             RCT_USE_PREBUILT_RNCORE: '1'
             RCT_USE_RN_DEP: '1'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -364,9 +364,17 @@ jobs:
     e2e-ios:
         if: needs.detect-mobile-impact.outputs.mobile == 'true'
         needs: [detect-mobile-impact, build-ios-e2e-app]
-        name: E2E Tests on iOS
+        name: E2E Tests on iOS (shard ${{ matrix.shard-number }}/2)
         runs-on: [self-hosted, macOS, ARM64, macos-tartelet]
-        timeout-minutes: 150
+        timeout-minutes: 90
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - shard-index: 0
+                      shard-number: 1
+                    - shard-index: 1
+                      shard-number: 2
         permissions:
             contents: read
         env:
@@ -490,16 +498,28 @@ jobs:
                   echo $! > "$ARTIFACT_DIR/simulator-log.pid"
 
             - name: Run Maestro UI tests
-              timeout-minutes: 135
+              timeout-minutes: 75
               working-directory: tests/app-tests
               shell: bash
+              env:
+                  SHARD_INDEX: ${{ matrix.shard-index }}
               run: |
                   set -euo pipefail
+                  mapfile -t all_flows < <(find flows -maxdepth 1 -type f -name '*.flow.yaml' | sort)
+                  selected=()
+                  for index in "${!all_flows[@]}"; do
+                    if (( index % 2 == SHARD_INDEX )); then
+                      selected+=("${all_flows[$index]}")
+                    fi
+                  done
+                  test "${#selected[@]}" -gt 0
+                  printf 'Shard %s flows:\n%s\n' "$SHARD_INDEX" "${selected[*]}"
                   sh ./scripts/run-maestro-suite.sh com.vitalyiegorov.budgie.e2e \
                     --format junit \
                     --output ./artifacts/maestro/report.xml \
                     --debug-output ./artifacts/maestro \
                     --test-output-dir ./artifacts/maestro \
+                    "${selected[@]}" \
                     2>&1 | tee ./artifacts/maestro/maestro-console.log
 
             - name: Stop iOS Simulator captures
@@ -526,7 +546,7 @@ jobs:
               if: always()
               uses: actions/upload-artifact@v6
               with:
-                  name: maestro-ios-artifacts
+                  name: maestro-ios-artifacts-shard-${{ matrix.shard-number }}
                   include-hidden-files: true
                   path: |
                       tests/app-tests/artifacts/maestro/**
@@ -537,7 +557,7 @@ jobs:
               if: failure()
               uses: actions/upload-artifact@v6
               with:
-                  name: maestro-ios-simulator-failure-artifacts
+                  name: maestro-ios-simulator-failure-artifacts-shard-${{ matrix.shard-number }}
                   include-hidden-files: true
                   path: |
                       tests/app-tests/artifacts/simulator/**

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,8 @@ env:
     MAESTRO_CLI_NO_ANALYTICS: 'true'
     MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED: 'true'
     MAESTRO_VERSION: '2.6.1'
+    EAS_CLI_VERSION: '20.5.1'
+    EXPO_REPACK_VERSION: '0.7.2'
     RCT_USE_PREBUILT_RNCORE: 1
     RCT_USE_RN_DEP: 1
 
@@ -173,7 +175,7 @@ jobs:
             - name: Setup EAS
               uses: expo/expo-github-action@v8
               with:
-                  eas-version: latest
+                  eas-version: ${{ env.EAS_CLI_VERSION }}
                   token: ${{ secrets.EXPO_TOKEN }}
 
             - name: Install dependencies
@@ -243,8 +245,30 @@ jobs:
             - name: Setup EAS
               uses: expo/expo-github-action@v8
               with:
-                  eas-version: latest
+                  eas-version: ${{ env.EAS_CLI_VERSION }}
                   token: ${{ secrets.EXPO_TOKEN }}
+
+            - name: Generate native fingerprint
+              id: fingerprint
+              working-directory: packages/app
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  eas fingerprint:generate \
+                    --build-profile e2e \
+                    --platform ios \
+                    --json \
+                    --non-interactive > "$RUNNER_TEMP/ios-fingerprint.json"
+                  hash=$(jq -er '.hash' "$RUNNER_TEMP/ios-fingerprint.json")
+                  echo "hash=$hash" >> "$GITHUB_OUTPUT"
+                  echo "Native fingerprint: $hash"
+
+            - name: Restore fingerprinted native app
+              id: native-app-cache
+              uses: actions/cache/restore@v5
+              with:
+                  path: .ci-cache/ios-native-app
+                  key: ios-native-app-${{ runner.os }}-arm64-xcode26_4_1-${{ steps.fingerprint.outputs.hash }}
 
             - name: Select Xcode 26.4.1
               run: |
@@ -264,6 +288,7 @@ jobs:
                   xcodebuild -version
 
             - name: Restore CocoaPods cache
+              if: steps.native-app-cache.outputs.cache-hit != 'true'
               uses: actions/cache/restore@v5
               with:
                   path: |
@@ -275,6 +300,7 @@ jobs:
                       pods-${{ runner.os }}-
 
             - name: Setup ccache
+              if: steps.native-app-cache.outputs.cache-hit != 'true'
               run: |
                   export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
                   mkdir -p "$CCACHE_DIR" "$IOS_DERIVED_DATA"
@@ -292,6 +318,7 @@ jobs:
                   fi
 
             - name: Restore ccache
+              if: steps.native-app-cache.outputs.cache-hit != 'true'
               uses: actions/cache/restore@v5
               with:
                   path: ${{ env.CCACHE_DIR }}
@@ -301,6 +328,7 @@ jobs:
                       ccache-${{ runner.os }}-
 
             - name: Expo Prebuild
+              if: steps.native-app-cache.outputs.cache-hit != 'true'
               working-directory: packages/app
               env:
                   APP_VARIANT: e2e
@@ -308,13 +336,15 @@ jobs:
               run: npx expo prebuild -p ios --clean
 
             - name: Sync CocoaPods
+              if: steps.native-app-cache.outputs.cache-hit != 'true'
               working-directory: packages/app/ios
               env:
                   APP_VARIANT: e2e
                   EXPO_PUBLIC_AI_DISABLE: 'true'
               run: pod install
 
-            - name: Build app
+            - name: Build native Release base
+              if: steps.native-app-cache.outputs.cache-hit != 'true'
               working-directory: packages/app
               env:
                   APP_VARIANT: e2e
@@ -331,7 +361,7 @@ jobs:
                     -configuration Release \
                     -derivedDataPath "$IOS_DERIVED_DATA" \
                     -destination "generic/platform=iOS Simulator" \
-                    -jobs $(sysctl -n hw.ncpu) \
+                    -jobs 5 \
                     CODE_SIGN_IDENTITY="-" \
                     AD_HOC_CODE_SIGNING_ALLOWED=YES \
                     PROVISIONING_PROFILE_SPECIFIER="" \
@@ -340,15 +370,63 @@ jobs:
                     ARCHS=arm64 \
                     EXCLUDED_ARCHS=x86_64
 
-            - name: Package iOS E2E app
+            - name: Package native base
+              if: steps.native-app-cache.outputs.cache-hit != 'true'
               run: |
+                  set -euo pipefail
                   APP_PATH=$(find "$IOS_DERIVED_DATA" -name "*.app" -path "*Release-iphonesimulator*" | head -1)
                   if [ -z "$APP_PATH" ]; then
                     echo "::error::Built iOS app bundle was not found in $IOS_DERIVED_DATA."
                     find "$IOS_DERIVED_DATA" -maxdepth 6 -name "*.app" || true
                     exit 1
                   fi
+                  test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$APP_PATH/Info.plist")" = 'com.vitalyiegorov.budgie.e2e'
+                  if /usr/libexec/PlistBuddy -c 'Print :DEV_CLIENT_DEFAULT_LAUNCHER_URL' "$APP_PATH/Info.plist" >/dev/null 2>&1; then
+                    echo '::error::Native E2E base unexpectedly contains a development-client launch URL.'
+                    exit 1
+                  fi
 
+                  ARTIFACT_DIR="$GITHUB_WORKSPACE/.ci-cache/ios-native-app"
+                  APP_BUNDLE_NAME=$(basename "$APP_PATH")
+                  mkdir -p "$ARTIFACT_DIR"
+                  tar -C "$(dirname "$APP_PATH")" -czf "$ARTIFACT_DIR/base.app.tar.gz" "$APP_BUNDLE_NAME"
+
+            - name: Save fingerprinted native app
+              if: steps.native-app-cache.outputs.cache-hit != 'true'
+              uses: actions/cache/save@v5
+              with:
+                  path: .ci-cache/ios-native-app
+                  key: ios-native-app-${{ runner.os }}-arm64-xcode26_4_1-${{ steps.fingerprint.outputs.hash }}
+
+            - name: Repack current JavaScript and assets
+              working-directory: packages/app
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  base_dir="$RUNNER_TEMP/ios-native-base"
+                  output_app="$GITHUB_WORKSPACE/.ci-artifacts/repacked/Budgie.app"
+                  mkdir -p "$base_dir" "$(dirname "$output_app")"
+                  tar -xzf "$GITHUB_WORKSPACE/.ci-cache/ios-native-app/base.app.tar.gz" -C "$base_dir"
+                  source_app=$(find "$base_dir" -maxdepth 1 -name '*.app' -print -quit)
+                  test -n "$source_app"
+                  npx --yes "@expo/repack-app@$EXPO_REPACK_VERSION" . \
+                    --platform ios \
+                    --source-app "$source_app" \
+                    --output "$output_app" \
+                    --embed-bundle-assets
+
+            - name: Validate and package repacked app
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  APP_PATH="$GITHUB_WORKSPACE/.ci-artifacts/repacked/Budgie.app"
+                  test -d "$APP_PATH"
+                  test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$APP_PATH/Info.plist")" = 'com.vitalyiegorov.budgie.e2e'
+                  if /usr/libexec/PlistBuddy -c 'Print :DEV_CLIENT_DEFAULT_LAUNCHER_URL' "$APP_PATH/Info.plist" >/dev/null 2>&1; then
+                    echo '::error::E2E app unexpectedly contains a development-client launch URL.'
+                    exit 1
+                  fi
+                  find "$APP_PATH" -name 'main.jsbundle' -type f -print -quit | grep -q .
                   ARTIFACT_DIR="$GITHUB_WORKSPACE/.ci-artifacts/ios-e2e-app"
                   APP_BUNDLE_NAME=$(basename "$APP_PATH")
                   mkdir -p "$ARTIFACT_DIR"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -118,7 +118,7 @@ jobs:
                   fi
 
             - name: Lint the PR Title
-              run: echo "${{env.PR_TITLE}}" | node_modules/.bin/commitlint
+              run: printf '%s\n' "$PR_TITLE" | node_modules/.bin/commitlint
 
             - name: Typescript checks
               run: yarn turbo run ts
@@ -192,11 +192,11 @@ jobs:
                   USE_CCACHE: '1'
               run: |
                   yarn expo export --output-dir dist --dump-assetmap --platform ios --platform android
-                  eas update --skip-bundler --input-dir dist --channel development --message "PR #${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}"
+                  eas update --skip-bundler --input-dir dist --channel development --message "PR #$PR_NUMBER - $PR_TITLE"
 
     build-ios-e2e-app:
         if: needs.detect-mobile-impact.outputs.mobile == 'true'
-        needs: [detect-mobile-impact, code-quality, eas-update-preview]
+        needs: [detect-mobile-impact, code-quality]
         name: Build iOS E2E app
         runs-on: [self-hosted, macOS, ARM64, macos-tartelet]
         timeout-minutes: 120
@@ -269,27 +269,61 @@ jobs:
               uses: actions/cache/restore@v5
               with:
                   path: .ci-cache/ios-native-app
-                  key: ios-native-app-${{ runner.os }}-arm64-xcode26_4_1-${{ steps.fingerprint.outputs.hash }}
+                  key: ios-native-v1-budgie-e2e-${{ runner.os }}-arm64-xcode26_4_1-17E202-${{ steps.fingerprint.outputs.hash }}
+
+            - name: Repack cached native app
+              id: repack
+              if: steps.native-app-cache.outputs.cache-hit == 'true'
+              continue-on-error: true
+              working-directory: packages/app
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  output_app="$GITHUB_WORKSPACE/.ci-artifacts/repacked/Budgie.app"
+                  mkdir -p "$(dirname "$output_app")"
+                  source_app=$(find "$GITHUB_WORKSPACE/.ci-cache/ios-native-app" -maxdepth 1 -name '*.app' -print -quit)
+                  test -n "$source_app"
+                  npx --yes "@expo/repack-app@$EXPO_REPACK_VERSION" . \
+                    --platform ios \
+                    --source-app "$source_app" \
+                    --output "$output_app" \
+                    --embed-bundle-assets
+                  test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$output_app/Info.plist")" = 'com.vitalyiegorov.budgie.e2e'
+                  ! /usr/libexec/PlistBuddy -c 'Print :DEV_CLIENT_DEFAULT_LAUNCHER_URL' "$output_app/Info.plist" >/dev/null 2>&1
+                  find "$output_app" -name 'main.jsbundle' -type f -print -quit | grep -q .
+
+            - name: Plan native build
+              id: native-plan
+              shell: bash
+              run: |
+                  if [ "${{ steps.native-app-cache.outputs.cache-hit }}" != 'true' ] || \
+                     [ "${{ steps.repack.outcome }}" != 'success' ]; then
+                    echo 'required=true' >> "$GITHUB_OUTPUT"
+                    if [ "${{ steps.native-app-cache.outputs.cache-hit }}" = 'true' ]; then
+                      echo '::warning::Repack failed validation; falling back to a full native build.'
+                    fi
+                  else
+                    echo 'required=false' >> "$GITHUB_OUTPUT"
+                  fi
 
             - name: Select Xcode 26.4.1
+              if: steps.native-plan.outputs.required == 'true'
               run: |
-                  if [ -d /Applications/Xcode_26.4.1.app ]; then
-                    XCODE_APP=/Applications/Xcode_26.4.1.app
-                  elif [ -d /Applications/Xcode.app ]; then
-                    XCODE_APP=/Applications/Xcode.app
-                  else
+                  XCODE_APP=/Applications/Xcode_26.4.1.app
+                  if [ ! -d "$XCODE_APP" ]; then
                     echo "::error::Xcode 26.4.1 is not installed on this runner."
-                    ls -1 /Applications | grep -i Xcode || true
                     exit 1
                   fi
 
                   echo "DEVELOPER_DIR=$XCODE_APP/Contents/Developer" >> "$GITHUB_ENV"
                   echo "Using Xcode at $XCODE_APP"
-                  xcode-select -p || true
-                  xcodebuild -version
+                  xcode_version=$("$XCODE_APP/Contents/Developer/usr/bin/xcodebuild" -version)
+                  printf '%s\n' "$xcode_version"
+                  grep -qx 'Xcode 26.4.1' <<< "$xcode_version"
+                  grep -qx 'Build version 17E202' <<< "$xcode_version"
 
             - name: Restore CocoaPods cache
-              if: steps.native-app-cache.outputs.cache-hit != 'true'
+              if: steps.native-plan.outputs.required == 'true'
               uses: actions/cache/restore@v5
               with:
                   path: |
@@ -301,7 +335,7 @@ jobs:
                       pods-${{ runner.os }}-
 
             - name: Setup ccache
-              if: steps.native-app-cache.outputs.cache-hit != 'true'
+              if: steps.native-plan.outputs.required == 'true'
               run: |
                   export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
                   mkdir -p "$CCACHE_DIR" "$IOS_DERIVED_DATA"
@@ -319,7 +353,7 @@ jobs:
                   fi
 
             - name: Restore ccache
-              if: steps.native-app-cache.outputs.cache-hit != 'true'
+              if: steps.native-plan.outputs.required == 'true'
               uses: actions/cache/restore@v5
               with:
                   path: ${{ env.CCACHE_DIR }}
@@ -329,7 +363,7 @@ jobs:
                       ccache-${{ runner.os }}-
 
             - name: Expo Prebuild
-              if: steps.native-app-cache.outputs.cache-hit != 'true'
+              if: steps.native-plan.outputs.required == 'true'
               working-directory: packages/app
               env:
                   APP_VARIANT: e2e
@@ -337,7 +371,7 @@ jobs:
               run: npx expo prebuild -p ios --clean
 
             - name: Sync CocoaPods
-              if: steps.native-app-cache.outputs.cache-hit != 'true'
+              if: steps.native-plan.outputs.required == 'true'
               working-directory: packages/app/ios
               env:
                   APP_VARIANT: e2e
@@ -345,7 +379,7 @@ jobs:
               run: pod install
 
             - name: Build native Release base
-              if: steps.native-app-cache.outputs.cache-hit != 'true'
+              if: steps.native-plan.outputs.required == 'true'
               working-directory: packages/app
               env:
                   APP_VARIANT: e2e
@@ -372,7 +406,7 @@ jobs:
                     EXCLUDED_ARCHS=x86_64
 
             - name: Package native base
-              if: steps.native-app-cache.outputs.cache-hit != 'true'
+              if: steps.native-plan.outputs.required == 'true'
               run: |
                   set -euo pipefail
                   APP_PATH=$(find "$IOS_DERIVED_DATA" -name "*.app" -path "*Release-iphonesimulator*" | head -1)
@@ -386,41 +420,28 @@ jobs:
                     echo '::error::Native E2E base unexpectedly contains a development-client launch URL.'
                     exit 1
                   fi
+                  find "$APP_PATH" -name 'main.jsbundle' -type f -print -quit | grep -q .
 
                   ARTIFACT_DIR="$GITHUB_WORKSPACE/.ci-cache/ios-native-app"
-                  APP_BUNDLE_NAME=$(basename "$APP_PATH")
                   mkdir -p "$ARTIFACT_DIR"
-                  tar -C "$(dirname "$APP_PATH")" -czf "$ARTIFACT_DIR/base.app.tar.gz" "$APP_BUNDLE_NAME"
+                  ditto "$APP_PATH" "$ARTIFACT_DIR/Base.app"
 
             - name: Save fingerprinted native app
               if: steps.native-app-cache.outputs.cache-hit != 'true'
               uses: actions/cache/save@v5
               with:
                   path: .ci-cache/ios-native-app
-                  key: ios-native-app-${{ runner.os }}-arm64-xcode26_4_1-${{ steps.fingerprint.outputs.hash }}
+                  key: ios-native-v1-budgie-e2e-${{ runner.os }}-arm64-xcode26_4_1-17E202-${{ steps.fingerprint.outputs.hash }}
 
-            - name: Repack current JavaScript and assets
-              working-directory: packages/app
+            - name: Validate and package current app
               shell: bash
               run: |
                   set -euo pipefail
-                  base_dir="$RUNNER_TEMP/ios-native-base"
-                  output_app="$GITHUB_WORKSPACE/.ci-artifacts/repacked/Budgie.app"
-                  mkdir -p "$base_dir" "$(dirname "$output_app")"
-                  tar -xzf "$GITHUB_WORKSPACE/.ci-cache/ios-native-app/base.app.tar.gz" -C "$base_dir"
-                  source_app=$(find "$base_dir" -maxdepth 1 -name '*.app' -print -quit)
-                  test -n "$source_app"
-                  npx --yes "@expo/repack-app@$EXPO_REPACK_VERSION" . \
-                    --platform ios \
-                    --source-app "$source_app" \
-                    --output "$output_app" \
-                    --embed-bundle-assets
-
-            - name: Validate and package repacked app
-              shell: bash
-              run: |
-                  set -euo pipefail
-                  APP_PATH="$GITHUB_WORKSPACE/.ci-artifacts/repacked/Budgie.app"
+                  if [ "${{ steps.repack.outcome }}" = 'success' ]; then
+                    APP_PATH="$GITHUB_WORKSPACE/.ci-artifacts/repacked/Budgie.app"
+                  else
+                    APP_PATH=$(find "$IOS_DERIVED_DATA" -name '*.app' -path '*Release-iphonesimulator*' -print -quit)
+                  fi
                   test -d "$APP_PATH"
                   test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$APP_PATH/Info.plist")" = 'com.vitalyiegorov.budgie.e2e'
                   if /usr/libexec/PlistBuddy -c 'Print :DEV_CLIENT_DEFAULT_LAUNCHER_URL' "$APP_PATH/Info.plist" >/dev/null 2>&1; then
@@ -439,6 +460,8 @@ jobs:
                   name: ios-e2e-app
                   path: .ci-artifacts/ios-e2e-app/*.tar.gz
                   if-no-files-found: error
+                  compression-level: 0
+                  retention-days: 3
 
     e2e-ios:
         if: needs.detect-mobile-impact.outputs.mobile == 'true'
@@ -464,13 +487,9 @@ jobs:
 
             - name: Select Xcode 26.4.1
               run: |
-                  if [ -d /Applications/Xcode_26.4.1.app ]; then
-                    XCODE_APP=/Applications/Xcode_26.4.1.app
-                  elif [ -d /Applications/Xcode.app ]; then
-                    XCODE_APP=/Applications/Xcode.app
-                  else
+                  XCODE_APP=/Applications/Xcode_26.4.1.app
+                  if [ ! -d "$XCODE_APP" ]; then
                     echo "::error::Xcode 26.4.1 is not installed on this runner."
-                    ls -1 /Applications | grep -i Xcode || true
                     exit 1
                   fi
 
@@ -584,7 +603,10 @@ jobs:
                   SHARD_INDEX: ${{ matrix.shard-index }}
               run: |
                   set -euo pipefail
-                  mapfile -t all_flows < <(find flows -maxdepth 1 -type f -name '*.flow.yaml' | sort)
+                  all_flows=()
+                  while IFS= read -r flow; do
+                    all_flows+=("$flow")
+                  done < <(find flows -maxdepth 1 -type f -name '*.flow.yaml' | sort)
                   selected=()
                   for index in "${!all_flows[@]}"; do
                     if (( index % 2 == SHARD_INDEX )); then

--- a/packages/app/app.config.js
+++ b/packages/app/app.config.js
@@ -290,7 +290,7 @@ export default ({ config }) => ({
     ],
     experiments: {
         typedRoutes: true,
-        reactCompiler: true,
+        reactCompiler: !IS_E2E,
         buildCacheProvider: 'eas'
     },
     runtimeVersion: {

--- a/packages/app/app.config.js
+++ b/packages/app/app.config.js
@@ -290,7 +290,7 @@ export default ({ config }) => ({
     ],
     experiments: {
         typedRoutes: true,
-        reactCompiler: !IS_E2E,
+        reactCompiler: true,
         buildCacheProvider: 'eas'
     },
     runtimeVersion: {


### PR DESCRIPTION
## What changed

- generates an Expo native fingerprint for the E2E build profile
- restores a pristine Release simulator app keyed by fingerprint, architecture, and Xcode version
- adds a one-VM `main` workflow that seeds the canonical cache for reuse by future PRs
- performs prebuild, CocoaPods, ccache setup, and Xcode compilation only on a native-cache miss
- repacks current JavaScript, assets, and metadata on cache hits with pinned `@expo/repack-app` 0.7.2
- skips Repack on cache misses and uses the freshly built embedded app directly
- treats Repack as a fast path: failed Repack validation falls back to a complete native build instead of blocking Maestro
- validates both the native base and repacked output and rejects dev-client launch metadata
- keeps React Compiler and production application configuration unchanged
- partitions the sorted Maestro suite deterministically across two self-hosted macOS workers
- keeps JUnit, debug, and simulator artifacts isolated by shard with `fail-fast: false`

## Why

Budgie already had a Metro-free Release artifact, but rebuilt native iOS code for every PR revision and ran all flows serially. Fingerprint-safe repacking removes redundant native builds after the first compatible artifact, while the two workers split the current suite evenly.

## Validation

- pinned EAS Fingerprint and Expo Repack CLI contracts verified
- workflow YAML parsed successfully
- `git diff --check` passed
- deterministic partition remains 20 flows per shard for the current suite
- authoritative validation is the live PR build/repack job plus both Maestro shards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * iOS end-to-end testing now runs in parallel across multiple shards, helping reduce validation time.
  * Test artifacts are uploaded with shard-specific names for easier review.
  * iOS build validation now checks app integrity and required production assets more thoroughly.

* **Chores**
  * Standardized iOS build tooling and caching for more consistent automated builds.
  * Pinned Expo and related command-line tool versions to improve workflow reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->