### PR TITLE
ci: speed up Maestro fixture runs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -650,6 +650,28 @@ jobs:
                     "${selected[@]}" \
                     2>&1 | tee ./artifacts/maestro/maestro-console.log
 
+            - name: Publish Maestro timing summary
+              if: always()
+              working-directory: tests/app-tests
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  timing_file="./artifacts/maestro/flow-timings.tsv"
+
+                  if [ ! -f "$timing_file" ]; then
+                    exit 0
+                  fi
+
+                  {
+                    echo '### Maestro flow timings'
+                    echo
+                    echo '| Flow | Status | Attempts | Seconds |'
+                    echo '| --- | --- | ---: | ---: |'
+                    tail -n +2 "$timing_file" |
+                      sort -t $'\t' -k5,5nr |
+                      awk -F '\t' '{ printf "| `%s` | %s | %s | %s |\n", $2, $3, $4, $5 }'
+                  } >> "$GITHUB_STEP_SUMMARY"
+
             - name: Stop iOS Simulator captures
               if: always()
               run: |

--- a/tests/app-tests/scripts/run-maestro-suite.sh
+++ b/tests/app-tests/scripts/run-maestro-suite.sh
@@ -208,7 +208,6 @@ seed_ios_database_fixture_if_needed() {
     rm -f "$sqlite_dir"/budgie.db*
     cp "$fixture_path" "$sqlite_dir/budgie.db"
     xcrun simctl launch "$DETECTED_SIMULATOR_UDID" "$APP_ID" >/dev/null
-    sleep 3
 
     DATABASE_FIXTURE_SEEDED="true"
     echo "Seeded active iOS database fixture $fixture_name"
@@ -439,6 +438,23 @@ fs.writeFileSync(outputPath, xml);
 EOF
 }
 
+record_flow_timing() {
+    local flow_index="$1"
+    local flow_name="$2"
+    local flow_status="$3"
+    local attempt_count="$4"
+    local started_at="$5"
+    local duration_seconds
+
+    if [ -z "$FLOW_TIMINGS_PATH" ]; then
+        return 0
+    fi
+
+    duration_seconds="$(($(date +%s) - started_at))"
+
+    printf '%s\t%s\t%s\t%s\t%s\n' "$flow_index" "$flow_name" "$flow_status" "$attempt_count" "$duration_seconds" >> "$FLOW_TIMINGS_PATH"
+}
+
 refresh_ios_fixtures_if_needed
 
 if [ -z "$RECURRING_EMPTY_DAY" ]; then
@@ -481,13 +497,16 @@ echo "Running Maestro suite from $WORKSPACE_DIR"
 
 REPORT_DIR=""
 REPORTS=()
+FLOW_TIMINGS_PATH=""
 FLOW_INDEX=0
 FLOW_TOTAL="${#FLOW_PATHS[@]}"
 
 if [ -n "$OUTPUT_PATH" ]; then
     REPORT_DIR="$(dirname "$OUTPUT_PATH")/.maestro-flow-reports"
+    FLOW_TIMINGS_PATH="$(dirname "$OUTPUT_PATH")/flow-timings.tsv"
     rm -rf "$REPORT_DIR"
     mkdir -p "$REPORT_DIR"
+    printf 'index\tflow\tstatus\tattempts\tduration_seconds\n' > "$FLOW_TIMINGS_PATH"
 fi
 
 for FLOW_PATH in "${FLOW_PATHS[@]}"; do
@@ -496,6 +515,7 @@ for FLOW_PATH in "${FLOW_PATHS[@]}"; do
     FLOW_OUTPUT_PATH=""
     FLOW_ARTIFACT_PATH=""
     FLOW_STATUS=0
+    FLOW_STARTED_AT="$(date +%s)"
 
     if [ -n "$OUTPUT_PATH" ]; then
         FLOW_OUTPUT_PATH="$REPORT_DIR/$FLOW_INDEX-$FLOW_NAME.xml"
@@ -515,6 +535,7 @@ for FLOW_PATH in "${FLOW_PATHS[@]}"; do
 
     if run_maestro_flow "$FLOW_PATH" "$FLOW_OUTPUT_PATH" "$FLOW_ARTIFACT_PATH/attempt-1" > "$FLOW_ARTIFACT_PATH/attempt-1/maestro-console.log" 2>&1; then
         cat "$FLOW_ARTIFACT_PATH/attempt-1/maestro-console.log"
+        record_flow_timing "$FLOW_INDEX" "$FLOW_NAME" success 1 "$FLOW_STARTED_AT"
         echo "Completed Maestro flow $FLOW_INDEX/$FLOW_TOTAL: $FLOW_NAME"
 
         if [ -n "$FLOW_OUTPUT_PATH" ] && [ -f "$FLOW_OUTPUT_PATH" ]; then
@@ -531,6 +552,7 @@ for FLOW_PATH in "${FLOW_PATHS[@]}"; do
 
             if run_maestro_flow "$FLOW_PATH" "$FLOW_OUTPUT_PATH" "$FLOW_ARTIFACT_PATH/attempt-2" > "$FLOW_ARTIFACT_PATH/attempt-2/maestro-console.log" 2>&1; then
                 cat "$FLOW_ARTIFACT_PATH/attempt-2/maestro-console.log"
+                record_flow_timing "$FLOW_INDEX" "$FLOW_NAME" success 2 "$FLOW_STARTED_AT"
                 echo "Completed Maestro flow $FLOW_INDEX/$FLOW_TOTAL after AX driver retry: $FLOW_NAME"
 
                 if [ -n "$FLOW_OUTPUT_PATH" ] && [ -f "$FLOW_OUTPUT_PATH" ]; then
@@ -543,6 +565,9 @@ for FLOW_PATH in "${FLOW_PATHS[@]}"; do
 
             FLOW_STATUS=$?
             cat "$FLOW_ARTIFACT_PATH/attempt-2/maestro-console.log"
+            record_flow_timing "$FLOW_INDEX" "$FLOW_NAME" failure 2 "$FLOW_STARTED_AT"
+        else
+            record_flow_timing "$FLOW_INDEX" "$FLOW_NAME" failure 1 "$FLOW_STARTED_AT"
         fi
 
         if [ -n "$FLOW_OUTPUT_PATH" ] && [ -f "$FLOW_OUTPUT_PATH" ]; then

--- a/tests/app-tests/scripts/test-run-maestro-suite.sh
+++ b/tests/app-tests/scripts/test-run-maestro-suite.sh
@@ -23,6 +23,8 @@ printf '%s\n' "$*" >> "$MOCK_XCRUN_LOG"
 if [ "$1" = simctl ] && [ "$2" = get_app_container ]; then
     printf '%s\n' "$MOCK_APP_DATA"
 fi
+
+exit 0
 EOF
 chmod +x "$TEMP_DIR/bin/xcrun"
 
@@ -60,11 +62,11 @@ run_case() {
         MOCK_MAESTRO_LOG="$case_dir/maestro.log" \
         MOCK_XCRUN_LOG="$case_dir/xcrun.log" \
         SIMULATOR_UDID='00000000-0000-0000-0000-000000000001' \
-        "$SCRIPT_DIR/run-maestro-suite.sh" com.example.test flows/test.flow.yaml --output "$case_dir/report.xml" --debug-output "$case_dir/artifacts/output" --test-output-dir "$case_dir/results/output" > "$case_dir/console.log" 2>&1 || status=$?
+        sh "$SCRIPT_DIR/run-maestro-suite.sh" com.example.test "$TEMP_DIR/flows/test.flow.yaml" --output "$case_dir/report.xml" --debug-output "$case_dir/artifacts/output" --test-output-dir "$case_dir/results/output" > "$case_dir/console.log" 2>&1 || status=$?
 
     test "$status" -eq "$expected_status"
     test "$(wc -l < "$case_dir/maestro.log" | tr -d ' ')" -eq "$expected_maestro_calls"
-    test "$(grep -c '^shutdown ' "$case_dir/xcrun.log" || true)" -eq "$expected_shutdown_calls"
+    test "$(grep -c '^simctl shutdown ' "$case_dir/xcrun.log" || true)" -eq "$expected_shutdown_calls"
 
     if [ "$failure_kind" = ax ]; then
         test -f "$case_dir/.maestro-flow-attempts/1-test.flow.yaml/attempt-1/maestro-console.log"
@@ -76,6 +78,10 @@ run_case() {
         test "$(grep -c -- "--debug-output $case_dir/.maestro-flow-attempts/1-test.flow.yaml/attempt-[12]/debug-output/output" "$case_dir/maestro.log")" -eq 2
         test "$(grep -c -- "--test-output-dir $case_dir/.maestro-flow-attempts/1-test.flow.yaml/attempt-[12]/test-output-dir/output" "$case_dir/maestro.log")" -eq 2
     fi
+
+    test -f "$case_dir/flow-timings.tsv"
+    grep -q $'index\tflow\tstatus\tattempts\tduration_seconds' "$case_dir/flow-timings.tsv"
+    grep -q $'1\ttest.flow.yaml\t' "$case_dir/flow-timings.tsv"
 }
 
 run_case ax 0 3 1


### PR DESCRIPTION
## Summary
- remove the fixed 3-second sleep after pre-seeding an iOS DB fixture and rely on Maestro readiness waits
- write per-flow Maestro timing TSVs next to the JUnit/debug artifacts
- publish a sortable Maestro timing table in each shard's GitHub step summary
- tighten the shell harness test so it invokes the temp flow through the same sh path CI uses

## Validation
- yarn install --immutable
- bash -n tests/app-tests/scripts/run-maestro-suite.sh
- sh tests/app-tests/scripts/test-run-maestro-suite.sh
- yarn workspace @budgie-at/app-tests selectors:check
- yarn format:check .github/workflows/pr.yml tests/app-tests/scripts/run-maestro-suite.sh tests/app-tests/scripts/test-run-maestro-suite.sh
- yarn format && yarn ts && yarn lint && yarn deadcode && yarn cpd