### PR TITLE
chore(consolidation): deterministic FEE-entry selection in fee-amount subquery

### DIFF
--- a/packages/consolidation/src/query/repository/sql-factory/refund-ranked-candidate-sql.factory.ts
+++ b/packages/consolidation/src/query/repository/sql-factory/refund-ranked-candidate-sql.factory.ts
@@ -63,6 +63,7 @@ const buildExpenseEntriesSql = (
                     AND expense_fee_entry.original_transaction_id IS NULL
                     AND expense_fee_entry.type = '${TransactionEntryTypeEnum.FEE}'
                     AND expense_fee_entry.amount > 0
+                ORDER BY expense_fee_entry.id
                 LIMIT 1
             ) AS feeAmount
         FROM transactions expense_tx INDEXED BY transactions_visible_type_operated_idx


### PR DESCRIPTION
## Summary

The correlated `feeAmount` subquery in `buildExpenseEntriesSql` (`packages/consolidation/src/query/repository/sql-factory/refund-ranked-candidate-sql.factory.ts`) selected the expense's FEE entry with `LIMIT 1` but no `ORDER BY`. The bank-sync mapper currently emits at most one live FEE entry per expense, so this is safe today, but nothing at the DB level enforces that — with more than one live FEE entry, selection would be non-deterministic.

This adds `ORDER BY expense_fee_entry.id` before `LIMIT 1` so the selection is deterministic at the DB level regardless of mapper behavior.

Fixes #607

## Test plan

- [x] `yarn workspace @budgie-at/consolidation-tests test` — 61 passed (24 test files)
- [x] `yarn workspace @budgie/consolidation ts` — clean, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when selecting fee amounts for expense entries by ensuring the same matching fee record is chosen each time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->