### PR TITLE
ci: tier Linux runner workloads

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,7 +24,7 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
-    runs-on: [self-hosted, linux-ci, linux-burst, linux-small]
+    runs-on: [self-hosted, linux-ci, linux-burst, linux-medium]
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,7 +24,7 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
-    runs-on: [self-hosted, linux-ci]
+    runs-on: [self-hosted, linux-ci, linux-burst, linux-small]
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,7 +24,7 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
-    runs-on: [self-hosted, linux-ci, linux-burst, linux-medium]
+    runs-on: [self-hosted, linux-tiered, linux-medium]
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: [self-hosted, linux-ci, linux-burst, linux-small]
+    runs-on: [self-hosted, linux-ci, linux-burst, linux-medium]
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: [self-hosted, linux-ci, linux-burst, linux-medium]
+    runs-on: [self-hosted, linux-tiered, linux-medium]
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: [self-hosted, linux-ci]
+    runs-on: [self-hosted, linux-ci, linux-burst, linux-small]
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/ios-native-cache.yml
+++ b/.github/workflows/ios-native-cache.yml
@@ -134,7 +134,7 @@ jobs:
             - name: Generate native project
               if: steps.native-app-cache.outputs.cache-hit != 'true'
               working-directory: packages/app
-              run: npx expo prebuild -p ios --clean
+              run: npx expo prebuild -p ios --clean --no-install
 
             - name: Install pods
               if: steps.native-app-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ios-native-cache.yml
+++ b/.github/workflows/ios-native-cache.yml
@@ -36,6 +36,13 @@ jobs:
         steps:
             - uses: actions/checkout@v5
 
+            - name: Setup macOS toolchain PATH
+              shell: bash
+              run: |
+                  echo "$HOME/.rbenv/shims" >> "$GITHUB_PATH"
+                  echo '/opt/homebrew/bin' >> "$GITHUB_PATH"
+                  echo '/opt/homebrew/sbin' >> "$GITHUB_PATH"
+
             - uses: actions/setup-node@v6
               with:
                   node-version: 22.x
@@ -107,7 +114,6 @@ jobs:
             - name: Setup ccache
               if: steps.native-app-cache.outputs.cache-hit != 'true'
               run: |
-                  export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
                   mkdir -p "$CCACHE_DIR" "$IOS_DERIVED_DATA"
                   if ! command -v ccache >/dev/null; then
                     command -v brew >/dev/null || {
@@ -116,6 +122,8 @@ jobs:
                     }
                     brew list ccache >/dev/null 2>&1 || brew install ccache
                   fi
+                  command -v ccache
+                  ccache --version
                   ccache --zero-stats || true
                   if command -v brew >/dev/null; then
                     echo "$(brew --prefix ccache)/libexec" >> "$GITHUB_PATH"
@@ -139,7 +147,10 @@ jobs:
             - name: Install pods
               if: steps.native-app-cache.outputs.cache-hit != 'true'
               working-directory: packages/app/ios
-              run: pod install
+              run: |
+                  command -v pod
+                  pod --version
+                  pod install
 
             - name: Build native Release base
               if: steps.native-app-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/landing-indexnow.yml
+++ b/.github/workflows/landing-indexnow.yml
@@ -17,7 +17,7 @@ jobs:
   submit:
     name: Submit IndexNow
     if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
-    runs-on: [self-hosted, linux-ci, linux-burst, linux-small]
+    runs-on: [self-hosted, linux-tiered, linux-small]
     timeout-minutes: 5
     steps:
       - name: Wait for Vercel deploy to propagate

--- a/.github/workflows/landing-indexnow.yml
+++ b/.github/workflows/landing-indexnow.yml
@@ -17,7 +17,7 @@ jobs:
   submit:
     name: Submit IndexNow
     if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
-    runs-on: [self-hosted, linux-ci]
+    runs-on: [self-hosted, linux-ci, linux-burst, linux-small]
     timeout-minutes: 5
     steps:
       - name: Wait for Vercel deploy to propagate

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,8 +86,8 @@ jobs:
     name: EAS Update
     needs: release
     # Expo's Hermes compiler package ships an x86-64 Linux host binary.
-    # Keep the export off the ARM64 self-hosted fleet.
-    runs-on: ubuntu-latest
+    # Keep the export on the hosted x86-64 image and off the ARM64 fleet.
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: Check for EXPO_TOKEN
@@ -96,6 +96,9 @@ jobs:
             echo "You must provide an EXPO_TOKEN secret linked to this project's Expo account in this repo's secrets. Learn more: https://docs.expo.dev/eas-update/github-actions"
             exit 1
           fi
+
+      - name: Verify x86-64 Hermes host
+        run: test "$(uname -m)" = 'x86_64'
 
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   release:
     name: Publish a release
-    runs-on: [self-hosted, linux-ci, linux-burst, linux-medium]
+    runs-on: [self-hosted, linux-tiered, linux-medium]
     timeout-minutes: 30
     steps:
       - name: Checkout repository

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   release:
     name: Publish a release
-    runs-on: [self-hosted, linux-ci]
+    runs-on: [self-hosted, linux-ci, linux-burst, linux-medium]
     timeout-minutes: 30
     steps:
       - name: Checkout repository
@@ -85,7 +85,9 @@ jobs:
   eas-update:
     name: EAS Update
     needs: release
-    runs-on: [self-hosted, linux-ci]
+    # Expo's Hermes compiler package ships an x86-64 Linux host binary.
+    # Keep the export off the ARM64 self-hosted fleet.
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Check for EXPO_TOKEN

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ on: pull_request
 jobs:
     detect-mobile-impact:
         name: Detect mobile impact
-        runs-on: [self-hosted, linux-ci, linux-burst, linux-medium]
+        runs-on: [self-hosted, linux-tiered, linux-medium]
         timeout-minutes: 15
         permissions:
             contents: read
@@ -89,7 +89,7 @@ jobs:
 
     code-quality:
         name: Code quality checks
-        runs-on: [self-hosted, linux-ci, linux-burst, linux-large]
+        runs-on: [self-hosted, linux-tiered, linux-large]
         timeout-minutes: 30
         permissions:
             contents: read

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ on: pull_request
 jobs:
     detect-mobile-impact:
         name: Detect mobile impact
-        runs-on: [self-hosted, linux-ci]
+        runs-on: [self-hosted, linux-ci, linux-burst, linux-medium]
         timeout-minutes: 15
         permissions:
             contents: read
@@ -89,7 +89,7 @@ jobs:
 
     code-quality:
         name: Code quality checks
-        runs-on: [self-hosted, linux-ci]
+        runs-on: [self-hosted, linux-ci, linux-burst, linux-large]
         timeout-minutes: 30
         permissions:
             contents: read
@@ -672,114 +672,3 @@ jobs:
                   if [ -n "${SIMULATOR_UDID:-}" ]; then
                     xcrun simctl shutdown "$SIMULATOR_UDID" || true
                   fi
-
-    e2e-android:
-        if: false && needs.detect-mobile-impact.outputs.mobile == 'true'
-        needs: [detect-mobile-impact, code-quality, eas-update-preview]
-        name: E2E Tests on Android
-        runs-on: [self-hosted, linux-ci]
-        timeout-minutes: 60
-        permissions:
-            contents: read
-        steps:
-            - uses: actions/checkout@v5
-
-            - name: Enable KVM group perms
-              run: |
-                  echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-                  sudo udevadm control --reload-rules
-                  sudo udevadm trigger --name-match=kvm
-
-            - name: Setup Node
-              uses: actions/setup-node@v6
-              with:
-                  node-version: 22.x
-
-            - name: Setup EAS
-              uses: expo/expo-github-action@v8
-              with:
-                  eas-version: latest
-                  token: ${{ secrets.EXPO_TOKEN }}
-
-            - name: Install dependencies
-              run: |
-                  yarn install
-
-            - name: Expo Prebuild
-              working-directory: packages/app
-              run: npx expo prebuild -p android --clean
-
-            - name: Cache Gradle
-              uses: actions/cache@v5
-              with:
-                  path: |
-                      ~/.gradle/caches
-                      ~/.gradle/wrapper
-                  key: ${{ runner.os }}-gradle-${{ hashFiles('packages/app/android/**/*.gradle*', 'packages/app/android/gradle/wrapper/gradle-wrapper.properties') }}
-                  restore-keys: ${{ runner.os }}-gradle-
-
-            - name: AVD cache
-              uses: actions/cache@v5
-              id: avd-cache
-              with:
-                  path: |
-                      ~/.android/avd/*
-                      ~/.android/adb*
-                  key: avd-34
-
-            - name: Build app
-              working-directory: packages/app
-              run: |
-                  eas build --profile=e2e --platform android --non-interactive --local --output app.android.apk
-
-            - name: Install Maestro
-              run: |
-                  maestro_bin="$HOME/.maestro/bin/maestro"
-                  installed_version="$(
-                    MAESTRO_CLI_NO_ANALYTICS=true \
-                      MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED=true \
-                      "$maestro_bin" --version 2>/dev/null | tail -n 1 | tr -d '\r' || true
-                  )"
-                  if [ ! -x "$maestro_bin" ] || [ "$installed_version" != "$MAESTRO_VERSION" ]; then
-                    curl -fsSL "https://get.maestro.mobile.dev" | env MAESTRO_VERSION="$MAESTRO_VERSION" bash
-                  fi
-                  echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
-                  test "$(MAESTRO_CLI_NO_ANALYTICS=true MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED=true "$maestro_bin" --version 2>&1 | tail -n 1 | tr -d '\r')" = "$MAESTRO_VERSION"
-
-            - name: Сreate AVD and generate snapshot for caching
-              if: steps.avd-cache.outputs.cache-hit != 'true'
-              uses: reactivecircus/android-emulator-runner@v2
-              with:
-                  api-level: 34
-                  target: aosp_atd
-                  channel: canary
-                  arch: x86_64
-                  force-avd-creation: false
-                  emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-                  disable-animations: false
-                  script: echo "Generated AVD snapshot for caching."
-
-            - name: Start emulator and run Maestro tests
-              uses: reactivecircus/android-emulator-runner@v2
-              with:
-                  api-level: 34
-                  target: aosp_atd
-                  channel: canary
-                  arch: x86_64
-                  force-avd-creation: false
-                  emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-                  disable-animations: true
-                  working-directory: tests/app-tests
-                  script: |
-                      cd ../../packages/app && eas build:run --platform android --path app.android.apk
-                      sh ./scripts/run-maestro-suite.sh com.vitaliiyehorov.budgie.e2e --config config.yaml --format junit --output ./report.xml --debug-output ./ && killall -INT crashpad_handler
-
-            - name: Upload Maestro artifacts (report, logs, videos, screenshots)
-              if: always()
-              uses: actions/upload-artifact@v6
-              with:
-                  name: maestro-android-artifacts
-                  include-hidden-files: true
-                  path: |
-                      tests/app-tests/.maestro/**
-                      tests/app-tests/*.mp4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -149,9 +149,9 @@ jobs:
         needs: [detect-mobile-impact]
         name: EAS Update Preview
         # Expo's Hermes compiler package ships an x86-64 Linux host binary.
-        # Keep this export off ARM64 self-hosted runners and reserve the Mac
-        # mini for the native iOS build and simulator stages below.
-        runs-on: ubuntu-latest
+        # Keep this export on the hosted x86-64 image and reserve the Mac mini
+        # for the native iOS build and simulator stages below.
+        runs-on: ubuntu-24.04
         timeout-minutes: 30
         permissions:
             contents: read
@@ -163,6 +163,9 @@ jobs:
                     echo "Learn more: https://docs.expo.dev/eas/github-actions"
                     exit 1
                   fi
+
+            - name: Verify x86-64 Hermes host
+              run: test "$(uname -m)" = 'x86_64'
 
             - name: Checkout repository
               uses: actions/checkout@v5

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -222,6 +222,13 @@ jobs:
         steps:
             - uses: actions/checkout@v5
 
+            - name: Setup macOS toolchain PATH
+              shell: bash
+              run: |
+                  echo "$HOME/.rbenv/shims" >> "$GITHUB_PATH"
+                  echo '/opt/homebrew/bin' >> "$GITHUB_PATH"
+                  echo '/opt/homebrew/sbin' >> "$GITHUB_PATH"
+
             - name: Runner diagnostics
               run: |
                   whoami
@@ -340,7 +347,6 @@ jobs:
             - name: Setup ccache
               if: steps.native-plan.outputs.required == 'true'
               run: |
-                  export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
                   mkdir -p "$CCACHE_DIR" "$IOS_DERIVED_DATA"
                   if ! command -v ccache >/dev/null; then
                     command -v brew >/dev/null || {
@@ -349,6 +355,7 @@ jobs:
                     }
                     brew list ccache >/dev/null 2>&1 || brew install ccache
                   fi
+                  command -v ccache
                   ccache --version
                   ccache --zero-stats || true
                   if command -v brew >/dev/null; then
@@ -379,7 +386,10 @@ jobs:
               env:
                   APP_VARIANT: e2e
                   EXPO_PUBLIC_AI_DISABLE: 'true'
-              run: pod install
+              run: |
+                  command -v pod
+                  pod --version
+                  pod install
 
             - name: Build native Release base
               if: steps.native-plan.outputs.required == 'true'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -368,7 +368,7 @@ jobs:
               env:
                   APP_VARIANT: e2e
                   EXPO_PUBLIC_AI_DISABLE: 'true'
-              run: npx expo prebuild -p ios --clean
+              run: npx expo prebuild -p ios --clean --no-install
 
             - name: Sync CocoaPods
               if: steps.native-plan.outputs.required == 'true'


### PR DESCRIPTION
## What changed

- route IndexNow to `linux-small` (1 CPU / 2 GB)
- route interactive Claude automation to `linux-medium` so tool execution has stable headroom
- route dependency and impact work to `linux-medium` (2 CPU / 4 GB)
- reserve `linux-large` (4 CPU / 8 GB) for the proven memory-heavy monorepo quality job
- remove the permanently disabled Android Maestro workflow
- keep CodeQL and Hermes EAS exports on x64 GitHub Linux because the local fleet is ARM64
- isolate new `linux-tiered` routing from legacy `linux-ci`/`linux-burst` jobs so subset label matching cannot bypass sizing
- use Expo prebuild `--no-install` so the explicit cached CocoaPods step is the only pod installation on native cache misses

## Why

The Mac mini previously assigned 8 GB to every Budgie Linux job, including API-only work. Tier labels let the burst manager provision the smallest stable VM while preserving 8 GB for the lint workload that previously exited 137 below that size.

## Validation

- all workflow YAML parsed successfully
- `git diff --check`
- tier-aware runner-manager smoke suite: 37 assertions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD Improvements**
  * Updated build and deployment workflows to use tiered runner environments.
  * Improved iOS build setup with toolchain, ccache, and CocoaPods verification.
  * Added host architecture checks for Hermes-related workflows.
  * Streamlined iOS project preparation and dependency installation.
  * Removed the Android end-to-end workflow job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->