### PR TITLE
test(app): harden native deep-link confirmation

### DIFF
--- a/tests/app-tests/flows/setup/prime-deep-links.flow.yaml
+++ b/tests/app-tests/flows/setup/prime-deep-links.flow.yaml
@@ -10,7 +10,9 @@ appId: ${APP_ID}
       when:
           visible: 'Open'
       commands:
-          - tapOn: 'Open'
+          - tapOn:
+                text: 'Open'
+                retryTapIfNoChange: true
           - extendedWaitUntil:
                 notVisible: 'Open in .*'
                 timeout: 5000

--- a/tests/app-tests/scripts/run-maestro-suite.sh
+++ b/tests/app-tests/scripts/run-maestro-suite.sh
@@ -443,9 +443,9 @@ prime_deep_links() {
     echo "Priming deep-link scheme confirmation"
 
     if [ -n "$DETECTED_SIMULATOR_UDID" ]; then
-        maestro --udid "$DETECTED_SIMULATOR_UDID" test "$prime_flow_path" --config "$WORKSPACE_DIR/config.yaml" -e APP_ID="$APP_ID" || true
+        maestro --udid "$DETECTED_SIMULATOR_UDID" test "$prime_flow_path" --config "$WORKSPACE_DIR/config.yaml" -e APP_ID="$APP_ID"
     else
-        maestro test "$prime_flow_path" --config "$WORKSPACE_DIR/config.yaml" -e APP_ID="$APP_ID" || true
+        maestro test "$prime_flow_path" --config "$WORKSPACE_DIR/config.yaml" -e APP_ID="$APP_ID"
     fi
 }
 

--- a/tests/app-tests/scripts/validate-maestro-selectors.sh
+++ b/tests/app-tests/scripts/validate-maestro-selectors.sh
@@ -69,3 +69,16 @@ if [ -n "$LONG_OPTIONAL_WAITS" ]; then
     echo "extendedWaitUntil with optional: true and timeout > 5000 silently burns the full timeout when the element is absent. Use a required wait or keep the optional grace wait at 5000 or less."
     exit 1
 fi
+
+PRIME_FLOW="$FLOW_DIR/setup/prime-deep-links.flow.yaml"
+SUITE_RUNNER="scripts/run-maestro-suite.sh"
+
+if ! grep -E -q 'retryTapIfNoChange:[[:space:]]*true' "$PRIME_FLOW"; then
+    echo "The native deep-link confirmation must retry only when the Open tap leaves the dialog unchanged."
+    exit 1
+fi
+
+if grep -E -n 'maestro .*prime_flow_path.*\|\| true' "$SUITE_RUNNER"; then
+    echo "Deep-link priming must fail the suite before business flows run behind an unresolved native dialog."
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- make the one legitimate native iOS Open confirmation retry only when the tap leaves the dialog unchanged
- fail deep-link priming before business flows instead of swallowing an unresolved system dialog
- add a selector-policy regression check first, then the implementation in a separate green commit

## Evidence
- reproduced on PR #561 shard 1: Home was healthy behind the still-visible `Open in budgie (E2E)?` system dialog
- regression validator failed before the implementation and passes afterward
- `bash -n`, selector policy, YAML parsing, and `git diff --check` pass locally
- full repository quality and both Maestro shards are delegated to this PR CI because installing another local dependency tree would violate the live fleet disk guard


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deep-link test handling when iOS confirmation prompts appear.
  * Test runs now stop when deep-link setup fails instead of continuing with unresolved dialogs.

* **Tests**
  * Added validation to ensure deep-link flows retry prompt interactions and failures are not suppressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->