### PR TITLE
ci: run Maestro shards on parallel macOS runners

### DIFF
--- a/.github/workflows/ios-native-cache.yml
+++ b/.github/workflows/ios-native-cache.yml
@@ -31,7 +31,7 @@ env:
 jobs:
     seed:
         name: Seed fingerprinted native app
-        runs-on: [self-hosted, macOS, ARM64, macos-tartelet]
+        runs-on: [self-hosted, macOS, ARM64, macos-builder]
         timeout-minutes: 120
         steps:
             - uses: actions/checkout@v5

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -198,7 +198,7 @@ jobs:
         if: needs.detect-mobile-impact.outputs.mobile == 'true'
         needs: [detect-mobile-impact, code-quality]
         name: Build iOS E2E app
-        runs-on: [self-hosted, macOS, ARM64, macos-tartelet]
+        runs-on: [self-hosted, macOS, ARM64, macos-builder]
         timeout-minutes: 120
         permissions:
             contents: read
@@ -467,10 +467,11 @@ jobs:
         if: needs.detect-mobile-impact.outputs.mobile == 'true'
         needs: [detect-mobile-impact, build-ios-e2e-app]
         name: E2E Tests on iOS (shard ${{ matrix.shard-number }}/2)
-        runs-on: [self-hosted, macOS, ARM64, macos-tartelet]
+        runs-on: [self-hosted, macOS, ARM64, macos-maestro]
         timeout-minutes: 90
         strategy:
             fail-fast: false
+            max-parallel: 2
             matrix:
                 include:
                     - shard-index: 0


### PR DESCRIPTION
## What changed

- route native app builds and cache seeding to the 14 GB `macos-builder` profile
- route the two Maestro shards to independent 7 GB `macos-maestro` runners
- make the intended two-way matrix concurrency explicit

## Why

The workflow already produced one reusable app artifact and two deterministic shards, but a single Tartelet lane serialized them. The host scheduler now provides exclusive build mode or two simulator-only runners, with Linux capacity drained during macOS work.

## Validation

- workflow YAML parsed successfully
- `git diff --check` passed
- runner manager smoke suite: 23 assertions passed
- pre/post-restart fleet health: 0 failures, 0 warnings
- builder and dual-Maestro memory envelopes: 20 GB including host reserve

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the macOS build and testing infrastructure to use refreshed runner configurations.
  * Improved parallel execution for iOS end-to-end testing.
  * No changes to app functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->