### PR TITLE
fix(app): reconcile Monobank batches before rate-limit wait

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -609,3 +609,5 @@ export const MyFormComponent = (props: Props) => { ... };
 ## Local Documentation
 
 The `docs/plans/` and `docs/superpowers/` folders contain design documents, specs, and implementation plans (including those produced by the superpowers brainstorming and writing-plans skills). These folders are gitignored for local-only usage — plans and specs are working documents that don't need version control.
+
+Agents must not create or commit plans or design docs unless explicitly requested by a human.

--- a/packages/app/src/sync/service/monobank-sync.service.ts
+++ b/packages/app/src/sync/service/monobank-sync.service.ts
@@ -25,6 +25,7 @@ import { mapBankAccountsToPreview } from '../util/map-bank-accounts-to-preview.u
 
 import { syncWorkloadService } from './sync-workload.service';
 import { transferConsolidationDrainerService } from './transfer-consolidation-drainer.service';
+import { transferConsolidationService } from './transfer-consolidation.service';
 
 import type { BankAccountInterface, BankSyncBatchResultInterface } from '@budgie/bank-sync';
 import type {
@@ -284,7 +285,7 @@ class AppMonobankSyncService {
         await microPause();
 
         const changedTransactions = await this.processFetchedTransactions(result.transactions, account.id);
-        this.enqueueConsolidationForChangedTransactions(changedTransactions);
+        await this.reconcileChangedTransactions(changedTransactions);
         await microPause();
 
         return result;
@@ -415,6 +416,21 @@ class AppMonobankSyncService {
 
     private shouldYieldToQueuedWork(): boolean {
         return syncWorkloadService.hasQueuedWork();
+    }
+
+    private async reconcileChangedTransactions(
+        changedTransactions: Array<Pick<TransactionEntityInterface, 'id' | 'operatedAt'>>
+    ): Promise<void> {
+        const consolidationScope = consolidationScopeService.buildFromTransactions(changedTransactions);
+        if (!isDefined(consolidationScope)) {
+            return;
+        }
+
+        try {
+            await transferConsolidationService.consolidate(consolidationScope);
+        } finally {
+            this.enqueueConsolidationForChangedTransactions(changedTransactions);
+        }
     }
 
     private enqueueConsolidationForChangedTransactions(

--- a/tests/bank-sync-tests/src/scenarios/consolidation/atm-cash-withdrawal.test.ts
+++ b/tests/bank-sync-tests/src/scenarios/consolidation/atm-cash-withdrawal.test.ts
@@ -94,7 +94,7 @@ describe('consolidation/atm-cash-withdrawal', () => {
         await monobankSyncService.sync();
         const result = await transferConsolidationService.consolidate();
 
-        expect(result.consolidated).toBe(1);
+        expect(result.consolidated).toBe(0);
 
         const [canonical] = fetchCanonicalsOfType(TransactionConsolidationTypeEnum.ATM_CASH_WITHDRAWAL);
         expect(canonical.fromAccountId).toBe(bankAccount.id);

--- a/tests/bank-sync-tests/src/scenarios/consolidation/monobank-immediate-reconciliation.test.ts
+++ b/tests/bank-sync-tests/src/scenarios/consolidation/monobank-immediate-reconciliation.test.ts
@@ -1,0 +1,73 @@
+import { monobankSyncService } from '@app/sync/service/monobank-sync.service';
+import { syncWorkloadService } from '@app/sync/service/sync-workload.service';
+import { AccountTypeEnum, TransactionConsolidationTypeEnum, TransactionEntryTypeEnum } from '@budgie/contracts';
+import { describe, expect, it, vi } from 'vitest';
+
+import { emptyFn, isDefined } from '@rnw-community/shared';
+
+import { buildMonobank, fetchCanonicalsOfType, fetchExpenseEntries, monobankStub, seed, setupMonobankFixture } from '../../harness';
+
+describe('consolidation/monobank-immediate-reconciliation', () => {
+    it('reconciles an ATM withdrawal before entering its rate-limit wait', async () => {
+        const { account: bankAccount } = setupMonobankFixture();
+        const cashAccount = seed.account({ title: 'Cash', type: AccountTypeEnum.CASH, instrumentId: bankAccount.instrumentId });
+        let releaseRateLimitWait: () => void = emptyFn;
+        const waitForQueuedUserWorkSpy = vi.spyOn(syncWorkloadService, 'waitForQueuedUserWork');
+        let syncPromise: Promise<unknown> = Promise.resolve();
+
+        try {
+            const rateLimitWaitEntered = new Promise<void>(resolve => {
+                waitForQueuedUserWorkSpy.mockImplementation(async () => {
+                    resolve();
+
+                    return new Promise<boolean>(resolveRateLimitWait => {
+                        releaseRateLimitWait = () => {
+                            resolveRateLimitWait(false);
+                        };
+                    });
+                });
+            });
+
+            monobankStub.statement([
+                buildMonobank.transaction({
+                    id: 'privacy-safe-atm-001',
+                    amount: -40800,
+                    commissionRate: -800,
+                    hold: false,
+                    mcc: 6011,
+                    operationAmount: -40800,
+                    time: Math.floor(new Date('2026-01-15T12:00:00.000Z').getTime() / 1000)
+                })
+            ]);
+
+            syncPromise = monobankSyncService.sync();
+            await Promise.race([
+                rateLimitWaitEntered,
+                syncPromise.then(() => {
+                    throw new Error('Monobank sync completed before entering its rate-limit wait');
+                })
+            ]);
+
+            const canonicals = fetchCanonicalsOfType(TransactionConsolidationTypeEnum.ATM_CASH_WITHDRAWAL);
+
+            expect(canonicals).toHaveLength(1);
+            const [canonical] = canonicals;
+            if (!isDefined(canonical)) {
+                return;
+            }
+
+            expect(canonical.fromAccountId).toBe(bankAccount.id);
+            expect(canonical.toAccountId).toBe(cashAccount.id);
+            expect((await fetchExpenseEntries(canonical.id)).find(entry => entry.type === TransactionEntryTypeEnum.FEE)?.amount).toBe(
+                8000000
+            );
+        } finally {
+            releaseRateLimitWait();
+            try {
+                await syncPromise;
+            } finally {
+                waitForQueuedUserWorkSpy.mockRestore();
+            }
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- Scope-consolidate persisted Monobank batches before the 60-second rate-limit wait.
- Keep the existing drainer as the fallback path.

## Root cause

Persisted Monobank batches were not reconciled until the queued-work drainer ran after the rate-limit wait.

## Product impact

ATM cash withdrawal fee entries remain fees, and a later manual consolidation is a no-op. This PR includes no broader repair or refund work.

## Tests

- Focused serial bank-sync suite: 4 files / 11 tests.
- yarn format, yarn ts, yarn lint, yarn deadcode, yarn cpd.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Monobank transaction sync now reconciles newly changed transactions immediately.
  * Consolidation processing continues to be scheduled even when an earlier reconciliation step fails.
  * ATM withdrawal fees are preserved correctly during consolidation.

* **Tests**
  * Added coverage confirming immediate ATM withdrawal reconciliation and associated fee handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->