### PR TITLE
fix: redact reconciliation lifecycle logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ These rules are vital and apply to every AI agent and orchestrator working in th
 - Set the LOWEST effort level that fits the task; raise effort only for verification/judging stages where correctness is critical.
 - Subagent prompts must be self-contained (paths, rules, constraints, validation steps) so no round-trips are wasted.
 - Do not spawn a top-tier agent for work a cheaper one can verify; prefer cheap execution + targeted verification over expensive single-shot runs.
+- Never commit agent-generated planning, design, or specification artifacts (including `docs/superpowers/plans` and `docs/superpowers/specs`); keep them outside the repository or untracked. Product documentation may be committed only when explicitly requested by the human.
 
 ## Git Commits And Pull Requests
 

--- a/packages/app/src/sync/service/bank-sync-duplicate-repair-source.service.ts
+++ b/packages/app/src/sync/service/bank-sync-duplicate-repair-source.service.ts
@@ -1,8 +1,6 @@
 import { ExternalSourceEnum } from '@budgie/contracts';
 import { Log } from '@budgie/logger';
 
-import { isDefined, isError } from '@rnw-community/shared';
-
 import { ERSTE_DUPLICATE_CANDIDATE_SQL } from '../constant/erste-duplicate-candidate-sql.constant';
 import { PRIVATBANK_DUPLICATE_CANDIDATE_SQL } from '../constant/privatbank-duplicate-candidate-sql.constant';
 
@@ -16,11 +14,7 @@ class BankSyncDuplicateRepairSourceService implements BankSyncDuplicateRepairSou
         private readonly candidateSql: string
     ) {}
 
-    @Log.withoutErrorPayload(
-        database => `enter database=${String(isDefined(database))}`,
-        (result, database) => `done database=${String(isDefined(database))} candidateCount=${result.length}`,
-        (error, database) => `throw database=${String(isDefined(database))} errorClass=${isError(error) ? error.name : 'UnknownError'}`
-    )
+    @Log.withoutErrorPayload()
     async findDuplicateCandidates(database: DB): Promise<BankSyncDuplicateCandidateRowInterface[]> {
         return database.$client.getAllAsync<BankSyncDuplicateCandidateRowInterface>(this.candidateSql);
     }

--- a/packages/app/src/sync/service/bank-sync-duplicate-repair-source.service.ts
+++ b/packages/app/src/sync/service/bank-sync-duplicate-repair-source.service.ts
@@ -1,7 +1,7 @@
 import { ExternalSourceEnum } from '@budgie/contracts';
 import { Log } from '@budgie/logger';
 
-import { getErrorMessage, isDefined } from '@rnw-community/shared';
+import { isDefined, isError } from '@rnw-community/shared';
 
 import { ERSTE_DUPLICATE_CANDIDATE_SQL } from '../constant/erste-duplicate-candidate-sql.constant';
 import { PRIVATBANK_DUPLICATE_CANDIDATE_SQL } from '../constant/privatbank-duplicate-candidate-sql.constant';
@@ -16,11 +16,10 @@ class BankSyncDuplicateRepairSourceService implements BankSyncDuplicateRepairSou
         private readonly candidateSql: string
     ) {}
 
-    @Log(
+    @Log.withoutErrorPayload(
         database => `enter database=${String(isDefined(database))}`,
-        (result, database) =>
-            `done database=${String(isDefined(database))} duplicateIds=${result.map(candidate => candidate.duplicateTransactionId).join(',')}`,
-        (error, database) => `throw database=${String(isDefined(database))} error=${getErrorMessage(error)}`
+        (result, database) => `done database=${String(isDefined(database))} candidateCount=${result.length}`,
+        (error, database) => `throw database=${String(isDefined(database))} errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async findDuplicateCandidates(database: DB): Promise<BankSyncDuplicateCandidateRowInterface[]> {
         return database.$client.getAllAsync<BankSyncDuplicateCandidateRowInterface>(this.candidateSql);

--- a/packages/app/src/sync/service/bank-sync-duplicate-soft-delete.service.ts
+++ b/packages/app/src/sync/service/bank-sync-duplicate-soft-delete.service.ts
@@ -1,6 +1,6 @@
 import { Log } from '@budgie/logger';
 
-import { getErrorMessage, isDefined, isEmptyArray } from '@rnw-community/shared';
+import { isDefined, isEmptyArray, isError } from '@rnw-community/shared';
 
 import type { BankSyncDuplicateCandidateRowInterface } from '../interface/bank-sync-duplicate-candidate-row.interface';
 import type { BankSyncDuplicateSoftDeleteResultInterface } from '../interface/bank-sync-duplicate-soft-delete-result.interface';
@@ -9,12 +9,12 @@ import type { DB } from '@budgie/contracts';
 class BankSyncDuplicateSoftDeleteService {
     private static readonly SQLITE_BATCH_SIZE = 500;
 
-    @Log(
-        (tx, duplicateTransactionIds) => `enter tx=${String(isDefined(tx))} duplicateTransactionIds=${duplicateTransactionIds.join(',')}`,
+    @Log.withoutErrorPayload(
+        (tx, duplicateTransactionIds) => `enter tx=${String(isDefined(tx))} requestedCount=${duplicateTransactionIds.length}`,
         (result, tx, duplicateTransactionIds) =>
-            `done tx=${String(isDefined(tx))} duplicateTransactionIds=${duplicateTransactionIds.join(',')} updatedTransactionIds=${result.updatedTransactionIds.join(',')}`,
+            `done tx=${String(isDefined(tx))} requestedCount=${duplicateTransactionIds.length} updatedCount=${result.updatedTransactionIds.length}`,
         (error, tx, duplicateTransactionIds) =>
-            `throw tx=${String(isDefined(tx))} duplicateTransactionIds=${duplicateTransactionIds.join(',')} error=${getErrorMessage(error)}`
+            `throw tx=${String(isDefined(tx))} requestedCount=${duplicateTransactionIds.length} errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async remove(tx: DB, duplicateTransactionIds: readonly number[]): Promise<BankSyncDuplicateSoftDeleteResultInterface> {
         if (isEmptyArray(duplicateTransactionIds)) {
@@ -32,12 +32,12 @@ class BankSyncDuplicateSoftDeleteService {
         return { updatedTransactionIds };
     }
 
-    @Log(
-        (tx, duplicateTransactionIds) => `enter tx=${String(isDefined(tx))} duplicateTransactionIds=${duplicateTransactionIds.join(',')}`,
+    @Log.withoutErrorPayload(
+        (tx, duplicateTransactionIds) => `enter tx=${String(isDefined(tx))} requestedCount=${duplicateTransactionIds.length}`,
         (result, tx, duplicateTransactionIds) =>
-            `done tx=${String(isDefined(tx))} duplicateTransactionIds=${duplicateTransactionIds.join(',')} updatedTransactionIds=${result.map(row => row.duplicateTransactionId).join(',')}`,
+            `done tx=${String(isDefined(tx))} requestedCount=${duplicateTransactionIds.length} updatedCount=${result.length}`,
         (error, tx, duplicateTransactionIds) =>
-            `throw tx=${String(isDefined(tx))} duplicateTransactionIds=${duplicateTransactionIds.join(',')} error=${getErrorMessage(error)}`
+            `throw tx=${String(isDefined(tx))} requestedCount=${duplicateTransactionIds.length} errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     private async softDeleteTransactionChunk(
         tx: DB,
@@ -51,12 +51,11 @@ class BankSyncDuplicateSoftDeleteService {
         );
     }
 
-    @Log(
-        (tx, updatedTransactionIds) => `enter tx=${String(isDefined(tx))} updatedTransactionIds=${updatedTransactionIds.join(',')}`,
-        (result, tx, updatedTransactionIds) =>
-            `done tx=${String(isDefined(tx))} updatedTransactionIds=${updatedTransactionIds.join(',')} result=${String(result)}`,
+    @Log.withoutErrorPayload(
+        (tx, updatedTransactionIds) => `enter tx=${String(isDefined(tx))} updatedCount=${updatedTransactionIds.length}`,
+        (_result, tx, updatedTransactionIds) => `done tx=${String(isDefined(tx))} updatedCount=${updatedTransactionIds.length}`,
         (error, tx, updatedTransactionIds) =>
-            `throw tx=${String(isDefined(tx))} updatedTransactionIds=${updatedTransactionIds.join(',')} error=${getErrorMessage(error)}`
+            `throw tx=${String(isDefined(tx))} updatedCount=${updatedTransactionIds.length} errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     private async softDeleteEntryChunk(tx: DB, updatedTransactionIds: readonly number[]): Promise<void> {
         const bindTransactionIds = [...updatedTransactionIds];

--- a/packages/app/src/sync/service/bank-sync-duplicate-soft-delete.service.ts
+++ b/packages/app/src/sync/service/bank-sync-duplicate-soft-delete.service.ts
@@ -1,6 +1,6 @@
 import { Log } from '@budgie/logger';
 
-import { isDefined, isEmptyArray, isError } from '@rnw-community/shared';
+import { isEmptyArray } from '@rnw-community/shared';
 
 import type { BankSyncDuplicateCandidateRowInterface } from '../interface/bank-sync-duplicate-candidate-row.interface';
 import type { BankSyncDuplicateSoftDeleteResultInterface } from '../interface/bank-sync-duplicate-soft-delete-result.interface';
@@ -9,13 +9,7 @@ import type { DB } from '@budgie/contracts';
 class BankSyncDuplicateSoftDeleteService {
     private static readonly SQLITE_BATCH_SIZE = 500;
 
-    @Log.withoutErrorPayload(
-        (tx, duplicateTransactionIds) => `enter tx=${String(isDefined(tx))} requestedCount=${duplicateTransactionIds.length}`,
-        (result, tx, duplicateTransactionIds) =>
-            `done tx=${String(isDefined(tx))} requestedCount=${duplicateTransactionIds.length} updatedCount=${result.updatedTransactionIds.length}`,
-        (error, tx, duplicateTransactionIds) =>
-            `throw tx=${String(isDefined(tx))} requestedCount=${duplicateTransactionIds.length} errorClass=${isError(error) ? error.name : 'UnknownError'}`
-    )
+    @Log.withoutErrorPayload()
     async remove(tx: DB, duplicateTransactionIds: readonly number[]): Promise<BankSyncDuplicateSoftDeleteResultInterface> {
         if (isEmptyArray(duplicateTransactionIds)) {
             return this.buildEmptyResult();
@@ -32,13 +26,7 @@ class BankSyncDuplicateSoftDeleteService {
         return { updatedTransactionIds };
     }
 
-    @Log.withoutErrorPayload(
-        (tx, duplicateTransactionIds) => `enter tx=${String(isDefined(tx))} requestedCount=${duplicateTransactionIds.length}`,
-        (result, tx, duplicateTransactionIds) =>
-            `done tx=${String(isDefined(tx))} requestedCount=${duplicateTransactionIds.length} updatedCount=${result.length}`,
-        (error, tx, duplicateTransactionIds) =>
-            `throw tx=${String(isDefined(tx))} requestedCount=${duplicateTransactionIds.length} errorClass=${isError(error) ? error.name : 'UnknownError'}`
-    )
+    @Log.withoutErrorPayload()
     private async softDeleteTransactionChunk(
         tx: DB,
         duplicateTransactionIds: readonly number[]
@@ -51,12 +39,7 @@ class BankSyncDuplicateSoftDeleteService {
         );
     }
 
-    @Log.withoutErrorPayload(
-        (tx, updatedTransactionIds) => `enter tx=${String(isDefined(tx))} updatedCount=${updatedTransactionIds.length}`,
-        (_result, tx, updatedTransactionIds) => `done tx=${String(isDefined(tx))} updatedCount=${updatedTransactionIds.length}`,
-        (error, tx, updatedTransactionIds) =>
-            `throw tx=${String(isDefined(tx))} updatedCount=${updatedTransactionIds.length} errorClass=${isError(error) ? error.name : 'UnknownError'}`
-    )
+    @Log.withoutErrorPayload()
     private async softDeleteEntryChunk(tx: DB, updatedTransactionIds: readonly number[]): Promise<void> {
         const bindTransactionIds = [...updatedTransactionIds];
 

--- a/packages/app/src/sync/service/bank-sync-repair.service.ts
+++ b/packages/app/src/sync/service/bank-sync-repair.service.ts
@@ -1,7 +1,7 @@
 import { ExternalSourceEnum, transactionAsync } from '@budgie/contracts';
 import { Log } from '@budgie/logger';
 
-import { emptyFn, getErrorMessage, isDefined, isPositiveNumber } from '@rnw-community/shared';
+import { emptyFn, isDefined, isError, isPositiveNumber } from '@rnw-community/shared';
 
 import { db } from '../../@generic/drizzle/db/db';
 import { foregroundWorkloadService } from '../../@generic/service/foreground-workload.service';
@@ -26,29 +26,28 @@ class BankSyncRepairService {
 
     private activeOperation: Promise<unknown> | null = null;
 
-    @Log(
+    @Log.withoutErrorPayload(
         'enter',
         result => `done duplicateTransactionCount=${result.duplicateTransactionCount}`,
-        error => `throw error=${getErrorMessage(error)}`
+        error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async previewDuplicates(): Promise<BankSyncDuplicateRepairPreviewInterface> {
         return this.runExclusive(() => this.buildPreview());
     }
 
-    @Log(
+    @Log.withoutErrorPayload(
         'enter',
         result => `done repairedTransactionCount=${result.repairedTransactionCount}`,
-        error => `throw error=${getErrorMessage(error)}`
+        error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async removeDuplicates(): Promise<BankSyncDuplicateRepairResultInterface> {
         return this.runExclusive(() => foregroundWorkloadService.run(() => this.removeDuplicatesInner()));
     }
 
-    @Log(
+    @Log.withoutErrorPayload(
         database => `enter sourceDatabase=${String(isDefined(database))}`,
-        (result, database) =>
-            `done sourceDatabase=${String(isDefined(database))} duplicateTransactionIds=${result.map(candidate => candidate.duplicateTransactionId).join(',')}`,
-        (error, database) => `throw sourceDatabase=${String(isDefined(database))} error=${getErrorMessage(error)}`
+        (result, database) => `done sourceDatabase=${String(isDefined(database))} candidateCount=${result.length}`,
+        (error, database) => `throw sourceDatabase=${String(isDefined(database))} errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     private async findDuplicateCandidates(database: DB): Promise<BankSyncDuplicateCandidateRowInterface[]> {
         const candidateGroups = await Promise.all(
@@ -58,15 +57,16 @@ class BankSyncRepairService {
         return candidateGroups.flat();
     }
 
-    @Log('enter', result => `done repairedCount=${result}`, error => `throw error=${getErrorMessage(error)}`)
+    @Log.withoutErrorPayload('enter', result => `done repairedCount=${result}`, error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`)
     private async repairConsolidationDuplicates(): Promise<number> {
         return consolidationCoordinatorService.repairExistingTransferIncomeDuplicates();
     }
 
-    @Log(
+    @Log.withoutErrorPayload(
         result => `enter repairedTransactionCount=${result.repairedTransactionCount}`,
         (done, result) => `done repairedTransactionCount=${result.repairedTransactionCount} result=${String(done)}`,
-        (error, result) => `throw repairedTransactionCount=${result.repairedTransactionCount} error=${getErrorMessage(error)}`
+        (error, result) =>
+            `throw repairedTransactionCount=${result.repairedTransactionCount} errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     private async rebuildBalancesWhenNeeded(result: BankSyncDuplicateRepairResultInterface): Promise<void> {
         if (isPositiveNumber(result.repairedTransactionCount)) {
@@ -74,10 +74,10 @@ class BankSyncRepairService {
         }
     }
 
-    @Log(
+    @Log.withoutErrorPayload(
         tx => `enter tx=${String(isDefined(tx))}`,
         (result, tx) => `done tx=${String(isDefined(tx))} repairedTransactionCount=${result.repairedTransactionCount}`,
-        (error, tx) => `throw tx=${String(isDefined(tx))} error=${getErrorMessage(error)}`
+        (error, tx) => `throw tx=${String(isDefined(tx))} errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     private async removeDuplicatesInTransaction(tx: DB): Promise<BankSyncDuplicateRepairResultInterface> {
         const candidates = await this.findDuplicateCandidates(tx);

--- a/packages/app/src/sync/service/bank-sync-repair.service.ts
+++ b/packages/app/src/sync/service/bank-sync-repair.service.ts
@@ -26,29 +26,17 @@ class BankSyncRepairService {
 
     private activeOperation: Promise<unknown> | null = null;
 
-    @Log.withoutErrorPayload(
-        'enter',
-        result => `done duplicateTransactionCount=${result.duplicateTransactionCount}`,
-        error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`
-    )
+    @Log.withoutErrorPayload(void 0, void 0, error => (isError(error) ? error.name : typeof error))
     async previewDuplicates(): Promise<BankSyncDuplicateRepairPreviewInterface> {
         return this.runExclusive(() => this.buildPreview());
     }
 
-    @Log.withoutErrorPayload(
-        'enter',
-        result => `done repairedTransactionCount=${result.repairedTransactionCount}`,
-        error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`
-    )
+    @Log.withoutErrorPayload(void 0, void 0, error => (isError(error) ? error.name : typeof error))
     async removeDuplicates(): Promise<BankSyncDuplicateRepairResultInterface> {
         return this.runExclusive(() => foregroundWorkloadService.run(() => this.removeDuplicatesInner()));
     }
 
-    @Log.withoutErrorPayload(
-        database => `enter sourceDatabase=${String(isDefined(database))}`,
-        (result, database) => `done sourceDatabase=${String(isDefined(database))} candidateCount=${result.length}`,
-        (error, database) => `throw sourceDatabase=${String(isDefined(database))} errorClass=${isError(error) ? error.name : 'UnknownError'}`
-    )
+    @Log.withoutErrorPayload()
     private async findDuplicateCandidates(database: DB): Promise<BankSyncDuplicateCandidateRowInterface[]> {
         const candidateGroups = await Promise.all(
             BankSyncRepairService.SOURCE_STRATEGIES.map(strategy => strategy.findDuplicateCandidates(database))
@@ -57,28 +45,19 @@ class BankSyncRepairService {
         return candidateGroups.flat();
     }
 
-    @Log.withoutErrorPayload('enter', result => `done repairedCount=${result}`, error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`)
+    @Log.withoutErrorPayload()
     private async repairConsolidationDuplicates(): Promise<number> {
         return consolidationCoordinatorService.repairExistingTransferIncomeDuplicates();
     }
 
-    @Log.withoutErrorPayload(
-        result => `enter repairedTransactionCount=${result.repairedTransactionCount}`,
-        (done, result) => `done repairedTransactionCount=${result.repairedTransactionCount} result=${String(done)}`,
-        (error, result) =>
-            `throw repairedTransactionCount=${result.repairedTransactionCount} errorClass=${isError(error) ? error.name : 'UnknownError'}`
-    )
+    @Log.withoutErrorPayload()
     private async rebuildBalancesWhenNeeded(result: BankSyncDuplicateRepairResultInterface): Promise<void> {
         if (isPositiveNumber(result.repairedTransactionCount)) {
             await accountBalanceIncrementalService.updateAllBalances(true);
         }
     }
 
-    @Log.withoutErrorPayload(
-        tx => `enter tx=${String(isDefined(tx))}`,
-        (result, tx) => `done tx=${String(isDefined(tx))} repairedTransactionCount=${result.repairedTransactionCount}`,
-        (error, tx) => `throw tx=${String(isDefined(tx))} errorClass=${isError(error) ? error.name : 'UnknownError'}`
-    )
+    @Log.withoutErrorPayload()
     private async removeDuplicatesInTransaction(tx: DB): Promise<BankSyncDuplicateRepairResultInterface> {
         const candidates = await this.findDuplicateCandidates(tx);
         const duplicateTransactionIds = candidates.map(candidate => candidate.duplicateTransactionId);

--- a/packages/app/src/sync/service/sync-workload.service.ts
+++ b/packages/app/src/sync/service/sync-workload.service.ts
@@ -20,10 +20,11 @@ class SyncWorkloadService {
         this.cancelQueuedWork();
     }
 
-    @Log(
+    @Log.withoutErrorPayload(
         (name, work) => `enter queue=background name="${name}" workName="${work.name}"`,
         (result, name, work) => `done queue=background name="${name}" workName="${work.name}" result=${String(result)}`,
-        (error, name, work) => `throw queue=background name="${name}" workName="${work.name}" error=${getErrorMessage(error)}`
+        (error, name, work) =>
+            `throw queue=background name="${name}" workName="${work.name}" errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async run<T>(name: string, work: () => Promise<T>): Promise<T> {
         this.throwIfBlocked();

--- a/packages/app/src/sync/service/sync-workload.service.ts
+++ b/packages/app/src/sync/service/sync-workload.service.ts
@@ -20,12 +20,7 @@ class SyncWorkloadService {
         this.cancelQueuedWork();
     }
 
-    @Log.withoutErrorPayload(
-        (name, work) => `enter queue=background name="${name}" workName="${work.name}"`,
-        (result, name, work) => `done queue=background name="${name}" workName="${work.name}" result=${String(result)}`,
-        (error, name, work) =>
-            `throw queue=background name="${name}" workName="${work.name}" errorClass=${isError(error) ? error.name : 'UnknownError'}`
-    )
+    @Log.withoutErrorPayload()
     async run<T>(name: string, work: () => Promise<T>): Promise<T> {
         this.throwIfBlocked();
 

--- a/packages/app/src/sync/service/transfer-consolidation-drainer.service.ts
+++ b/packages/app/src/sync/service/transfer-consolidation-drainer.service.ts
@@ -1,7 +1,7 @@
 import { consolidationScopeService } from '@budgie/consolidation';
 import { Log } from '@budgie/logger';
 
-import { emptyFn, getErrorMessage, isDefined } from '@rnw-community/shared';
+import { emptyFn, getErrorMessage, isDefined, isError } from '@rnw-community/shared';
 
 import { scheduleIdleCallback } from '../../@generic/utils/schedule-idle-callback.util';
 import { TransferConsolidationDrainReasonEnum } from '../enum/transfer-consolidation-drain-reason.enum';
@@ -26,13 +26,11 @@ class TransferConsolidationDrainerService {
     private timer: ReturnType<typeof setTimeout> | null = null;
     private cancelIdleCallback: (() => void) | null = null;
 
-    @Log(
-        (reason, scope) =>
-            `enter reason=${reason} scopeTransactionIds=${scope?.transactionIds.join(',') ?? ''} scopeFrom=${scope?.operatedAtFrom.toISOString() ?? ''} scopeTo=${scope?.operatedAtTo.toISOString() ?? ''}`,
-        (_result, reason, scope) =>
-            `done reason=${reason} scopeTransactionIds=${scope?.transactionIds.join(',') ?? ''} scopeFrom=${scope?.operatedAtFrom.toISOString() ?? ''} scopeTo=${scope?.operatedAtTo.toISOString() ?? ''}`,
+    @Log.withoutErrorPayload(
+        (reason, scope) => `enter reason=${reason} scopeIdCount=${scope?.transactionIds.length ?? 0}`,
+        (_result, reason, scope) => `done reason=${reason} scopeIdCount=${scope?.transactionIds.length ?? 0}`,
         (error, reason, scope) =>
-            `throw reason=${reason} scopeTransactionIds=${scope?.transactionIds.join(',') ?? ''} scopeFrom=${scope?.operatedAtFrom.toISOString() ?? ''} scopeTo=${scope?.operatedAtTo.toISOString() ?? ''} error=${getErrorMessage(error)}`
+            `throw reason=${reason} scopeIdCount=${scope?.transactionIds.length ?? 0} errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     enqueue(reason: TransferConsolidationDrainReasonEnum, scope: ConsolidationScanScopeInterface | null = null): void {
         this.addPendingScope(scope);
@@ -56,7 +54,7 @@ class TransferConsolidationDrainerService {
         this.cancelScheduledRun();
     }
 
-    @Log('enter', 'done', error => `throw error=${getErrorMessage(error)}`)
+    @Log.withoutErrorPayload('enter', 'done', error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`)
     private async run(): Promise<void> {
         if (this.isRunning) {
             return;

--- a/packages/app/src/sync/service/transfer-consolidation-drainer.service.ts
+++ b/packages/app/src/sync/service/transfer-consolidation-drainer.service.ts
@@ -26,12 +26,7 @@ class TransferConsolidationDrainerService {
     private timer: ReturnType<typeof setTimeout> | null = null;
     private cancelIdleCallback: (() => void) | null = null;
 
-    @Log.withoutErrorPayload(
-        (reason, scope) => `enter reason=${reason} scopeIdCount=${scope?.transactionIds.length ?? 0}`,
-        (_result, reason, scope) => `done reason=${reason} scopeIdCount=${scope?.transactionIds.length ?? 0}`,
-        (error, reason, scope) =>
-            `throw reason=${reason} scopeIdCount=${scope?.transactionIds.length ?? 0} errorClass=${isError(error) ? error.name : 'UnknownError'}`
-    )
+    @Log.withoutErrorPayload()
     enqueue(reason: TransferConsolidationDrainReasonEnum, scope: ConsolidationScanScopeInterface | null = null): void {
         this.addPendingScope(scope);
         this.hasPendingRun = true;
@@ -54,7 +49,7 @@ class TransferConsolidationDrainerService {
         this.cancelScheduledRun();
     }
 
-    @Log.withoutErrorPayload('enter', 'done', error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`)
+    @Log.withoutErrorPayload(void 0, void 0, error => (isError(error) ? error.name : typeof error))
     private async run(): Promise<void> {
         if (this.isRunning) {
             return;

--- a/packages/app/src/sync/service/transfer-consolidation.service.ts
+++ b/packages/app/src/sync/service/transfer-consolidation.service.ts
@@ -2,7 +2,7 @@ import { Log } from '@budgie/logger';
 import * as BackgroundTask from 'expo-background-task';
 import * as TaskManager from 'expo-task-manager';
 
-import { emptyFn, getErrorMessage, isDefined, isPositiveNumber } from '@rnw-community/shared';
+import { emptyFn, getErrorMessage, isDefined, isError, isPositiveNumber } from '@rnw-community/shared';
 
 import { foregroundWorkloadService } from '../../@generic/service/foreground-workload.service';
 import { accountBalanceIncrementalService } from '../../account/service/account-balance-incremental.service';
@@ -43,13 +43,10 @@ class TransferConsolidationService {
         return this.runExclusive(() => this.buildPreview());
     }
 
-    @Log(
-        scope =>
-            `enter appScopeFrom=${scope?.operatedAtFrom.toISOString() ?? ''} appScopeTo=${scope?.operatedAtTo.toISOString() ?? ''} appScopeIdCount=${scope?.transactionIds.length ?? 0}`,
-        (result, scope) =>
-            `done appScopeFrom=${scope?.operatedAtFrom.toISOString() ?? ''} appScopeTo=${scope?.operatedAtTo.toISOString() ?? ''} appScopeIdCount=${scope?.transactionIds.length ?? 0} found=${result.found} consolidated=${result.consolidated}`,
-        (error, scope) =>
-            `throw appScopeFrom=${scope?.operatedAtFrom.toISOString() ?? ''} appScopeTo=${scope?.operatedAtTo.toISOString() ?? ''} appScopeIdCount=${scope?.transactionIds.length ?? 0} error=${getErrorMessage(error)}`
+    @Log.withoutErrorPayload(
+        scope => `enter scopeIdCount=${scope?.transactionIds.length ?? 0}`,
+        (result, scope) => `done scopeIdCount=${scope?.transactionIds.length ?? 0} found=${result.found} consolidated=${result.consolidated}`,
+        (error, scope) => `throw scopeIdCount=${scope?.transactionIds.length ?? 0} errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async consolidate(scope: ConsolidationScanScopeInterface | null = null): Promise<ConsolidationResultInterface> {
         return this.runExclusive(() => this.runConsolidationIfIdle(scope));

--- a/packages/app/src/sync/service/transfer-consolidation.service.ts
+++ b/packages/app/src/sync/service/transfer-consolidation.service.ts
@@ -34,10 +34,10 @@ class TransferConsolidationService {
         });
     }
 
-    @Log(
+    @Log.withoutErrorPayload(
         'enter',
         result => `done autoCandidateCount=${result.autoCandidateCount} manualReviewCandidateCount=${result.manualReviewCandidateCount}`,
-        error => `throw error=${getErrorMessage(error)}`
+        error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async preview(): Promise<ConsolidationPreviewInterface> {
         return this.runExclusive(() => this.buildPreview());
@@ -52,11 +52,11 @@ class TransferConsolidationService {
         return this.runExclusive(() => this.runConsolidationIfIdle(scope));
     }
 
-    @Log(
+    @Log.withoutErrorPayload(
         'enter',
         result =>
             `done autoCandidateCount=${result.autoCandidateCount} manualReviewCandidateCount=${result.manualReviewCandidateCount} remainingCandidateGroupCount=${result.remainingCandidateGroupCount} isRunning=${String(result.isRunning)}`,
-        error => `throw error=${getErrorMessage(error)}`
+        error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async getProgressSnapshot(): Promise<ConsolidationProgressSnapshotInterface> {
         return this.runExclusive(() => this.buildProgressSnapshot());

--- a/packages/app/src/sync/service/transfer-consolidation.service.ts
+++ b/packages/app/src/sync/service/transfer-consolidation.service.ts
@@ -34,30 +34,17 @@ class TransferConsolidationService {
         });
     }
 
-    @Log.withoutErrorPayload(
-        'enter',
-        result => `done autoCandidateCount=${result.autoCandidateCount} manualReviewCandidateCount=${result.manualReviewCandidateCount}`,
-        error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`
-    )
+    @Log.withoutErrorPayload(void 0, void 0, error => (isError(error) ? error.name : typeof error))
     async preview(): Promise<ConsolidationPreviewInterface> {
         return this.runExclusive(() => this.buildPreview());
     }
 
-    @Log.withoutErrorPayload(
-        scope => `enter scopeIdCount=${scope?.transactionIds.length ?? 0}`,
-        (result, scope) => `done scopeIdCount=${scope?.transactionIds.length ?? 0} found=${result.found} consolidated=${result.consolidated}`,
-        (error, scope) => `throw scopeIdCount=${scope?.transactionIds.length ?? 0} errorClass=${isError(error) ? error.name : 'UnknownError'}`
-    )
+    @Log.withoutErrorPayload()
     async consolidate(scope: ConsolidationScanScopeInterface | null = null): Promise<ConsolidationResultInterface> {
         return this.runExclusive(() => this.runConsolidationIfIdle(scope));
     }
 
-    @Log.withoutErrorPayload(
-        'enter',
-        result =>
-            `done autoCandidateCount=${result.autoCandidateCount} manualReviewCandidateCount=${result.manualReviewCandidateCount} remainingCandidateGroupCount=${result.remainingCandidateGroupCount} isRunning=${String(result.isRunning)}`,
-        error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`
-    )
+    @Log.withoutErrorPayload(void 0, void 0, error => (isError(error) ? error.name : typeof error))
     async getProgressSnapshot(): Promise<ConsolidationProgressSnapshotInterface> {
         return this.runExclusive(() => this.buildProgressSnapshot());
     }

--- a/packages/consolidation/src/auto/service/consolidation-auto-candidate.service.ts
+++ b/packages/consolidation/src/auto/service/consolidation-auto-candidate.service.ts
@@ -1,6 +1,6 @@
 import { Log } from '@budgie/logger';
 
-import { getErrorMessage, isDefined } from '@rnw-community/shared';
+import { isError } from '@rnw-community/shared';
 
 import type { ConsolidationResultInterface } from '../interface/consolidation-result.interface';
 import type { ConsolidationFamilyRegistryService } from './consolidation-family-registry.service';
@@ -9,12 +9,10 @@ import type { ConsolidationScanScopeInterface, ExistingTransferIncomeDuplicateCa
 export class ConsolidationAutoCandidateService {
     constructor(private readonly consolidationFamilyRegistryService: ConsolidationFamilyRegistryService) {}
 
-    @Log(
-        (scope, onProgress) => `enter scopeIdCount=${scope?.transactionIds.length ?? 0} hasOnProgress=${String(isDefined(onProgress))}`,
-        (result, scope, onProgress) =>
-            `done scopeIdCount=${scope?.transactionIds.length ?? 0} hasOnProgress=${String(isDefined(onProgress))} found=${result.found} consolidated=${result.consolidated}`,
-        (error, scope, onProgress) =>
-            `throw scopeIdCount=${scope?.transactionIds.length ?? 0} hasOnProgress=${String(isDefined(onProgress))} error=${getErrorMessage(error)}`
+    @Log.withoutErrorPayload(
+        () => 'enter process',
+        result => `done foundCount=${result.found} consolidatedCount=${result.consolidated}`,
+        error => `throw processErrorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async process(
         scope: ConsolidationScanScopeInterface | null = null,
@@ -54,10 +52,10 @@ export class ConsolidationAutoCandidateService {
         return { found: result.found, consolidated: result.consolidated };
     }
 
-    @Log(
-        scope => `enter scopeIdCount=${scope?.transactionIds.length ?? 0}`,
-        (result, scope) => `done scopeIdCount=${scope?.transactionIds.length ?? 0} count=${result}`,
-        (error, scope) => `throw scopeIdCount=${scope?.transactionIds.length ?? 0} error=${getErrorMessage(error)}`
+    @Log.withoutErrorPayload(
+        () => 'enter count',
+        result => `done candidateCount=${result}`,
+        error => `throw countErrorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async count(scope: ConsolidationScanScopeInterface | null = null): Promise<number> {
         const families = this.consolidationFamilyRegistryService.buildFamilies();
@@ -83,10 +81,11 @@ export class ConsolidationAutoCandidateService {
         return result.found;
     }
 
-    @Log(
+    @Log.withoutErrorPayload(
         candidates => `enter existingTransferIncomeDuplicateCount=${candidates.length}`,
         (result, candidates) => `done existingTransferIncomeDuplicateCount=${candidates.length} consolidated=${result}`,
-        (error, candidates) => `throw existingTransferIncomeDuplicateCount=${candidates.length} error=${getErrorMessage(error)}`
+        (error, candidates) =>
+            `throw existingTransferIncomeDuplicateCount=${candidates.length} errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async processExistingTransferIncomeDuplicateCandidates(
         candidates: ExistingTransferIncomeDuplicateCandidateInterface[]

--- a/packages/consolidation/src/auto/service/consolidation-candidate.service.ts
+++ b/packages/consolidation/src/auto/service/consolidation-candidate.service.ts
@@ -1,6 +1,6 @@
 import { Log } from '@budgie/logger';
 
-import { getErrorMessage } from '@rnw-community/shared';
+import { isError } from '@rnw-community/shared';
 
 import type { ConsolidationRepositoriesInterface } from '../interface/consolidation-repositories.interface';
 import type {
@@ -18,7 +18,11 @@ export class ConsolidationCandidateService {
         private readonly yieldControl: () => Promise<void>
     ) {}
 
-    @Log('enter', result => `done existingTransferIncomeDuplicateCount=${result.length}`, error => `throw error=${getErrorMessage(error)}`)
+    @Log.withoutErrorPayload(
+        'enter',
+        result => `done existingTransferIncomeDuplicateCount=${result.length}`,
+        error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`
+    )
     async findExistingTransferIncomeDuplicateRepairCandidates(): Promise<ExistingTransferIncomeDuplicateCandidateInterface[]> {
         const existingTransferBridgeCandidates = await this.repositories.existingTransferRepository.findBridgeCandidates(null);
         await this.yieldControl();
@@ -42,7 +46,11 @@ export class ConsolidationCandidateService {
         return existingTransferIncomeDuplicateCandidates;
     }
 
-    @Log('enter', result => `done count=${result}`, error => `throw error=${getErrorMessage(error)}`)
+    @Log.withoutErrorPayload(
+        'enter',
+        result => `done count=${result}`,
+        error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`
+    )
     async countManualReviewCandidates(): Promise<number> {
         const [manualReviewCandidates, atmCashWithdrawalReviewCandidates, refundReviewCandidates] = await Promise.all([
             this.repositories.transferPairRepository.findManualReviewCandidates(),

--- a/packages/consolidation/src/auto/service/consolidation-coordinator.service.ts
+++ b/packages/consolidation/src/auto/service/consolidation-coordinator.service.ts
@@ -1,6 +1,6 @@
 import { Log } from '@budgie/logger';
 
-import { getErrorMessage, isDefined } from '@rnw-community/shared';
+import { isError } from '@rnw-community/shared';
 
 import type { ConsolidationResultInterface } from '../interface/consolidation-result.interface';
 import type { ConsolidationAutoCandidateService } from './consolidation-auto-candidate.service';
@@ -13,13 +13,10 @@ export class ConsolidationCoordinatorService {
         private readonly consolidationAutoCandidateService: ConsolidationAutoCandidateService
     ) {}
 
-    @Log(
-        (scope, onProgress) =>
-            `enter hasScope=${String(isDefined(scope))} scopeIdCount=${scope?.transactionIds.length ?? 0} hasOnProgress=${String(isDefined(onProgress))}`,
-        (result, scope, onProgress) =>
-            `done hasScope=${String(isDefined(scope))} scopeIdCount=${scope?.transactionIds.length ?? 0} hasOnProgress=${String(isDefined(onProgress))} found=${result.found} consolidated=${result.consolidated}`,
-        (error, scope, onProgress) =>
-            `throw hasScope=${String(isDefined(scope))} scopeIdCount=${scope?.transactionIds.length ?? 0} hasOnProgress=${String(isDefined(onProgress))} error=${getErrorMessage(error)}`
+    @Log.withoutErrorPayload(
+        () => 'enter consolidate',
+        result => `done foundCount=${result.found} consolidatedCount=${result.consolidated}`,
+        error => `throw consolidateErrorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async consolidate(
         scope: ConsolidationScanScopeInterface | null = null,
@@ -28,27 +25,38 @@ export class ConsolidationCoordinatorService {
         return this.consolidationAutoCandidateService.process(scope, onProgress);
     }
 
-    @Log(
-        scope => `enter hasScope=${String(isDefined(scope))} scopeIdCount=${scope?.transactionIds.length ?? 0}`,
-        (result, scope) => `done hasScope=${String(isDefined(scope))} scopeIdCount=${scope?.transactionIds.length ?? 0} count=${result}`,
-        (error, scope) =>
-            `throw hasScope=${String(isDefined(scope))} scopeIdCount=${scope?.transactionIds.length ?? 0} error=${getErrorMessage(error)}`
+    @Log.withoutErrorPayload(
+        () => 'enter countAutoCandidates',
+        result => `done candidateCount=${result}`,
+        error => `throw countAutoCandidatesErrorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async countAutoCandidates(scope: ConsolidationScanScopeInterface | null = null): Promise<number> {
         return this.consolidationAutoCandidateService.count(scope);
     }
 
-    @Log('enter', result => `done count=${result}`, error => `throw error=${getErrorMessage(error)}`)
+    @Log.withoutErrorPayload(
+        'enter',
+        result => `done count=${result}`,
+        error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`
+    )
     async countManualReviewCandidates(): Promise<number> {
         return this.consolidationCandidateService.countManualReviewCandidates();
     }
 
-    @Log('enter', result => `done count=${result}`, error => `throw error=${getErrorMessage(error)}`)
+    @Log.withoutErrorPayload(
+        'enter',
+        result => `done count=${result}`,
+        error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`
+    )
     async countExistingTransferIncomeDuplicateRepairCandidates(): Promise<number> {
         return (await this.consolidationCandidateService.findExistingTransferIncomeDuplicateRepairCandidates()).length;
     }
 
-    @Log('enter', result => `done repairedCount=${result}`, error => `throw error=${getErrorMessage(error)}`)
+    @Log.withoutErrorPayload(
+        'enter',
+        result => `done repairedCount=${result}`,
+        error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`
+    )
     async repairExistingTransferIncomeDuplicates(): Promise<number> {
         const candidates = await this.consolidationCandidateService.findExistingTransferIncomeDuplicateRepairCandidates();
 

--- a/packages/consolidation/src/auto/service/consolidation-scope.service.ts
+++ b/packages/consolidation/src/auto/service/consolidation-scope.service.ts
@@ -1,7 +1,7 @@
 import { REFUND_TIME_WINDOW_SECONDS } from '@budgie/contracts';
 import { Log } from '@budgie/logger';
 
-import { getErrorMessage, isNotEmptyArray } from '@rnw-community/shared';
+import { isError, isNotEmptyArray } from '@rnw-community/shared';
 
 import type { ConsolidationScanScopeInterface, TransactionEntityInterface } from '@budgie/contracts';
 
@@ -9,11 +9,11 @@ class ConsolidationScopeService {
     private static readonly SAFETY_MARGIN_RATIO = 0.2;
     private static readonly PADDING_MS = REFUND_TIME_WINDOW_SECONDS * (1 + ConsolidationScopeService.SAFETY_MARGIN_RATIO) * 1000;
 
-    @Log(
+    @Log.withoutErrorPayload(
         transactions => `enter transactionCount=${transactions.length}`,
         (result, transactions) =>
             `done transactionCount=${transactions.length} hasScope=${String(isNotEmptyArray(result?.transactionIds ?? []))} scopeIdCount=${result?.transactionIds.length ?? 0}`,
-        (error, transactions) => `throw transactionCount=${transactions.length} error=${getErrorMessage(error)}`
+        (error, transactions) => `throw transactionCount=${transactions.length} errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     buildFromTransactions(transactions: Pick<TransactionEntityInterface, 'id' | 'operatedAt'>[]): ConsolidationScanScopeInterface | null {
         if (!isNotEmptyArray(transactions)) {
@@ -32,13 +32,13 @@ class ConsolidationScopeService {
         };
     }
 
-    @Log(
+    @Log.withoutErrorPayload(
         (currentScope, nextScope) =>
             `enter currentIdCount=${currentScope.transactionIds.length} nextIdCount=${nextScope.transactionIds.length}`,
         (result, currentScope, nextScope) =>
             `done currentIdCount=${currentScope.transactionIds.length} nextIdCount=${nextScope.transactionIds.length} resultIdCount=${result.transactionIds.length}`,
         (error, currentScope, nextScope) =>
-            `throw currentIdCount=${currentScope.transactionIds.length} nextIdCount=${nextScope.transactionIds.length} error=${getErrorMessage(error)}`
+            `throw currentIdCount=${currentScope.transactionIds.length} nextIdCount=${nextScope.transactionIds.length} errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     merge(currentScope: ConsolidationScanScopeInterface, nextScope: ConsolidationScanScopeInterface): ConsolidationScanScopeInterface {
         return {

--- a/packages/consolidation/src/executor/service/consolidation-eligibility.service.ts
+++ b/packages/consolidation/src/executor/service/consolidation-eligibility.service.ts
@@ -1,6 +1,6 @@
 import { Log } from '@budgie/logger';
 
-import { getErrorMessage, isDefined } from '@rnw-community/shared';
+import { isDefined, isError } from '@rnw-community/shared';
 
 import type { ConsolidationExecutorDependenciesInterface } from '../interface/consolidation-executor-dependencies.interface';
 import type { DB, TransactionWithEntriesEntityInterface } from '@budgie/contracts';
@@ -8,13 +8,13 @@ import type { DB, TransactionWithEntriesEntityInterface } from '@budgie/contract
 export class ConsolidationEligibilityService {
     constructor(private readonly dependencies: ConsolidationExecutorDependenciesInterface) {}
 
-    @Log(
-        (sourceTransactionIds, tx, allowedMovedSourceTransactionIds = []) =>
-            `enter check sourceIds=${sourceTransactionIds.join(',')} allowed=${allowedMovedSourceTransactionIds.join(',')} tx=${String(isDefined(tx))}`,
-        (result, sourceTransactionIds, tx, allowedMovedSourceTransactionIds = []) =>
-            `done eligible=${String(result)} sourceIds=${sourceTransactionIds.join(',')} allowed=${allowedMovedSourceTransactionIds.join(',')} tx=${String(isDefined(tx))}`,
-        (error, sourceTransactionIds, tx, allowedMovedSourceTransactionIds = []) =>
-            `throw check sourceIds=${sourceTransactionIds.join(',')} allowed=${allowedMovedSourceTransactionIds.join(',')} tx=${String(isDefined(tx))} error=${getErrorMessage(error)}`
+    @Log.withoutErrorPayload(
+        (sourceTransactionIds, _tx, allowedMovedSourceTransactionIds = []) =>
+            `enter sourceCount=${sourceTransactionIds.length} allowedMovedCount=${allowedMovedSourceTransactionIds.length}`,
+        (result, sourceTransactionIds, _tx, allowedMovedSourceTransactionIds = []) =>
+            `done eligible=${String(result)} sourceCount=${sourceTransactionIds.length} allowedMovedCount=${allowedMovedSourceTransactionIds.length}`,
+        (error, sourceTransactionIds, _tx, allowedMovedSourceTransactionIds = []) =>
+            `throw sourceCount=${sourceTransactionIds.length} allowedMovedCount=${allowedMovedSourceTransactionIds.length} errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async areCandidatesStillEligible(
         sourceTransactionIds: number[],
@@ -24,13 +24,13 @@ export class ConsolidationEligibilityService {
         return isDefined(await this.findEligibleSourceTransactions(sourceTransactionIds, tx, allowedMovedSourceTransactionIds));
     }
 
-    @Log(
-        (sourceTransactionIds, tx, allowedMovedSourceTransactionIds = []) =>
-            `enter load ids=${sourceTransactionIds.join(',')} movedAllowed=${allowedMovedSourceTransactionIds.join(',')} tx=${String(isDefined(tx))}`,
-        (result, sourceTransactionIds, tx, allowedMovedSourceTransactionIds = []) =>
-            `done loaded=${result?.map(transaction => transaction.id).join(',') ?? ''} ids=${sourceTransactionIds.join(',')} movedAllowed=${allowedMovedSourceTransactionIds.join(',')} tx=${String(isDefined(tx))}`,
-        (error, sourceTransactionIds, tx, allowedMovedSourceTransactionIds = []) =>
-            `throw load ids=${sourceTransactionIds.join(',')} movedAllowed=${allowedMovedSourceTransactionIds.join(',')} tx=${String(isDefined(tx))} error=${getErrorMessage(error)}`
+    @Log.withoutErrorPayload(
+        (sourceTransactionIds, _tx, allowedMovedSourceTransactionIds = []) =>
+            `enter requestedCount=${sourceTransactionIds.length} allowedMovedCount=${allowedMovedSourceTransactionIds.length}`,
+        (result, sourceTransactionIds, _tx, allowedMovedSourceTransactionIds = []) =>
+            `done loadedCount=${result?.length ?? 0} requestedCount=${sourceTransactionIds.length} allowedMovedCount=${allowedMovedSourceTransactionIds.length}`,
+        (error, sourceTransactionIds, _tx, allowedMovedSourceTransactionIds = []) =>
+            `throw requestedCount=${sourceTransactionIds.length} allowedMovedCount=${allowedMovedSourceTransactionIds.length} errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async findEligibleSourceTransactions(
         sourceTransactionIds: number[],
@@ -58,13 +58,11 @@ export class ConsolidationEligibilityService {
         return null;
     }
 
-    @Log(
-        (sourceTransactionIds, existingTransferId, tx) =>
-            `enter sourceTransactionIds=${sourceTransactionIds.join(',')} existingTransferId=${existingTransferId} hasTx=${String(isDefined(tx))}`,
-        (result, sourceTransactionIds, existingTransferId, tx) =>
-            `done sourceTransactionIds=${sourceTransactionIds.join(',')} existingTransferId=${existingTransferId} hasTx=${String(isDefined(tx))} result=${String(result)}`,
-        (error, sourceTransactionIds, existingTransferId, tx) =>
-            `throw sourceTransactionIds=${sourceTransactionIds.join(',')} existingTransferId=${existingTransferId} hasTx=${String(isDefined(tx))} error=${getErrorMessage(error)}`
+    @Log.withoutErrorPayload(
+        sourceTransactionIds => `enter sourceCount=${sourceTransactionIds.length}`,
+        (result, sourceTransactionIds) => `done sourceCount=${sourceTransactionIds.length} eligible=${String(result)}`,
+        (error, sourceTransactionIds) =>
+            `throw sourceCount=${sourceTransactionIds.length} errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async isExistingTransferConsolidationStillEligible(
         sourceTransactionIds: number[],

--- a/packages/consolidation/src/executor/service/consolidation-executor.service.ts
+++ b/packages/consolidation/src/executor/service/consolidation-executor.service.ts
@@ -1,6 +1,6 @@
 import { Log } from '@budgie/logger';
 
-import { getErrorMessage, isDefined } from '@rnw-community/shared';
+import { isDefined, isError } from '@rnw-community/shared';
 
 import { ConsolidationEligibilityService } from './consolidation-eligibility.service';
 import { ConsolidationMutationService } from './consolidation-mutation.service';
@@ -28,24 +28,18 @@ export class ConsolidationExecutorService {
     }
 
     @Log(
-        (candidate, consolidationPlan) =>
-            `enter pair=${candidate.expenseTransactionId}/${candidate.incomeTransactionId} bucket=${candidate.confidenceBucket} plan=${consolidationPlan.sourceTransactionIds.join(',')}/${consolidationPlan.canonicalInput.consolidationType}`,
-        (result, candidate, consolidationPlan) =>
-            `done pairResult=${String(result)} pair=${candidate.expenseTransactionId}/${candidate.incomeTransactionId} plan=${consolidationPlan.sourceTransactionIds.join(',')}/${consolidationPlan.canonicalInput.consolidationType}`,
-        (error, candidate, consolidationPlan) =>
-            `throw pair=${candidate.expenseTransactionId}/${candidate.incomeTransactionId} plan=${consolidationPlan.sourceTransactionIds.join(',')}/${consolidationPlan.canonicalInput.consolidationType} error=${getErrorMessage(error)}`
+        () => 'enter pair',
+        result => `done pairOutcome=${String(result)}`,
+        error => `throw pairErrorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async consolidatePair(candidate: TransferPairCandidateInterface, consolidationPlan: ConsolidationPlanInterface): Promise<boolean> {
         return await this.consolidateTwoRequiredSources(candidate.expenseTransactionId, candidate.incomeTransactionId, consolidationPlan);
     }
 
     @Log(
-        (candidate, consolidationPlan) =>
-            `enter atm=${candidate.transactionId} cash=${candidate.sourceAccountId}->${candidate.targetCashAccountId} amount=${candidate.amount} plan=${consolidationPlan.sourceTransactionIds.join(',')}/${consolidationPlan.canonicalInput.consolidationType}`,
-        (result, candidate, consolidationPlan) =>
-            `done atmResult=${String(result)} transaction=${candidate.transactionId} plan=${consolidationPlan.sourceTransactionIds.join(',')}/${consolidationPlan.canonicalInput.consolidationType}`,
-        (error, candidate, consolidationPlan) =>
-            `throw atm=${candidate.transactionId} plan=${consolidationPlan.sourceTransactionIds.join(',')}/${consolidationPlan.canonicalInput.consolidationType} error=${getErrorMessage(error)}`
+        () => 'enter atmWithdrawal',
+        result => `done atmWithdrawalOutcome=${String(result)}`,
+        error => `throw atmWithdrawalErrorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async consolidateAtmCashWithdrawal(
         candidate: AtmCashWithdrawalCandidateInterface,
@@ -57,12 +51,9 @@ export class ConsolidationExecutorService {
     }
 
     @Log(
-        (candidate, consolidationPlan) =>
-            `enter ibanBridge=${candidate.expenseTransactionId}/${candidate.incomeTransactionId} route=${candidate.sourceAccountId}->${candidate.bridgeAccountId}->${candidate.targetAccountId} rate=${candidate.exchangeRate} plan=${consolidationPlan.sourceTransactionIds.join(',')}/${consolidationPlan.canonicalInput.consolidationType}`,
-        (result, candidate, consolidationPlan) =>
-            `done ibanBridgeResult=${String(result)} direct=${candidate.existingDirectTransferId ?? ''} plan=${consolidationPlan.sourceTransactionIds.join(',')}/${consolidationPlan.canonicalInput.consolidationType}`,
-        (error, candidate, consolidationPlan) =>
-            `throw ibanBridge=${candidate.expenseTransactionId}/${candidate.incomeTransactionId} amount=${candidate.bridgeAmount} plan=${consolidationPlan.sourceTransactionIds.join(',')}/${consolidationPlan.canonicalInput.consolidationType} error=${getErrorMessage(error)}`
+        () => 'enter ibanBridge',
+        result => `done ibanBridgeOutcome=${String(result)}`,
+        error => `throw ibanBridgeErrorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async consolidateIbanBridgeTransfer(
         candidate: IbanBridgeTransferCandidateInterface,
@@ -72,12 +63,9 @@ export class ConsolidationExecutorService {
     }
 
     @Log(
-        (candidate, consolidationPlan) =>
-            `enter existingBridge=${candidate.sourceExpenseTransactionId}/${candidate.bridgeIncomeTransactionId}/${candidate.existingTransferId} route=${candidate.sourceAccountId}->${candidate.bridgeAccountId}->${candidate.targetAccountId} plan=${consolidationPlan.sourceTransactionIds.join(',')}/${consolidationPlan.canonicalInput.consolidationType}`,
-        (result, candidate, consolidationPlan) =>
-            `done existingBridgeResult=${String(result)} amounts=${candidate.sourceAmount}/${candidate.targetAmount} plan=${consolidationPlan.sourceTransactionIds.join(',')}/${consolidationPlan.canonicalInput.consolidationType}`,
-        (error, candidate, consolidationPlan) =>
-            `throw existingBridge=${candidate.sourceExpenseTransactionId}/${candidate.bridgeIncomeTransactionId}/${candidate.existingTransferId} rate=${candidate.exchangeRate} plan=${consolidationPlan.sourceTransactionIds.join(',')}/${consolidationPlan.canonicalInput.consolidationType} error=${getErrorMessage(error)}`
+        () => 'enter existingTransferBridge',
+        result => `done existingTransferBridgeOutcome=${String(result)}`,
+        error => `throw existingTransferBridgeErrorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async consolidateExistingTransferBridge(
         candidate: ExistingTransferBridgeCandidateInterface,
@@ -95,12 +83,9 @@ export class ConsolidationExecutorService {
     }
 
     @Log(
-        (candidate, consolidationPlan) =>
-            `enter bridgeChain=${candidate.sourceExpenseTransactionId}/${candidate.bridgeIncomeTransactionId}/${candidate.bridgeExpenseTransactionId}/${candidate.targetIncomeTransactionId} route=${candidate.sourceAccountId}->${candidate.bridgeAccountId}->${candidate.targetAccountId} plan=${consolidationPlan.sourceTransactionIds.join(',')}/${consolidationPlan.canonicalInput.consolidationType}`,
-        (result, candidate, consolidationPlan) =>
-            `done bridgeChainResult=${String(result)} amounts=${candidate.sourceAmount}/${candidate.targetAmount} plan=${consolidationPlan.sourceTransactionIds.join(',')}/${consolidationPlan.canonicalInput.consolidationType}`,
-        (error, candidate, consolidationPlan) =>
-            `throw bridgeChain=${candidate.sourceExpenseTransactionId}/${candidate.bridgeIncomeTransactionId}/${candidate.bridgeExpenseTransactionId}/${candidate.targetIncomeTransactionId} rate=${candidate.exchangeRate} plan=${consolidationPlan.sourceTransactionIds.join(',')}/${consolidationPlan.canonicalInput.consolidationType} error=${getErrorMessage(error)}`
+        () => 'enter ibanBridgeChain',
+        result => `done ibanBridgeChainOutcome=${String(result)}`,
+        error => `throw ibanBridgeChainErrorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async consolidateIbanBridgeChainTransfer(
         candidate: IbanBridgeChainTransferCandidateInterface,

--- a/packages/consolidation/src/executor/service/consolidation-executor.service.ts
+++ b/packages/consolidation/src/executor/service/consolidation-executor.service.ts
@@ -27,7 +27,7 @@ export class ConsolidationExecutorService {
         this.consolidationMutationService = new ConsolidationMutationService(dependencies);
     }
 
-    @Log(
+    @Log.withoutErrorPayload(
         () => 'enter pair',
         result => `done pairOutcome=${String(result)}`,
         error => `throw pairErrorClass=${isError(error) ? error.name : 'UnknownError'}`
@@ -36,7 +36,7 @@ export class ConsolidationExecutorService {
         return await this.consolidateTwoRequiredSources(candidate.expenseTransactionId, candidate.incomeTransactionId, consolidationPlan);
     }
 
-    @Log(
+    @Log.withoutErrorPayload(
         () => 'enter atmWithdrawal',
         result => `done atmWithdrawalOutcome=${String(result)}`,
         error => `throw atmWithdrawalErrorClass=${isError(error) ? error.name : 'UnknownError'}`
@@ -50,7 +50,7 @@ export class ConsolidationExecutorService {
         );
     }
 
-    @Log(
+    @Log.withoutErrorPayload(
         () => 'enter ibanBridge',
         result => `done ibanBridgeOutcome=${String(result)}`,
         error => `throw ibanBridgeErrorClass=${isError(error) ? error.name : 'UnknownError'}`
@@ -62,7 +62,7 @@ export class ConsolidationExecutorService {
         return await this.consolidateTwoRequiredSources(candidate.expenseTransactionId, candidate.incomeTransactionId, consolidationPlan);
     }
 
-    @Log(
+    @Log.withoutErrorPayload(
         () => 'enter existingTransferBridge',
         result => `done existingTransferBridgeOutcome=${String(result)}`,
         error => `throw existingTransferBridgeErrorClass=${isError(error) ? error.name : 'UnknownError'}`
@@ -82,7 +82,7 @@ export class ConsolidationExecutorService {
         );
     }
 
-    @Log(
+    @Log.withoutErrorPayload(
         () => 'enter ibanBridgeChain',
         result => `done ibanBridgeChainOutcome=${String(result)}`,
         error => `throw ibanBridgeChainErrorClass=${isError(error) ? error.name : 'UnknownError'}`

--- a/packages/consolidation/src/executor/service/consolidation-mutation.service.ts
+++ b/packages/consolidation/src/executor/service/consolidation-mutation.service.ts
@@ -18,7 +18,7 @@ import type {
 export class ConsolidationMutationService {
     constructor(private readonly dependencies: ConsolidationExecutorDependenciesInterface) {}
 
-    @Log(
+    @Log.withoutErrorPayload(
         () => 'enter canonicalTransfer',
         () => 'done canonicalTransfer',
         error => `throw canonicalTransferErrorClass=${isError(error) ? error.name : 'UnknownError'}`
@@ -76,7 +76,7 @@ export class ConsolidationMutationService {
         return canonicalTransaction;
     }
 
-    @Log(
+    @Log.withoutErrorPayload(
         () => 'enter atmWithdrawalFeeEntry',
         () => 'done atmWithdrawalFeeEntry',
         error => `throw atmWithdrawalFeeEntryErrorClass=${isError(error) ? error.name : 'UnknownError'}`
@@ -116,7 +116,7 @@ export class ConsolidationMutationService {
         );
     }
 
-    @Log(
+    @Log.withoutErrorPayload(
         () => 'enter moveSources',
         () => 'done moveSources',
         error => `throw moveSourcesErrorClass=${isError(error) ? error.name : 'UnknownError'}`
@@ -126,7 +126,7 @@ export class ConsolidationMutationService {
         await this.dependencies.transactionRepository.setConsolidationParent(sourceTransactionIds, canonicalTransactionId, tx);
     }
 
-    @Log(
+    @Log.withoutErrorPayload(
         () => 'enter copySourceTags',
         () => 'done copySourceTags',
         error => `throw copySourceTagsErrorClass=${isError(error) ? error.name : 'UnknownError'}`

--- a/packages/consolidation/src/executor/service/consolidation-mutation.service.ts
+++ b/packages/consolidation/src/executor/service/consolidation-mutation.service.ts
@@ -1,7 +1,7 @@
 import { CategorySourceEnum, TransactionEntryTypeEnum, TransactionTypeEnum } from '@budgie/contracts';
 import { Log } from '@budgie/logger';
 
-import { getErrorMessage, isDefined, isPositiveNumber } from '@rnw-community/shared';
+import { isDefined, isError, isPositiveNumber } from '@rnw-community/shared';
 
 import { consolidationCopySourceTransactionTags } from '../../shared/utils/consolidation-copy-source-transaction-tags.util';
 
@@ -19,12 +19,9 @@ export class ConsolidationMutationService {
     constructor(private readonly dependencies: ConsolidationExecutorDependenciesInterface) {}
 
     @Log(
-        (input, tx) =>
-            `enter title="${input.title}" fromAccountId=${input.fromAccountId} toAccountId=${input.toAccountId} fromAmount=${input.fromAmount} toAmount=${input.toAmount} type=${input.consolidationType} hasTx=${String(isDefined(tx))}`,
-        (result, input, tx) =>
-            `done title="${input.title}" fromAccountId=${input.fromAccountId} toAccountId=${input.toAccountId} fromAmount=${input.fromAmount} toAmount=${input.toAmount} type=${input.consolidationType} hasTx=${String(isDefined(tx))} canonicalTransactionId=${result.id}`,
-        (error, input, tx) =>
-            `throw title="${input.title}" fromAccountId=${input.fromAccountId} toAccountId=${input.toAccountId} fromAmount=${input.fromAmount} toAmount=${input.toAmount} type=${input.consolidationType} hasTx=${String(isDefined(tx))} error=${getErrorMessage(error)}`
+        () => 'enter canonicalTransfer',
+        () => 'done canonicalTransfer',
+        error => `throw canonicalTransferErrorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async createCanonicalTransfer(input: CanonicalTransferInputInterface, tx: DB): Promise<TransactionEntityInterface> {
         const canonicalTransaction = await this.dependencies.transactionRepository.create(
@@ -80,18 +77,9 @@ export class ConsolidationMutationService {
     }
 
     @Log(
-        (candidate, sourceTransactions, canonicalTransactionId, tx) =>
-            `enter transactionId=${candidate.transactionId} sourceAccountId=${candidate.sourceAccountId} sourceTransactionIds=${sourceTransactions.map(transaction => transaction.id).join(',')} canonicalTransactionId=${canonicalTransactionId} hasTx=${String(isDefined(tx))}`,
-        (result, ...inputs) => {
-            const [candidate, sourceTransactions, canonicalTransactionId, tx] = inputs;
-
-            return `done transactionId=${candidate.transactionId} sourceAccountId=${candidate.sourceAccountId} sourceTransactionIds=${sourceTransactions.map(transaction => transaction.id).join(',')} canonicalTransactionId=${canonicalTransactionId} hasTx=${String(isDefined(tx))} result=${String(result)}`;
-        },
-        (error, ...inputs) => {
-            const [candidate, sourceTransactions, canonicalTransactionId, tx] = inputs;
-
-            return `throw transactionId=${candidate.transactionId} sourceAccountId=${candidate.sourceAccountId} sourceTransactionIds=${sourceTransactions.map(transaction => transaction.id).join(',')} canonicalTransactionId=${canonicalTransactionId} hasTx=${String(isDefined(tx))} error=${getErrorMessage(error)}`;
-        }
+        () => 'enter atmWithdrawalFeeEntry',
+        () => 'done atmWithdrawalFeeEntry',
+        error => `throw atmWithdrawalFeeEntryErrorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async createAtmCashWithdrawalFeeEntry(
         candidate: AtmCashWithdrawalCandidateInterface,
@@ -129,12 +117,9 @@ export class ConsolidationMutationService {
     }
 
     @Log(
-        (sourceTransactionIds, canonicalTransactionId, tx) =>
-            `enter moveSources ids=${sourceTransactionIds.join(',')} parent=${canonicalTransactionId} tx=${String(isDefined(tx))}`,
-        (result, sourceTransactionIds, canonicalTransactionId, tx) =>
-            `done moved=${String(result)} ids=${sourceTransactionIds.join(',')} parent=${canonicalTransactionId} tx=${String(isDefined(tx))}`,
-        (error, sourceTransactionIds, canonicalTransactionId, tx) =>
-            `throw moveSources ids=${sourceTransactionIds.join(',')} parent=${canonicalTransactionId} tx=${String(isDefined(tx))} error=${getErrorMessage(error)}`
+        () => 'enter moveSources',
+        () => 'done moveSources',
+        error => `throw moveSourcesErrorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async moveSourcesToCanonical(sourceTransactionIds: number[], canonicalTransactionId: number, tx: DB): Promise<void> {
         await this.dependencies.transactionEntryRepository.moveToConsolidatedTransaction(sourceTransactionIds, canonicalTransactionId, tx);
@@ -142,12 +127,9 @@ export class ConsolidationMutationService {
     }
 
     @Log(
-        (sourceTransactionIds, canonicalTransactionId, tx) =>
-            `enter copyTags from=${sourceTransactionIds.join(',')} to=${canonicalTransactionId} tx=${String(isDefined(tx))}`,
-        (result, sourceTransactionIds, canonicalTransactionId, tx) =>
-            `done tagsCopied=${String(result)} from=${sourceTransactionIds.join(',')} to=${canonicalTransactionId} tx=${String(isDefined(tx))}`,
-        (error, sourceTransactionIds, canonicalTransactionId, tx) =>
-            `throw copyTags from=${sourceTransactionIds.join(',')} to=${canonicalTransactionId} tx=${String(isDefined(tx))} error=${getErrorMessage(error)}`
+        () => 'enter copySourceTags',
+        () => 'done copySourceTags',
+        error => `throw copySourceTagsErrorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async copySourceTags(sourceTransactionIds: number[], canonicalTransactionId: number, tx: DB): Promise<void> {
         await consolidationCopySourceTransactionTags(

--- a/packages/consolidation/src/executor/service/consolidation-repair-executor.service.ts
+++ b/packages/consolidation/src/executor/service/consolidation-repair-executor.service.ts
@@ -16,16 +16,16 @@ import type {
 } from '@budgie/contracts';
 
 export class ConsolidationRepairExecutorService {
-    private readonly consolidationEligibilityService: ConsolidationEligibilityService;
-
     private readonly consolidationMutationService: ConsolidationMutationService;
 
+    private readonly consolidationEligibilityService: ConsolidationEligibilityService;
+
     constructor(private readonly dependencies: ConsolidationExecutorDependenciesInterface) {
-        this.consolidationEligibilityService = new ConsolidationEligibilityService(dependencies);
         this.consolidationMutationService = new ConsolidationMutationService(dependencies);
+        this.consolidationEligibilityService = new ConsolidationEligibilityService(dependencies);
     }
 
-    @Log(
+    @Log.withoutErrorPayload(
         () => 'enter ibanBridgeCanonicalDuplicate',
         result => `done ibanBridgeCanonicalDuplicateOutcome=${String(result)}`,
         error => `throw ibanBridgeCanonicalDuplicateErrorClass=${isError(error) ? error.name : 'UnknownError'}`
@@ -36,7 +36,7 @@ export class ConsolidationRepairExecutorService {
         );
     }
 
-    @Log(
+    @Log.withoutErrorPayload(
         () => 'enter existingTransferChainReclaim',
         result => `done existingTransferChainReclaimOutcome=${String(result)}`,
         error => `throw existingTransferChainReclaimErrorClass=${isError(error) ? error.name : 'UnknownError'}`
@@ -47,7 +47,7 @@ export class ConsolidationRepairExecutorService {
         );
     }
 
-    @Log(
+    @Log.withoutErrorPayload(
         () => 'enter existingTransferIncomeDuplicate',
         result => `done existingTransferIncomeDuplicateOutcome=${String(result)}`,
         error => `throw existingTransferIncomeDuplicateErrorClass=${isError(error) ? error.name : 'UnknownError'}`
@@ -58,7 +58,7 @@ export class ConsolidationRepairExecutorService {
         );
     }
 
-    @Log(
+    @Log.withoutErrorPayload(
         () => 'enter refundRepair',
         result => `done refundRepairOutcome=${String(result)}`,
         error => `throw refundRepairErrorClass=${isError(error) ? error.name : 'UnknownError'}`

--- a/packages/consolidation/src/executor/service/consolidation-repair-executor.service.ts
+++ b/packages/consolidation/src/executor/service/consolidation-repair-executor.service.ts
@@ -1,7 +1,7 @@
 import { TransactionConsolidationTypeEnum } from '@budgie/contracts';
 import { Log } from '@budgie/logger';
 
-import { getErrorMessage } from '@rnw-community/shared';
+import { isError } from '@rnw-community/shared';
 
 import { ConsolidationEligibilityService } from './consolidation-eligibility.service';
 import { ConsolidationMutationService } from './consolidation-mutation.service';
@@ -26,12 +26,9 @@ export class ConsolidationRepairExecutorService {
     }
 
     @Log(
-        candidate =>
-            `enter expenseTransactionId=${candidate.expenseTransactionId} incomeTransactionId=${candidate.incomeTransactionId} existingCanonicalTransferId=${candidate.existingCanonicalTransferId} sourceAccountId=${candidate.sourceAccountId} targetAccountId=${candidate.targetAccountId} timeDiff=${candidate.timeDiff}`,
-        (result, candidate) =>
-            `done result=${String(result)} expenseTransactionId=${candidate.expenseTransactionId} incomeTransactionId=${candidate.incomeTransactionId} existingCanonicalTransferId=${candidate.existingCanonicalTransferId} sourceAccountId=${candidate.sourceAccountId} targetAccountId=${candidate.targetAccountId} timeDiff=${candidate.timeDiff}`,
-        (error, candidate) =>
-            `throw expenseTransactionId=${candidate.expenseTransactionId} incomeTransactionId=${candidate.incomeTransactionId} existingCanonicalTransferId=${candidate.existingCanonicalTransferId} sourceAccountId=${candidate.sourceAccountId} targetAccountId=${candidate.targetAccountId} timeDiff=${candidate.timeDiff} error=${getErrorMessage(error)}`
+        () => 'enter ibanBridgeCanonicalDuplicate',
+        result => `done ibanBridgeCanonicalDuplicateOutcome=${String(result)}`,
+        error => `throw ibanBridgeCanonicalDuplicateErrorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async consolidateIbanBridgeCanonicalDuplicate(candidate: IbanBridgeCanonicalDuplicateCandidateInterface): Promise<boolean> {
         return await this.dependencies.runTransaction(this.dependencies.database, async tx =>
@@ -40,12 +37,9 @@ export class ConsolidationRepairExecutorService {
     }
 
     @Log(
-        candidate =>
-            `enter existingTransferId=${candidate.existingTransferId} bridgeIncomeTransactionId=${candidate.bridgeIncomeTransactionId} bridgeExpenseTransactionId=${candidate.bridgeExpenseTransactionId} sourceAccountId=${candidate.sourceAccountId} bridgeAccountId=${candidate.bridgeAccountId} targetAccountId=${candidate.targetAccountId} sourceAmount=${candidate.sourceAmount} bridgeAmount=${candidate.bridgeAmount} targetAmount=${candidate.targetAmount} exchangeRate=${candidate.exchangeRate}`,
-        (result, candidate) =>
-            `done result=${String(result)} existingTransferId=${candidate.existingTransferId} bridgeIncomeTransactionId=${candidate.bridgeIncomeTransactionId} bridgeExpenseTransactionId=${candidate.bridgeExpenseTransactionId} sourceAccountId=${candidate.sourceAccountId} bridgeAccountId=${candidate.bridgeAccountId} targetAccountId=${candidate.targetAccountId} sourceAmount=${candidate.sourceAmount} bridgeAmount=${candidate.bridgeAmount} targetAmount=${candidate.targetAmount} exchangeRate=${candidate.exchangeRate}`,
-        (error, candidate) =>
-            `throw existingTransferId=${candidate.existingTransferId} bridgeIncomeTransactionId=${candidate.bridgeIncomeTransactionId} bridgeExpenseTransactionId=${candidate.bridgeExpenseTransactionId} sourceAccountId=${candidate.sourceAccountId} bridgeAccountId=${candidate.bridgeAccountId} targetAccountId=${candidate.targetAccountId} sourceAmount=${candidate.sourceAmount} bridgeAmount=${candidate.bridgeAmount} targetAmount=${candidate.targetAmount} exchangeRate=${candidate.exchangeRate} error=${getErrorMessage(error)}`
+        () => 'enter existingTransferChainReclaim',
+        result => `done existingTransferChainReclaimOutcome=${String(result)}`,
+        error => `throw existingTransferChainReclaimErrorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async consolidateExistingTransferChainReclaim(candidate: ExistingTransferChainReclaimCandidateInterface): Promise<boolean> {
         return await this.dependencies.runTransaction(this.dependencies.database, async tx =>
@@ -54,12 +48,9 @@ export class ConsolidationRepairExecutorService {
     }
 
     @Log(
-        candidate =>
-            `enter existingTransferId=${candidate.existingTransferId} incomeTransactionId=${candidate.incomeTransactionId} sourceAccountId=${candidate.sourceAccountId} targetAccountId=${candidate.targetAccountId} targetEntryId=${candidate.existingTransferTargetEntryId} sourceAmount=${candidate.sourceAmount} amount=${candidate.amount} exchangeRate=${candidate.exchangeRate} amountDelta=${candidate.amountDelta} timeDiff=${candidate.timeDiff}`,
-        (result, candidate) =>
-            `done result=${String(result)} existingTransferId=${candidate.existingTransferId} incomeTransactionId=${candidate.incomeTransactionId} sourceAccountId=${candidate.sourceAccountId} targetAccountId=${candidate.targetAccountId} targetEntryId=${candidate.existingTransferTargetEntryId} sourceAmount=${candidate.sourceAmount} amount=${candidate.amount} exchangeRate=${candidate.exchangeRate} amountDelta=${candidate.amountDelta} timeDiff=${candidate.timeDiff}`,
-        (error, candidate) =>
-            `throw existingTransferId=${candidate.existingTransferId} incomeTransactionId=${candidate.incomeTransactionId} sourceAccountId=${candidate.sourceAccountId} targetAccountId=${candidate.targetAccountId} targetEntryId=${candidate.existingTransferTargetEntryId} sourceAmount=${candidate.sourceAmount} amount=${candidate.amount} exchangeRate=${candidate.exchangeRate} amountDelta=${candidate.amountDelta} timeDiff=${candidate.timeDiff} error=${getErrorMessage(error)}`
+        () => 'enter existingTransferIncomeDuplicate',
+        result => `done existingTransferIncomeDuplicateOutcome=${String(result)}`,
+        error => `throw existingTransferIncomeDuplicateErrorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async consolidateExistingTransferIncomeDuplicate(candidate: ExistingTransferIncomeDuplicateCandidateInterface): Promise<boolean> {
         return await this.dependencies.runTransaction(this.dependencies.database, async tx =>
@@ -68,12 +59,9 @@ export class ConsolidationRepairExecutorService {
     }
 
     @Log(
-        candidate =>
-            `enter expenseTransactionId=${candidate.expenseTransactionId} accountId=${candidate.accountId} refundIncomeTransactionIds=${candidate.refundIncomeTransactionIds.join(',')} refundsTotal=${candidate.refundsTotal} expenseEntryAmount=${candidate.expenseEntryAmount}`,
-        (result, candidate) =>
-            `done result=${String(result)} expenseTransactionId=${candidate.expenseTransactionId} refundIncomeTransactionIds=${candidate.refundIncomeTransactionIds.join(',')} refundsTotal=${candidate.refundsTotal}`,
-        (error, candidate) =>
-            `throw expenseTransactionId=${candidate.expenseTransactionId} refundIncomeTransactionIds=${candidate.refundIncomeTransactionIds.join(',')} refundsTotal=${candidate.refundsTotal} error=${getErrorMessage(error)}`
+        () => 'enter refundRepair',
+        result => `done refundRepairOutcome=${String(result)}`,
+        error => `throw refundRepairErrorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async consolidateRefund(candidate: RefundCandidateInterface): Promise<boolean> {
         return await this.dependencies.runTransaction(this.dependencies.database, async tx => this.consolidateRefundInner(candidate, tx));

--- a/packages/consolidation/src/executor/service/unconsolidation.service.ts
+++ b/packages/consolidation/src/executor/service/unconsolidation.service.ts
@@ -1,7 +1,7 @@
 import { TransactionConsolidationTypeEnum } from '@budgie/contracts';
 import { Log } from '@budgie/logger';
 
-import { getErrorMessage, isDefined } from '@rnw-community/shared';
+import { isDefined, isError } from '@rnw-community/shared';
 
 import type { UnconsolidationDependenciesInterface } from '../interface/unconsolidation-dependencies.interface';
 import type { DB, TransactionEntityInterface } from '@budgie/contracts';
@@ -9,11 +9,7 @@ import type { DB, TransactionEntityInterface } from '@budgie/contracts';
 export class UnconsolidationService {
     constructor(private readonly dependencies: UnconsolidationDependenciesInterface) {}
 
-    @Log(
-        (transactionId, tx) => `enter transactionId=${transactionId} hasTx=${String(isDefined(tx))}`,
-        (result, transactionId, tx) => `done result=${String(result)} transactionId=${transactionId} hasTx=${String(isDefined(tx))}`,
-        (error, transactionId, tx) => `throw transactionId=${transactionId} hasTx=${String(isDefined(tx))} error=${getErrorMessage(error)}`
-    )
+    @Log.withoutErrorPayload(() => 'enter', () => 'done', error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`)
     async unconsolidateById(transactionId: number, tx: DB): Promise<void> {
         const canonical = await this.dependencies.transactionRepository.getByIdRaw(transactionId, tx);
 

--- a/packages/consolidation/src/refund/service/refund-consolidation.service.ts
+++ b/packages/consolidation/src/refund/service/refund-consolidation.service.ts
@@ -17,7 +17,7 @@ import type {
 export class RefundConsolidationService {
     constructor(private readonly dependencies: RefundConsolidationDependenciesInterface) {}
 
-    @Log(
+    @Log.withoutErrorPayload(
         () => 'enter',
         result => `done candidateCount=${result.length}`,
         error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`
@@ -26,7 +26,7 @@ export class RefundConsolidationService {
         return await this.dependencies.refundPairRepository.findRefundableExpenseCandidates(refundIncomeTransactionId, search);
     }
 
-    @Log(() => 'enter', () => 'done', error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`)
+    @Log.withoutErrorPayload(() => 'enter', () => 'done', error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`)
     async convertToRefund(params: ConvertToRefundParamsInterface): Promise<number> {
         return await this.dependencies.runTransaction(this.dependencies.database, async tx => this.convertToRefundInner(params, tx));
     }

--- a/packages/consolidation/src/refund/service/refund-consolidation.service.ts
+++ b/packages/consolidation/src/refund/service/refund-consolidation.service.ts
@@ -1,7 +1,7 @@
 import { TransactionConsolidationTypeEnum, TransactionEntryTypeEnum, TransactionTypeEnum } from '@budgie/contracts';
 import { Log } from '@budgie/logger';
 
-import { getErrorMessage, isDefined } from '@rnw-community/shared';
+import { isDefined, isError } from '@rnw-community/shared';
 
 import { consolidationCopySourceTransactionTags } from '../../shared/utils/consolidation-copy-source-transaction-tags.util';
 
@@ -18,23 +18,15 @@ export class RefundConsolidationService {
     constructor(private readonly dependencies: RefundConsolidationDependenciesInterface) {}
 
     @Log(
-        (refundIncomeTransactionId, search) => `enter refundIncomeTransactionId=${refundIncomeTransactionId} search="${search}"`,
-        (result, refundIncomeTransactionId, search) =>
-            `done refundIncomeTransactionId=${refundIncomeTransactionId} search="${search}" candidateIds=${result.map(candidate => candidate.id).join(',')}`,
-        (error, refundIncomeTransactionId, search) =>
-            `throw refundIncomeTransactionId=${refundIncomeTransactionId} search="${search}" error=${getErrorMessage(error)}`
+        () => 'enter',
+        result => `done candidateCount=${result.length}`,
+        error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async findRefundableExpenses(refundIncomeTransactionId: number, search: string): Promise<RefundableExpenseCandidateInterface[]> {
         return await this.dependencies.refundPairRepository.findRefundableExpenseCandidates(refundIncomeTransactionId, search);
     }
 
-    @Log(
-        params => `enter refundIncomeTransactionId=${params.refundIncomeTransactionId} expenseTransactionId=${params.expenseTransactionId}`,
-        (result, params) =>
-            `done refundIncomeTransactionId=${params.refundIncomeTransactionId} expenseTransactionId=${params.expenseTransactionId} canonicalTransactionId=${result}`,
-        (error, params) =>
-            `throw refundIncomeTransactionId=${params.refundIncomeTransactionId} expenseTransactionId=${params.expenseTransactionId} error=${getErrorMessage(error)}`
-    )
+    @Log(() => 'enter', () => 'done', error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`)
     async convertToRefund(params: ConvertToRefundParamsInterface): Promise<number> {
         return await this.dependencies.runTransaction(this.dependencies.database, async tx => this.convertToRefundInner(params, tx));
     }

--- a/packages/contracts/src/transaction-entry/repository/transaction-entry.repository.ts
+++ b/packages/contracts/src/transaction-entry/repository/transaction-entry.repository.ts
@@ -2,7 +2,7 @@ import { Log } from '@budgie/logger';
 import { and, count, eq, inArray, isNotNull, isNull, or, sql } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/sqlite-core';
 
-import { getErrorMessage, isDefined, isNotEmptyArray } from '@rnw-community/shared';
+import { isDefined, isError, isNotEmptyArray } from '@rnw-community/shared';
 
 import { AccountEntityTable } from '../../account/table/account-entity.table';
 import { TransactionEntityTable } from '../../transaction/table/transaction-entity.table';
@@ -19,11 +19,10 @@ import type { PendingBaseValuationBucketInterface } from '../interface/pending-b
 export class TransactionEntryRepository {
     constructor(private db: DB) {}
 
-    @Log(
-        (sourceIds, canonicalId, tx) => `enter sourceIds=${sourceIds.join(',')} canonicalId=${canonicalId} inTx=${String(isDefined(tx))}`,
+    @Log.withoutErrorPayload(
+        sourceIds => `enter sourceCount=${sourceIds.length}`,
         'done',
-        (error, sourceIds, canonicalId, tx) =>
-            `throw sourceIds=${sourceIds.join(',')} canonicalId=${canonicalId} inTx=${String(isDefined(tx))} error=${getErrorMessage(error)}`
+        (error, sourceIds) => `throw sourceCount=${sourceIds.length} errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async moveToConsolidatedTransaction(sourceTransactionIds: number[], canonicalTransactionId: number, tx?: DB): Promise<void> {
         if (!isNotEmptyArray(sourceTransactionIds)) {
@@ -45,11 +44,7 @@ export class TransactionEntryRepository {
             );
     }
 
-    @Log(
-        (canonicalId, tx) => `enter canonicalId=${canonicalId} inTx=${String(isDefined(tx))}`,
-        'done',
-        (error, canonicalId, tx) => `throw canonicalId=${canonicalId} inTx=${String(isDefined(tx))} error=${getErrorMessage(error)}`
-    )
+    @Log.withoutErrorPayload(() => 'enter', 'done', error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`)
     async moveBackToOriginalTransactions(canonicalTransactionId: number, tx?: DB): Promise<void> {
         await (tx ?? this.db)
             .update(TransactionEntryEntityTable)
@@ -66,12 +61,11 @@ export class TransactionEntryRepository {
             );
     }
 
-    @Log(
-        (transactionIds, tx) => `enter transactionIds=${transactionIds.join(',')} inTx=${String(isDefined(tx))}`,
-        (result, transactionIds, tx) =>
-            `done result=${String(result)} transactionIds=${transactionIds.join(',')} inTx=${String(isDefined(tx))}`,
-        (error, transactionIds, tx) =>
-            `throw transactionIds=${transactionIds.join(',')} inTx=${String(isDefined(tx))} error=${getErrorMessage(error)}`
+    @Log.withoutErrorPayload(
+        transactionIds => `enter transactionCount=${transactionIds.length}`,
+        (result, transactionIds) => `done moved=${String(result)} transactionCount=${transactionIds.length}`,
+        (error, transactionIds) =>
+            `throw transactionCount=${transactionIds.length} errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async hasMovedSourceEntries(transactionIds: number[], tx?: DB): Promise<boolean> {
         if (!isNotEmptyArray(transactionIds)) {

--- a/packages/contracts/src/transaction/repository/transaction.repository.ts
+++ b/packages/contracts/src/transaction/repository/transaction.repository.ts
@@ -3,7 +3,15 @@ import { Log } from '@budgie/logger';
 import { SQL, and, count, eq, gte, inArray, isNotNull, isNull, lt, ne, notInArray, or, sql } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/sqlite-core';
 
-import { getErrorMessage, isDefined, isEmptyArray, isNotEmptyArray, isNotEmptyString, isPositiveNumber } from '@rnw-community/shared';
+import {
+    getErrorMessage,
+    isDefined,
+    isEmptyArray,
+    isError,
+    isNotEmptyArray,
+    isNotEmptyString,
+    isPositiveNumber
+} from '@rnw-community/shared';
 
 import { LanguageEnum } from '../../@generic/enum/language.enum';
 import { BaseTransactionFilterRepository } from '../../@generic/repository/base-transaction-filter.repository';
@@ -53,25 +61,10 @@ export class TransactionRepository extends BaseTransactionFilterRepository {
         }
     } as const;
 
-    @Log(
-        (inputs, tx) =>
-            `enter hasTx=${String(isDefined(tx))} count=${inputs.length} externalIds=${inputs
-                .slice(0, 5)
-                .map(input => input.externalId)
-                .join(',')}`,
-        (result, inputs, tx) =>
-            `done hasTx=${String(isDefined(tx))} count=${inputs.length} externalIds=${inputs
-                .slice(0, 5)
-                .map(input => input.externalId)
-                .join(',')} insertedIds=${result
-                .slice(0, 5)
-                .map(row => row.id)
-                .join(',')}`,
-        (error, inputs, tx) =>
-            `throw hasTx=${String(isDefined(tx))} count=${inputs.length} externalIds=${inputs
-                .slice(0, 5)
-                .map(input => input.externalId)
-                .join(',')} error=${getErrorMessage(error)}`
+    @Log.withoutErrorPayload(
+        inputs => `enter count=${inputs.length}`,
+        (result, inputs) => `done requestedCount=${inputs.length} insertedCount=${result.length}`,
+        (error, inputs) => `throw count=${inputs.length} errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async bulkCreate(inputs: TransactionCreateEntityInterface[], tx?: DB): Promise<TransactionEntityInterface[]> {
         if (isNotEmptyArray(inputs)) {
@@ -350,12 +343,11 @@ export class TransactionRepository extends BaseTransactionFilterRepository {
             );
     }
 
-    @Log(
-        (sourceTransactionIds, canonicalTransactionId, tx) =>
-            `enter sourceTransactionIds=${sourceTransactionIds.join(',')} canonicalTransactionId=${canonicalTransactionId} hasTx=${String(isDefined(tx))}`,
+    @Log.withoutErrorPayload(
+        sourceTransactionIds => `enter sourceCount=${sourceTransactionIds.length}`,
         'done',
-        (error, sourceTransactionIds, canonicalTransactionId, tx) =>
-            `throw sourceTransactionIds=${sourceTransactionIds.join(',')} canonicalTransactionId=${canonicalTransactionId} hasTx=${String(isDefined(tx))} error=${getErrorMessage(error)}`
+        (error, sourceTransactionIds) =>
+            `throw sourceCount=${sourceTransactionIds.length} errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async setConsolidationParent(sourceTransactionIds: number[], canonicalTransactionId: number, tx?: DB): Promise<void> {
         if (isEmptyArray(sourceTransactionIds)) {
@@ -374,11 +366,10 @@ export class TransactionRepository extends BaseTransactionFilterRepository {
             );
     }
 
-    @Log(
-        (transactionId, type, tx) => `enter transactionId=${transactionId} type=${type ?? 'null'} hasTx=${String(isDefined(tx))}`,
+    @Log.withoutErrorPayload(
+        (_transactionId, type) => `enter type=${type ?? 'null'}`,
         'done',
-        (error, transactionId, type, tx) =>
-            `throw transactionId=${transactionId} type=${type ?? 'null'} hasTx=${String(isDefined(tx))} error=${getErrorMessage(error)}`
+        (error, _transactionId, type) => `throw type=${type ?? 'null'} errorClass=${isError(error) ? error.name : 'UnknownError'}`
     )
     async setConsolidationType(transactionId: number, type: TransactionConsolidationTypeEnum | null, tx?: DB): Promise<void> {
         await (tx ?? this.db)
@@ -387,12 +378,7 @@ export class TransactionRepository extends BaseTransactionFilterRepository {
             .where(and(eq(TransactionEntityTable.id, transactionId), isNull(TransactionEntityTable.consolidationParentTransactionId)));
     }
 
-    @Log(
-        (canonicalTransactionId, tx) => `enter canonicalTransactionId=${canonicalTransactionId} hasTx=${String(isDefined(tx))}`,
-        'done',
-        (error, canonicalTransactionId, tx) =>
-            `throw canonicalTransactionId=${canonicalTransactionId} hasTx=${String(isDefined(tx))} error=${getErrorMessage(error)}`
-    )
+    @Log.withoutErrorPayload(() => 'enter', 'done', error => `throw errorClass=${isError(error) ? error.name : 'UnknownError'}`)
     async clearConsolidationParent(canonicalTransactionId: number, tx?: DB): Promise<void> {
         await (tx ?? this.db)
             .update(TransactionEntityTable)

--- a/packages/logger/src/console-transport.util.ts
+++ b/packages/logger/src/console-transport.util.ts
@@ -30,4 +30,11 @@ export const consoleTransport = {
     }
 };
 
-export const Log = createLogDecorator({ transport: consoleTransport });
+export const Log = Object.assign(createLogDecorator({ transport: consoleTransport }), {
+    withoutErrorPayload: createLogDecorator({
+        transport: {
+            ...consoleTransport,
+            error: (message, _error, logContext) => void consoleTransport.error(message, null, logContext)
+        }
+    })
+});

--- a/tests/bank-sync-tests/src/scenarios/consolidation/reconciliation-log-privacy.test.ts
+++ b/tests/bank-sync-tests/src/scenarios/consolidation/reconciliation-log-privacy.test.ts
@@ -1,0 +1,107 @@
+import { bankSyncRepairService } from '@app/sync/service/bank-sync-repair.service';
+import { consolidationCoordinatorService } from '@app/sync/service/consolidation-coordinator.service';
+import { syncWorkloadService } from '@app/sync/service/sync-workload.service';
+import { transferConsolidationDrainerService } from '@app/sync/service/transfer-consolidation-drainer.service';
+import { transferConsolidationService } from '@app/sync/service/transfer-consolidation.service';
+import { TransferConsolidationDrainReasonEnum } from '@app/sync/enum/transfer-consolidation-drain-reason.enum';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { isError, isObject } from '@rnw-community/shared';
+
+import type { ConsolidationScanScopeInterface } from '@budgie/contracts';
+
+vi.unmock('@app/sync/service/transfer-consolidation-drainer.service');
+
+const reconciliationSentinel = 'app-reconciliation-error-sentinel';
+const reconciliationScope: ConsolidationScanScopeInterface = {
+    operatedAtFrom: new Date('2026-06-07T08:09:10.000Z'),
+    operatedAtTo: new Date('2026-06-08T09:10:11.000Z'),
+    transactionIds: [710000000001, 720000000002]
+};
+const reconciliationScopeSentinels = ['710000000001', '720000000002', '2026-06-07T08:09:10.000Z', '2026-06-08T09:10:11.000Z'];
+const capturedConsoleArguments: unknown[][] = [];
+
+const serializeConsoleArgument = (value: unknown): string => {
+    if (isError(value)) {
+        return `${value.name}:${value.message}:${value.stack ?? ''}:${Object.values(Object.getOwnPropertyDescriptors(value))
+            .map(descriptor => serializeConsoleArgument(descriptor.value))
+            .join(':')}`;
+    }
+
+    if (value instanceof Date) {
+        return value.toISOString();
+    }
+
+    if (Array.isArray(value)) {
+        return value.map(serializeConsoleArgument).join(':');
+    }
+
+    if (isObject(value)) {
+        return Object.entries(value)
+            .map(([key, entry]) => `${key}:${serializeConsoleArgument(entry)}`)
+            .join(':');
+    }
+
+    return String(value);
+};
+
+const captureConsoleArguments = (): void => {
+    const captureArguments = (...arguments_: unknown[]): void => {
+        capturedConsoleArguments.push(arguments_);
+    };
+
+    vi.spyOn(console, 'debug').mockImplementation(captureArguments);
+    vi.spyOn(console, 'error').mockImplementation(captureArguments);
+    vi.spyOn(console, 'log').mockImplementation(captureArguments);
+};
+
+const expectReconciliationConsoleArgumentsArePrivate = (): void => {
+    const capturedOutput = capturedConsoleArguments.flatMap(arguments_ => arguments_.map(serializeConsoleArgument)).join('\n');
+
+    expect(capturedConsoleArguments).not.toEqual([]);
+    expect(capturedOutput).not.toContain(reconciliationSentinel);
+    for (const sentinel of reconciliationScopeSentinels) {
+        expect(capturedOutput).not.toContain(sentinel);
+    }
+};
+
+describe('consolidation/app-reconciliation-log-privacy', () => {
+    afterEach(() => {
+        transferConsolidationDrainerService.cancelPending();
+        capturedConsoleArguments.length = 0;
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it('keeps reconciliation scopes and errors private at production app boundaries', async () => {
+        captureConsoleArguments();
+        const reconciliationError = new Error(reconciliationSentinel);
+        const coordinatorConsolidateSpy = vi.spyOn(consolidationCoordinatorService, 'consolidate').mockRejectedValue(reconciliationError);
+
+        await expect(transferConsolidationService.consolidate(reconciliationScope)).rejects.toBe(reconciliationError);
+        await expect(syncWorkloadService.run('transfer-consolidation-drain', () => Promise.reject(reconciliationError))).rejects.toBe(
+            reconciliationError
+        );
+
+        vi.useFakeTimers();
+        Object.assign(transferConsolidationDrainerService, {
+            cancelIdleCallback: null,
+            hasPendingRun: false,
+            isRunning: false,
+            pendingScope: null,
+            timer: null
+        });
+        transferConsolidationDrainerService.enqueue(TransferConsolidationDrainReasonEnum.FILE_IMPORT, reconciliationScope);
+        await vi.advanceTimersByTimeAsync(1500);
+        await vi.runOnlyPendingTimersAsync();
+        await Promise.resolve();
+        expect(coordinatorConsolidateSpy).toHaveBeenCalledWith(reconciliationScope, undefined);
+
+        const coordinatorCountSpy = vi
+            .spyOn(consolidationCoordinatorService, 'countExistingTransferIncomeDuplicateRepairCandidates')
+            .mockRejectedValue(reconciliationError);
+        await expect(bankSyncRepairService.previewDuplicates()).rejects.toBe(reconciliationError);
+        expect(coordinatorCountSpy).toHaveBeenCalledTimes(1);
+        expectReconciliationConsoleArgumentsArePrivate();
+    });
+});

--- a/tests/bank-sync-tests/src/scenarios/consolidation/reconciliation-log-privacy.test.ts
+++ b/tests/bank-sync-tests/src/scenarios/consolidation/reconciliation-log-privacy.test.ts
@@ -1,20 +1,29 @@
-import { bankSyncRepairService } from '@app/sync/service/bank-sync-repair.service';
+import { TransferConsolidationDrainReasonEnum } from '@app/sync/enum/transfer-consolidation-drain-reason.enum';
 import { bankSyncDuplicateSoftDeleteService } from '@app/sync/service/bank-sync-duplicate-soft-delete.service';
+import { bankSyncRepairService } from '@app/sync/service/bank-sync-repair.service';
 import { consolidationCoordinatorService } from '@app/sync/service/consolidation-coordinator.service';
 import { syncWorkloadService } from '@app/sync/service/sync-workload.service';
 import { transferConsolidationDrainerService } from '@app/sync/service/transfer-consolidation-drainer.service';
 import { transferConsolidationService } from '@app/sync/service/transfer-consolidation.service';
-import { TransferConsolidationDrainReasonEnum } from '@app/sync/enum/transfer-consolidation-drain-reason.enum';
+import {
+    ExternalSourceEnum,
+    TransactionEntityTable,
+    TransactionEntryEntityTable,
+    TransactionEntryTypeEnum,
+    TransactionTypeEnum
+} from '@budgie/contracts';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { isError, isObject } from '@rnw-community/shared';
 
-import { ExternalSourceEnum, TransactionEntityTable, TransactionEntryEntityTable, TransactionEntryTypeEnum, TransactionTypeEnum } from '@budgie/contracts';
-
-import { insertOne } from '../../harness/db/insert-one';
 import { seed, testDb } from '../../harness';
+import { insertOne } from '../../harness/db/insert-one';
 
-import type { ConsolidationScanScopeInterface, TransactionCreateEntityInterface, TransactionEntryCreateEntityInterface } from '@budgie/contracts';
+import type {
+    ConsolidationScanScopeInterface,
+    TransactionCreateEntityInterface,
+    TransactionEntryCreateEntityInterface
+} from '@budgie/contracts';
 
 vi.unmock('@app/sync/service/transfer-consolidation-drainer.service');
 

--- a/tests/bank-sync-tests/src/scenarios/consolidation/reconciliation-log-privacy.test.ts
+++ b/tests/bank-sync-tests/src/scenarios/consolidation/reconciliation-log-privacy.test.ts
@@ -13,6 +13,7 @@ import type { ConsolidationScanScopeInterface } from '@budgie/contracts';
 vi.unmock('@app/sync/service/transfer-consolidation-drainer.service');
 
 const reconciliationSentinel = 'app-reconciliation-error-sentinel';
+const reconciliationPreviewSentinel = 'app-reconciliation-preview-error-sentinel';
 const reconciliationScope: ConsolidationScanScopeInterface = {
     operatedAtFrom: new Date('2026-06-07T08:09:10.000Z'),
     operatedAtTo: new Date('2026-06-08T09:10:11.000Z'),
@@ -60,6 +61,7 @@ const expectReconciliationConsoleArgumentsArePrivate = (): void => {
 
     expect(capturedConsoleArguments).not.toEqual([]);
     expect(capturedOutput).not.toContain(reconciliationSentinel);
+    expect(capturedOutput).not.toContain(reconciliationPreviewSentinel);
     for (const sentinel of reconciliationScopeSentinels) {
         expect(capturedOutput).not.toContain(sentinel);
     }
@@ -82,6 +84,14 @@ describe('consolidation/app-reconciliation-log-privacy', () => {
         await expect(syncWorkloadService.run('transfer-consolidation-drain', () => Promise.reject(reconciliationError))).rejects.toBe(
             reconciliationError
         );
+
+        const reconciliationPreviewError = new Error(reconciliationPreviewSentinel);
+        const coordinatorCountAutoCandidatesSpy = vi
+            .spyOn(consolidationCoordinatorService, 'countAutoCandidates')
+            .mockRejectedValue(reconciliationPreviewError);
+        await expect(transferConsolidationService.preview()).rejects.toBe(reconciliationPreviewError);
+        await expect(transferConsolidationService.getProgressSnapshot()).rejects.toBe(reconciliationPreviewError);
+        expect(coordinatorCountAutoCandidatesSpy).toHaveBeenCalledTimes(2);
 
         vi.useFakeTimers();
         Object.assign(transferConsolidationDrainerService, {

--- a/tests/bank-sync-tests/src/scenarios/consolidation/reconciliation-log-privacy.test.ts
+++ b/tests/bank-sync-tests/src/scenarios/consolidation/reconciliation-log-privacy.test.ts
@@ -1,4 +1,5 @@
 import { bankSyncRepairService } from '@app/sync/service/bank-sync-repair.service';
+import { bankSyncDuplicateSoftDeleteService } from '@app/sync/service/bank-sync-duplicate-soft-delete.service';
 import { consolidationCoordinatorService } from '@app/sync/service/consolidation-coordinator.service';
 import { syncWorkloadService } from '@app/sync/service/sync-workload.service';
 import { transferConsolidationDrainerService } from '@app/sync/service/transfer-consolidation-drainer.service';
@@ -8,12 +9,19 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { isError, isObject } from '@rnw-community/shared';
 
-import type { ConsolidationScanScopeInterface } from '@budgie/contracts';
+import { ExternalSourceEnum, TransactionEntityTable, TransactionEntryEntityTable, TransactionEntryTypeEnum, TransactionTypeEnum } from '@budgie/contracts';
+
+import { insertOne } from '../../harness/db/insert-one';
+import { seed, testDb } from '../../harness';
+
+import type { ConsolidationScanScopeInterface, TransactionCreateEntityInterface, TransactionEntryCreateEntityInterface } from '@budgie/contracts';
 
 vi.unmock('@app/sync/service/transfer-consolidation-drainer.service');
 
 const reconciliationSentinel = 'app-reconciliation-error-sentinel';
 const reconciliationPreviewSentinel = 'app-reconciliation-preview-error-sentinel';
+const duplicateTransactionIdSentinel = '910000000002';
+const duplicateErrorSentinel = 'bank-repair-duplicate-error-sentinel';
 const reconciliationScope: ConsolidationScanScopeInterface = {
     operatedAtFrom: new Date('2026-06-07T08:09:10.000Z'),
     operatedAtTo: new Date('2026-06-08T09:10:11.000Z'),
@@ -21,6 +29,36 @@ const reconciliationScope: ConsolidationScanScopeInterface = {
 };
 const reconciliationScopeSentinels = ['710000000001', '720000000002', '2026-06-07T08:09:10.000Z', '2026-06-08T09:10:11.000Z'];
 const capturedConsoleArguments: unknown[][] = [];
+
+const seedPrivatbankDuplicate = (accountId: number, externalId: string) => {
+    const transaction = insertOne(TransactionEntityTable, {
+        type: TransactionTypeEnum.INCOME,
+        title: 'privacy duplicate',
+        externalId,
+        externalSource: ExternalSourceEnum.PRIVATBANK,
+        operatedAt: new Date('2026-06-09T10:11:12.000Z'),
+        exchangeRate: 1,
+        fromAccountId: null,
+        toAccountId: accountId,
+        comment: '',
+        updatedBy: null,
+        consolidationParentTransactionId: null,
+        consolidationType: null
+    } satisfies TransactionCreateEntityInterface);
+    insertOne(TransactionEntryEntityTable, {
+        transactionId: transaction.id,
+        accountId,
+        type: TransactionEntryTypeEnum.DEBIT,
+        amount: 1_000_000,
+        externalId,
+        exchangeRate: 1,
+        categoryId: null,
+        mccCategoryId: null,
+        originalTransactionId: null
+    } satisfies TransactionEntryCreateEntityInterface);
+
+    return transaction;
+};
 
 const serializeConsoleArgument = (value: unknown): string => {
     if (isError(value)) {
@@ -62,6 +100,8 @@ const expectReconciliationConsoleArgumentsArePrivate = (): void => {
     expect(capturedConsoleArguments).not.toEqual([]);
     expect(capturedOutput).not.toContain(reconciliationSentinel);
     expect(capturedOutput).not.toContain(reconciliationPreviewSentinel);
+    expect(capturedOutput).not.toContain(duplicateErrorSentinel);
+    expect(capturedOutput).not.toContain(duplicateTransactionIdSentinel);
     for (const sentinel of reconciliationScopeSentinels) {
         expect(capturedOutput).not.toContain(sentinel);
     }
@@ -112,6 +152,28 @@ describe('consolidation/app-reconciliation-log-privacy', () => {
             .mockRejectedValue(reconciliationError);
         await expect(bankSyncRepairService.previewDuplicates()).rejects.toBe(reconciliationError);
         expect(coordinatorCountSpy).toHaveBeenCalledTimes(1);
+        expectReconciliationConsoleArgumentsArePrivate();
+    });
+
+    it('keeps nested duplicate preview and removal logs private', async () => {
+        captureConsoleArguments();
+        const account = seed.account({ externalId: 'privacy-duplicate-account', externalSource: ExternalSourceEnum.PRIVATBANK });
+        await testDb.$client.runAsync("INSERT INTO sqlite_sequence(name, seq) VALUES ('transactions', 910000000000)");
+        const keptTransaction = seedPrivatbankDuplicate(account.id, 'privacy-duplicate-kept');
+        const duplicateTransaction = seedPrivatbankDuplicate(account.id, 'privacy-duplicate-removed');
+
+        const preview = await bankSyncRepairService.previewDuplicates();
+        const result = await bankSyncRepairService.removeDuplicates();
+
+        expect(preview.duplicateTransactionCount).toBe(1);
+        expect(result.repairedTransactionCount).toBe(1);
+        expect(duplicateTransaction.id).toBe(910000000002);
+        expect(keptTransaction.deletedAt).toBeNull();
+
+        const duplicateError = new Error(duplicateErrorSentinel);
+        const getAllAsyncSpy = vi.spyOn(testDb.$client, 'getAllAsync').mockRejectedValue(duplicateError);
+        await expect(bankSyncDuplicateSoftDeleteService.remove(testDb, [duplicateTransaction.id])).rejects.toBe(duplicateError);
+        getAllAsyncSpy.mockRestore();
         expectReconciliationConsoleArgumentsArePrivate();
     });
 });

--- a/tests/consolidation-tests/src/harness/test-context.ts
+++ b/tests/consolidation-tests/src/harness/test-context.ts
@@ -1,6 +1,8 @@
 import { buildTestDb, createTestRepositories, TestQueryService, TestSeedService } from '@budgie-at/test-kit';
 import {
     ConsolidationAutoCandidateService,
+    ConsolidationCandidateService,
+    ConsolidationCoordinatorService,
     ConsolidationExecutorService,
     ConsolidationFamilyRegistryService,
     ConsolidationRepairExecutorService,
@@ -51,6 +53,21 @@ const consolidationFamilyRegistryService = new ConsolidationFamilyRegistryServic
 );
 
 export const consolidationAutoCandidateService = new ConsolidationAutoCandidateService(consolidationFamilyRegistryService);
+
+const consolidationCandidateService = new ConsolidationCandidateService(
+    {
+        atmCashWithdrawalRepository: repositories.atmCashWithdrawalRepository,
+        existingTransferRepository: repositories.existingTransferRepository,
+        refundPairRepository: repositories.refundPairRepository,
+        transferPairRepository: repositories.transferPairRepository
+    },
+    yieldControl
+);
+
+export const consolidationCoordinatorService = new ConsolidationCoordinatorService(
+    consolidationCandidateService,
+    consolidationAutoCandidateService
+);
 
 export const unconsolidationService = new UnconsolidationService({
     transactionRepository: repositories.transactionRepository,

--- a/tests/consolidation-tests/src/harness/test-context.ts
+++ b/tests/consolidation-tests/src/harness/test-context.ts
@@ -23,6 +23,7 @@ export const existingTransferRepository = repositories.existingTransferRepositor
 export const ibanBridgeTransferRepository = repositories.ibanBridgeTransferRepository;
 export const refundPairRepository = repositories.refundPairRepository;
 export const transferPairRepository = repositories.transferPairRepository;
+export const transactionRepository = repositories.transactionRepository;
 
 const consolidationExecutorDependencies = {
     database: testDb,

--- a/tests/consolidation-tests/src/scenarios/reconciliation-log-privacy.test.ts
+++ b/tests/consolidation-tests/src/scenarios/reconciliation-log-privacy.test.ts
@@ -1,23 +1,29 @@
-import { PRECISION } from '@budgie/contracts';
+import { PRECISION, TransactionConsolidationTypeEnum } from '@budgie/contracts';
+import { Log } from '@budgie/logger';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { isError } from '@rnw-community/shared';
+import { emptyFn, isError } from '@rnw-community/shared';
 
 import {
     consolidationAutoCandidateService,
     consolidationRepairExecutorService,
     refundConsolidationService,
     refundPairRepository,
+    testDb,
     testQueryService,
     testSeedService,
-    transactionRepository
+    transactionRepository,
+    unconsolidationService
 } from '../harness/test-context';
 
 const reconciliationLogContexts = [
+    'ConsolidationAutoCandidateService',
+    'ConsolidationEligibilityService',
     'ConsolidationExecutorService',
     'ConsolidationMutationService',
     'ConsolidationRepairExecutorService',
-    'RefundConsolidationService'
+    'RefundConsolidationService',
+    'UnconsolidationService'
 ];
 
 const reconciliationSentinels = [
@@ -26,12 +32,22 @@ const reconciliationSentinels = [
     'external-id-sentinel',
     'DE89370400440532013000',
     'reference-sentinel',
+    '810000000001',
+    '820000000001',
+    '830000000001',
     'executor-mutation-error-sentinel',
     'repair-error-sentinel',
     'refund-error-sentinel'
 ];
 
-const capturedReconciliationLogLines: string[] = [];
+const capturedConsoleLines: string[] = [];
+
+class OrdinaryLoggedService {
+    @Log('enter', 'done', 'throw')
+    fail(error: Error): never {
+        throw error;
+    }
+}
 
 const serializeConsoleArgument = (value: unknown): string => {
     if (isError(value)) {
@@ -41,13 +57,9 @@ const serializeConsoleArgument = (value: unknown): string => {
     return JSON.stringify(value) ?? String(value);
 };
 
-const captureReconciliationLogLines = (): void => {
+const captureConsoleLines = (): void => {
     const captureArguments = (...arguments_: unknown[]): void => {
-        const serializedArguments = arguments_.map(serializeConsoleArgument).join('\n');
-
-        if (reconciliationLogContexts.some(context => serializedArguments.includes(`[${context}::`))) {
-            capturedReconciliationLogLines.push(serializedArguments);
-        }
+        capturedConsoleLines.push(arguments_.map(serializeConsoleArgument).join('\n'));
     };
 
     vi.spyOn(console, 'debug').mockImplementation(captureArguments);
@@ -56,25 +68,29 @@ const captureReconciliationLogLines = (): void => {
 };
 
 const expectReconciliationLogsArePrivate = (): void => {
-    const capturedOutput = capturedReconciliationLogLines.join('\n');
+    const capturedOutput = capturedConsoleLines.join('\n');
 
-    expect(capturedReconciliationLogLines).not.toEqual([]);
-    for (const context of reconciliationLogContexts) {
-        expect(capturedOutput).toContain(`[${context}::`);
-    }
+    expect(capturedConsoleLines).not.toEqual([]);
     for (const sentinel of reconciliationSentinels) {
         expect(capturedOutput).not.toContain(sentinel);
     }
 };
 
+const seedSensitiveIdentifiers = async (): Promise<void> => {
+    await testDb.$client.runAsync("INSERT INTO sqlite_sequence(name, seq) VALUES ('accounts', 810000000000)");
+    await testDb.$client.runAsync("INSERT INTO sqlite_sequence(name, seq) VALUES ('transactions', 820000000000)");
+    await testDb.$client.runAsync("INSERT INTO sqlite_sequence(name, seq) VALUES ('transaction_entries', 830000000000)");
+};
+
 describe('consolidation/reconciliation-log-privacy', () => {
     afterEach(() => {
         vi.restoreAllMocks();
-        capturedReconciliationLogLines.length = 0;
+        capturedConsoleLines.length = 0;
     });
 
     it('does not expose reconciliation data in successful lifecycle logs from every reconciliation service', async () => {
-        captureReconciliationLogLines();
+        captureConsoleLines();
+        await seedSensitiveIdentifiers();
 
         const transferMcc = testQueryService.findMccByCode('4829');
         testSeedService.amountTransferPair(424242 * PRECISION, transferMcc.id);
@@ -91,13 +107,20 @@ describe('consolidation/reconciliation-log-privacy', () => {
         const refundCandidates = await refundPairRepository.findCandidates();
 
         expect(transferResult.consolidated).toBe(1);
+        const canonicalTransfer = testQueryService.fetchCanonicalsOfType(TransactionConsolidationTypeEnum.TRANSFER_PAIR)[0];
+
         await expect(consolidationRepairExecutorService.consolidateRefund(refundCandidates[0])).resolves.toBe(true);
         await expect(refundConsolidationService.findRefundableExpenses(refunds[0].id, 'reference-sentinel')).resolves.toEqual([]);
+        await expect(unconsolidationService.unconsolidateById(canonicalTransfer.id, testDb)).resolves.toBeUndefined();
+        for (const context of reconciliationLogContexts) {
+            expect(capturedConsoleLines.join('\n')).toContain(`[${context}::`);
+        }
         expectReconciliationLogsArePrivate();
     });
 
     it('does not expose thrown error payloads from every reconciliation service', async () => {
-        captureReconciliationLogLines();
+        captureConsoleLines();
+        await seedSensitiveIdentifiers();
 
         const transferMcc = testQueryService.findMccByCode('4829');
         testSeedService.amountTransferPair(424242 * PRECISION, transferMcc.id);
@@ -127,7 +150,14 @@ describe('consolidation/reconciliation-log-privacy', () => {
         vi.spyOn(refundPairRepository, 'findRefundableExpenseCandidates').mockRejectedValue(new Error('refund-error-sentinel'));
 
         await expect(refundConsolidationService.findRefundableExpenses(-1, 'reference-sentinel')).rejects.toThrow('refund-error-sentinel');
-        expect(vi.mocked(console.error).mock.calls.some(arguments_ => arguments_.includes(executorMutationError))).toBe(true);
         expectReconciliationLogsArePrivate();
+    });
+
+    it('preserves raw error diagnostics for ordinary logs outside reconciliation', () => {
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(emptyFn);
+        const ordinaryError = new Error('ordinary-error-diagnostic');
+
+        expect(() => new OrdinaryLoggedService().fail(ordinaryError)).toThrow('ordinary-error-diagnostic');
+        expect(consoleErrorSpy.mock.calls.some(arguments_ => arguments_.includes(ordinaryError))).toBe(true);
     });
 });

--- a/tests/consolidation-tests/src/scenarios/reconciliation-log-privacy.test.ts
+++ b/tests/consolidation-tests/src/scenarios/reconciliation-log-privacy.test.ts
@@ -120,9 +120,7 @@ describe('consolidation/reconciliation-log-privacy', () => {
         await expect(unconsolidationService.unconsolidateById(canonicalTransfer.id, testDb)).resolves.toBeUndefined();
         await expect(consolidationCoordinatorService.countExistingTransferIncomeDuplicateRepairCandidates()).resolves.toBe(0);
         expect(
-            consolidationScopeService.buildFromTransactions([
-                { id: 810000000001, operatedAt: new Date('2026-06-07T08:09:10.000Z') }
-            ])
+            consolidationScopeService.buildFromTransactions([{ id: 810000000001, operatedAt: new Date('2026-06-07T08:09:10.000Z') }])
         ).toEqual({
             operatedAtFrom: expect.any(Date),
             operatedAtTo: expect.any(Date),

--- a/tests/consolidation-tests/src/scenarios/reconciliation-log-privacy.test.ts
+++ b/tests/consolidation-tests/src/scenarios/reconciliation-log-privacy.test.ts
@@ -1,3 +1,4 @@
+import { consolidationScopeService } from '@budgie/consolidation';
 import { PRECISION, TransactionConsolidationTypeEnum } from '@budgie/contracts';
 import { Log } from '@budgie/logger';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -6,6 +7,7 @@ import { emptyFn, isError } from '@rnw-community/shared';
 
 import {
     consolidationAutoCandidateService,
+    consolidationCoordinatorService,
     consolidationRepairExecutorService,
     refundConsolidationService,
     refundPairRepository,
@@ -18,10 +20,13 @@ import {
 
 const reconciliationLogContexts = [
     'ConsolidationAutoCandidateService',
+    'ConsolidationCandidateService',
+    'ConsolidationCoordinatorService',
     'ConsolidationEligibilityService',
     'ConsolidationExecutorService',
     'ConsolidationMutationService',
     'ConsolidationRepairExecutorService',
+    'ConsolidationScopeService',
     'RefundConsolidationService',
     'UnconsolidationService'
 ];
@@ -37,7 +42,8 @@ const reconciliationSentinels = [
     '830000000001',
     'executor-mutation-error-sentinel',
     'repair-error-sentinel',
-    'refund-error-sentinel'
+    'refund-error-sentinel',
+    '2026-06-07T08:09:10.000Z'
 ];
 
 const capturedConsoleLines: string[] = [];
@@ -94,7 +100,7 @@ describe('consolidation/reconciliation-log-privacy', () => {
 
         const transferMcc = testQueryService.findMccByCode('4829');
         testSeedService.amountTransferPair(424242 * PRECISION, transferMcc.id);
-        const transferResult = await consolidationAutoCandidateService.process();
+        const transferResult = await consolidationCoordinatorService.consolidate();
         const account = testSeedService.account({ externalId: 'external-id-sentinel', iban: 'DE89370400440532013000' });
         const { refunds } = testSeedService.refundedExpense({
             accountId: account.id,
@@ -112,6 +118,16 @@ describe('consolidation/reconciliation-log-privacy', () => {
         await expect(consolidationRepairExecutorService.consolidateRefund(refundCandidates[0])).resolves.toBe(true);
         await expect(refundConsolidationService.findRefundableExpenses(refunds[0].id, 'reference-sentinel')).resolves.toEqual([]);
         await expect(unconsolidationService.unconsolidateById(canonicalTransfer.id, testDb)).resolves.toBeUndefined();
+        await expect(consolidationCoordinatorService.countExistingTransferIncomeDuplicateRepairCandidates()).resolves.toBe(0);
+        expect(
+            consolidationScopeService.buildFromTransactions([
+                { id: 810000000001, operatedAt: new Date('2026-06-07T08:09:10.000Z') }
+            ])
+        ).toEqual({
+            operatedAtFrom: expect.any(Date),
+            operatedAtTo: expect.any(Date),
+            transactionIds: [810000000001]
+        });
         for (const context of reconciliationLogContexts) {
             expect(capturedConsoleLines.join('\n')).toContain(`[${context}::`);
         }

--- a/tests/consolidation-tests/src/scenarios/reconciliation-log-privacy.test.ts
+++ b/tests/consolidation-tests/src/scenarios/reconciliation-log-privacy.test.ts
@@ -1,0 +1,69 @@
+import { PRECISION } from '@budgie/contracts';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { refundConsolidationService, testSeedService, transactionRepository } from '../harness/test-context';
+
+const reconciliationSentinels = [
+    'Raw Merchant Sentinel',
+    '424242000000',
+    'external-id-sentinel',
+    'DE89370400440532013000',
+    'reference-sentinel',
+    'raw-error-sentinel'
+];
+
+const capturedLogLines: string[] = [];
+
+const captureReconciliationLogLines = (): void => {
+    vi.spyOn(console, 'debug').mockImplementation((...arguments_) => {
+        capturedLogLines.push(arguments_.join(' '));
+    });
+    vi.spyOn(console, 'error').mockImplementation((...arguments_) => {
+        capturedLogLines.push(arguments_.slice(0, 2).join(' '));
+    });
+    vi.spyOn(console, 'log').mockImplementation((...arguments_) => {
+        capturedLogLines.push(arguments_.join(' '));
+    });
+};
+
+describe('consolidation/reconciliation-log-privacy', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        capturedLogLines.length = 0;
+    });
+
+    it('does not expose reconciliation data in successful or thrown lifecycle logs', async () => {
+        captureReconciliationLogLines();
+
+        const account = testSeedService.account({ externalId: 'external-id-sentinel' });
+        const { expense, refunds } = testSeedService.refundedExpense({
+            accountId: account.id,
+            expenseAmount: 424242 * PRECISION,
+            refundAmounts: [42 * PRECISION],
+            refundTitle: 'Raw Merchant Sentinel',
+            title: 'reference-sentinel DE89370400440532013000'
+        });
+
+        await refundConsolidationService.convertToRefund({
+            refundIncomeTransactionId: refunds[0].id,
+            expenseTransactionId: expense.id
+        });
+        await refundConsolidationService.findRefundableExpenses(-1, 'raw-error-sentinel');
+        vi.spyOn(transactionRepository, 'findByIds').mockRejectedValue(new Error('raw-error-sentinel'));
+
+        await expect(
+            refundConsolidationService.convertToRefund({
+                refundIncomeTransactionId: refunds[0].id,
+                expenseTransactionId: expense.id
+            })
+        ).rejects.toThrow('raw-error-sentinel');
+
+        expect(capturedLogLines).not.toEqual([]);
+        expect(capturedLogLines.join('\n')).not.toContain(reconciliationSentinels[0]);
+        expect(capturedLogLines.join('\n')).not.toContain(reconciliationSentinels[1]);
+        expect(capturedLogLines.join('\n')).not.toContain(reconciliationSentinels[2]);
+        expect(capturedLogLines.join('\n')).not.toContain(reconciliationSentinels[3]);
+        expect(capturedLogLines.join('\n')).not.toContain(reconciliationSentinels[4]);
+        expect(capturedLogLines.join('\n')).not.toContain(reconciliationSentinels[5]);
+    });
+});

--- a/tests/consolidation-tests/src/scenarios/reconciliation-log-privacy.test.ts
+++ b/tests/consolidation-tests/src/scenarios/reconciliation-log-privacy.test.ts
@@ -1,7 +1,24 @@
 import { PRECISION } from '@budgie/contracts';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { refundConsolidationService, testSeedService, transactionRepository } from '../harness/test-context';
+import { isError } from '@rnw-community/shared';
+
+import {
+    consolidationAutoCandidateService,
+    consolidationRepairExecutorService,
+    refundConsolidationService,
+    refundPairRepository,
+    testQueryService,
+    testSeedService,
+    transactionRepository
+} from '../harness/test-context';
+
+const reconciliationLogContexts = [
+    'ConsolidationExecutorService',
+    'ConsolidationMutationService',
+    'ConsolidationRepairExecutorService',
+    'RefundConsolidationService'
+];
 
 const reconciliationSentinels = [
     'Raw Merchant Sentinel',
@@ -9,61 +26,108 @@ const reconciliationSentinels = [
     'external-id-sentinel',
     'DE89370400440532013000',
     'reference-sentinel',
-    'raw-error-sentinel'
+    'executor-mutation-error-sentinel',
+    'repair-error-sentinel',
+    'refund-error-sentinel'
 ];
 
-const capturedLogLines: string[] = [];
+const capturedReconciliationLogLines: string[] = [];
+
+const serializeConsoleArgument = (value: unknown): string => {
+    if (isError(value)) {
+        return `${value.name}\n${value.message}\n${value.stack ?? ''}\n${JSON.stringify(Object.getOwnPropertyDescriptors(value))}`;
+    }
+
+    return JSON.stringify(value) ?? String(value);
+};
 
 const captureReconciliationLogLines = (): void => {
-    vi.spyOn(console, 'debug').mockImplementation((...arguments_) => {
-        capturedLogLines.push(arguments_.join(' '));
-    });
-    vi.spyOn(console, 'error').mockImplementation((...arguments_) => {
-        capturedLogLines.push(arguments_.slice(0, 2).join(' '));
-    });
-    vi.spyOn(console, 'log').mockImplementation((...arguments_) => {
-        capturedLogLines.push(arguments_.join(' '));
-    });
+    const captureArguments = (...arguments_: unknown[]): void => {
+        const serializedArguments = arguments_.map(serializeConsoleArgument).join('\n');
+
+        if (reconciliationLogContexts.some(context => serializedArguments.includes(`[${context}::`))) {
+            capturedReconciliationLogLines.push(serializedArguments);
+        }
+    };
+
+    vi.spyOn(console, 'debug').mockImplementation(captureArguments);
+    vi.spyOn(console, 'error').mockImplementation(captureArguments);
+    vi.spyOn(console, 'log').mockImplementation(captureArguments);
+};
+
+const expectReconciliationLogsArePrivate = (): void => {
+    const capturedOutput = capturedReconciliationLogLines.join('\n');
+
+    expect(capturedReconciliationLogLines).not.toEqual([]);
+    for (const context of reconciliationLogContexts) {
+        expect(capturedOutput).toContain(`[${context}::`);
+    }
+    for (const sentinel of reconciliationSentinels) {
+        expect(capturedOutput).not.toContain(sentinel);
+    }
 };
 
 describe('consolidation/reconciliation-log-privacy', () => {
     afterEach(() => {
         vi.restoreAllMocks();
-        capturedLogLines.length = 0;
+        capturedReconciliationLogLines.length = 0;
     });
 
-    it('does not expose reconciliation data in successful or thrown lifecycle logs', async () => {
+    it('does not expose reconciliation data in successful lifecycle logs from every reconciliation service', async () => {
         captureReconciliationLogLines();
 
-        const account = testSeedService.account({ externalId: 'external-id-sentinel' });
-        const { expense, refunds } = testSeedService.refundedExpense({
+        const transferMcc = testQueryService.findMccByCode('4829');
+        testSeedService.amountTransferPair(424242 * PRECISION, transferMcc.id);
+        const transferResult = await consolidationAutoCandidateService.process();
+        const account = testSeedService.account({ externalId: 'external-id-sentinel', iban: 'DE89370400440532013000' });
+        const { refunds } = testSeedService.refundedExpense({
             accountId: account.id,
             expenseAmount: 424242 * PRECISION,
+            externalIdPrefix: 'reference-sentinel',
             refundAmounts: [42 * PRECISION],
-            refundTitle: 'Raw Merchant Sentinel',
-            title: 'reference-sentinel DE89370400440532013000'
+            refundTitle: 'Raw Merchant Sentinel reference-sentinel DE89370400440532013000',
+            title: 'Raw Merchant Sentinel reference-sentinel DE89370400440532013000'
         });
+        const refundCandidates = await refundPairRepository.findCandidates();
 
-        await refundConsolidationService.convertToRefund({
-            refundIncomeTransactionId: refunds[0].id,
-            expenseTransactionId: expense.id
+        expect(transferResult.consolidated).toBe(1);
+        await expect(consolidationRepairExecutorService.consolidateRefund(refundCandidates[0])).resolves.toBe(true);
+        await expect(refundConsolidationService.findRefundableExpenses(refunds[0].id, 'reference-sentinel')).resolves.toEqual([]);
+        expectReconciliationLogsArePrivate();
+    });
+
+    it('does not expose thrown error payloads from every reconciliation service', async () => {
+        captureReconciliationLogLines();
+
+        const transferMcc = testQueryService.findMccByCode('4829');
+        testSeedService.amountTransferPair(424242 * PRECISION, transferMcc.id);
+        const executorMutationError = new Error('executor-mutation-error-sentinel');
+        const createTransactionSpy = vi.spyOn(transactionRepository, 'create').mockRejectedValue(executorMutationError);
+
+        await expect(consolidationAutoCandidateService.process()).rejects.toThrow('executor-mutation-error-sentinel');
+        createTransactionSpy.mockRestore();
+
+        const account = testSeedService.account({ externalId: 'external-id-sentinel', iban: 'DE89370400440532013000' });
+        testSeedService.refundedExpense({
+            accountId: account.id,
+            expenseAmount: 424242 * PRECISION,
+            externalIdPrefix: 'reference-sentinel',
+            refundAmounts: [42 * PRECISION],
+            refundTitle: 'Raw Merchant Sentinel reference-sentinel DE89370400440532013000',
+            title: 'Raw Merchant Sentinel reference-sentinel DE89370400440532013000'
         });
-        await refundConsolidationService.findRefundableExpenses(-1, 'raw-error-sentinel');
-        vi.spyOn(transactionRepository, 'findByIds').mockRejectedValue(new Error('raw-error-sentinel'));
+        const refundCandidates = await refundPairRepository.findCandidates();
+        const setConsolidationTypeSpy = vi
+            .spyOn(transactionRepository, 'setConsolidationType')
+            .mockRejectedValue(new Error('repair-error-sentinel'));
 
-        await expect(
-            refundConsolidationService.convertToRefund({
-                refundIncomeTransactionId: refunds[0].id,
-                expenseTransactionId: expense.id
-            })
-        ).rejects.toThrow('raw-error-sentinel');
+        await expect(consolidationRepairExecutorService.consolidateRefund(refundCandidates[0])).rejects.toThrow('repair-error-sentinel');
+        setConsolidationTypeSpy.mockRestore();
 
-        expect(capturedLogLines).not.toEqual([]);
-        expect(capturedLogLines.join('\n')).not.toContain(reconciliationSentinels[0]);
-        expect(capturedLogLines.join('\n')).not.toContain(reconciliationSentinels[1]);
-        expect(capturedLogLines.join('\n')).not.toContain(reconciliationSentinels[2]);
-        expect(capturedLogLines.join('\n')).not.toContain(reconciliationSentinels[3]);
-        expect(capturedLogLines.join('\n')).not.toContain(reconciliationSentinels[4]);
-        expect(capturedLogLines.join('\n')).not.toContain(reconciliationSentinels[5]);
+        vi.spyOn(refundPairRepository, 'findRefundableExpenseCandidates').mockRejectedValue(new Error('refund-error-sentinel'));
+
+        await expect(refundConsolidationService.findRefundableExpenses(-1, 'reference-sentinel')).rejects.toThrow('refund-error-sentinel');
+        expect(vi.mocked(console.error).mock.calls.some(arguments_ => arguments_.includes(executorMutationError))).toBe(true);
+        expectReconciliationLogsArePrivate();
     });
 });


### PR DESCRIPTION
## Root cause

Decorated reconciliation boundaries forwarded raw Error objects, scope values, and transaction IDs into lifecycle logs.

## Changes

- Added the typed, additive `Log.withoutErrorPayload` decorator.
- Redacted reconciliation boundaries in consolidation, app, and bank-repair flows.
- Added full recursive console-argument regression coverage.
- Added the AGENTS no-agent-plans rule.

## Behavior

Exact errors are still rethrown, and normal `Log` behavior is unchanged.

## Verification

- Focused consolidation tests: 3/3
- Focused bank-sync tests: 2/2
- Full consolidation + bank-sync suites
- Format, 13-package TypeScript, lint, deadcode, and CPD
- Diff clean

This is PR 1 of the series. It contains no migrations, provenance, HMAC, or lifecycle changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Privacy & Security**
  * Improved reconciliation and duplicate-repair logging to prevent sensitive transaction details and error payloads from appearing in logs.
  * Error logs now report generalized error types instead of raw messages.

* **Testing**
  * Added coverage verifying sensitive reconciliation data remains absent from application logs.
  * Confirmed ordinary logging continues to retain diagnostic error information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->