### PR TITLE
chore(consolidation): cover casing variants of PrivatBank reversal title prefixes

### DIFF
--- a/packages/consolidation/src/query/repository/sql-factory/refund-ranked-candidate-sql.factory.ts
+++ b/packages/consolidation/src/query/repository/sql-factory/refund-ranked-candidate-sql.factory.ts
@@ -6,8 +6,12 @@ import type { ConsolidationScanScopeInterface } from '@budgie/contracts';
 
 const MANUAL_REVIEW_TIME_WINDOW_SECONDS = 7_776_000;
 
-const REJECTED_PAYMENT_PRINCIPAL_TITLE_PREFIX = 'Повернення коштів за забракованим платежем';
-const REJECTED_PAYMENT_FEE_TITLE_PREFIX = 'Повернення комісій';
+const REJECTED_PAYMENT_PRINCIPAL_TITLE_PREFIXES = [
+    'Повернення коштів за забракованим платежем',
+    'ПОВЕРНЕННЯ КОШТІВ ЗА ЗАБРАКОВАНИМ ПЛАТЕЖЕМ'
+] as const;
+
+const REJECTED_PAYMENT_FEE_TITLE_PREFIXES = ['Повернення комісій', 'ПОВЕРНЕННЯ КОМІСІЙ'] as const;
 
 const AUTO_TITLE_PREFIXES = [
     'Скасування. ',
@@ -37,6 +41,9 @@ const buildStripPrefixesSql = (seedExpression: string, prefixes: readonly string
 
 const buildStripCommaSuffixSql = (seedExpression: string): string =>
     `TRIM(CASE WHEN INSTR(${seedExpression}, ',') > 0 THEN SUBSTR(${seedExpression}, 1, INSTR(${seedExpression}, ',') - 1) ELSE ${seedExpression} END)`;
+
+const buildPrefixLikeSql = (column: string, prefixes: readonly string[]): string =>
+    `(${prefixes.map(prefix => `${column} LIKE '${prefix}%'`).join(' OR ')})`;
 
 const buildExpenseEntriesSql = (
     autoTitle: string,
@@ -132,11 +139,11 @@ const buildCompatiblePairsSql = (): string => `
                     AND inc.rawNormTitle != exp.rawNormTitle AND inc.operatedAt > exp.operatedAt
                     AND (inc.operatedAt - exp.operatedAt) <= ${REFUND_TIME_WINDOW_SECONDS}
                 THEN 'AUTO_REFUND_LOCALIZED_REFUND_TITLE'
-                WHEN inc.rawNormTitle LIKE '${REJECTED_PAYMENT_PRINCIPAL_TITLE_PREFIX}%' AND inc.accountId = exp.accountId
+                WHEN ${buildPrefixLikeSql('inc.rawNormTitle', REJECTED_PAYMENT_PRINCIPAL_TITLE_PREFIXES)} AND inc.accountId = exp.accountId
                     AND inc.amount = exp.amount AND inc.operatedAt > exp.operatedAt
                     AND (inc.operatedAt - exp.operatedAt) <= ${REFUND_TIME_WINDOW_SECONDS}
                 THEN 'AUTO_REFUND_REJECTED_PAYMENT_PRINCIPAL_TITLE'
-                WHEN inc.rawNormTitle LIKE '${REJECTED_PAYMENT_FEE_TITLE_PREFIX}%' AND inc.accountId = exp.accountId
+                WHEN ${buildPrefixLikeSql('inc.rawNormTitle', REJECTED_PAYMENT_FEE_TITLE_PREFIXES)} AND inc.accountId = exp.accountId
                     AND exp.feeAmount IS NOT NULL AND inc.amount = exp.feeAmount
                     AND inc.operatedAt > exp.operatedAt
                     AND (inc.operatedAt - exp.operatedAt) <= ${REFUND_TIME_WINDOW_SECONDS}
@@ -152,8 +159,8 @@ const buildCompatiblePairsSql = (): string => `
             CASE
                 WHEN inc.rawNormTitle = exp.rawNormTitle THEN 'exact-title'
                 WHEN inc.autoNormTitle = exp.autoNormTitle THEN 'localized-refund-title'
-                WHEN inc.rawNormTitle LIKE '${REJECTED_PAYMENT_PRINCIPAL_TITLE_PREFIX}%' THEN 'rejected-payment-principal-title'
-                WHEN inc.rawNormTitle LIKE '${REJECTED_PAYMENT_FEE_TITLE_PREFIX}%' THEN 'rejected-payment-fee-title'
+                WHEN ${buildPrefixLikeSql('inc.rawNormTitle', REJECTED_PAYMENT_PRINCIPAL_TITLE_PREFIXES)} THEN 'rejected-payment-principal-title'
+                WHEN ${buildPrefixLikeSql('inc.rawNormTitle', REJECTED_PAYMENT_FEE_TITLE_PREFIXES)} THEN 'rejected-payment-fee-title'
                 ELSE 'prefix-title-mcc'
             END AS matchType
         FROM income_entries inc

--- a/tests/consolidation-tests/src/harness/rejected-payment-fixture.ts
+++ b/tests/consolidation-tests/src/harness/rejected-payment-fixture.ts
@@ -4,6 +4,7 @@ const REJECTED_PAYMENT_AMOUNT_UAH = 41_003;
 
 export const REJECTED_PAYMENT_PRINCIPAL_TITLE =
     'Повернення коштів за забракованим платежем від 23.06.2026 р. на суму 41003.00 UAH на адресу Yehorov Ihor Vitaliiovych (ID платежу повернення 586959892)';
+export const REJECTED_PAYMENT_PRINCIPAL_TITLE_ALL_CAPS = REJECTED_PAYMENT_PRINCIPAL_TITLE.toUpperCase();
 export const REJECTED_PAYMENT_EXPENSE_AMOUNT = REJECTED_PAYMENT_AMOUNT_UAH * PRECISION;
 export const REJECTED_PAYMENT_FEE_TITLE = 'Повернення комісій за використання кредитних коштів';
 export const REJECTED_PAYMENT_FEE_AMOUNT = 820_060_000;

--- a/tests/consolidation-tests/src/scenarios/refund-pair-rejected-payment.test.ts
+++ b/tests/consolidation-tests/src/scenarios/refund-pair-rejected-payment.test.ts
@@ -63,33 +63,27 @@ const expectBothRefundsConsolidatedToExpense = (expenseId: number, refunds: Tran
     ]);
 };
 
+const runRejectedPaymentPrincipalRefundScenarioAndAssert = async (refundTitle: string) => {
+    const { consolidated, expense, refunds } = await runRefundScenario({
+        title: 'FOP TESTOVYI PRODUCTS',
+        refundTitle,
+        expenseAmount: REJECTED_PAYMENT_EXPENSE_AMOUNT,
+        refundAmounts: [REJECTED_PAYMENT_EXPENSE_AMOUNT],
+        refundDelaySeconds: 4_380
+    });
+
+    expect(consolidated).toBe(1);
+    expect(testQueryService.fetchTransactionById(expense.id).consolidationType).toBe(TransactionConsolidationTypeEnum.REFUND);
+    expect(testQueryService.fetchTransactionById(refunds[0].id).consolidationParentTransactionId).toBe(expense.id);
+};
+
 describe('consolidation/refund-pair-rejected-payment', () => {
     it('auto-consolidates a PrivatBank rejected-payment principal refund matched by title prefix', async () => {
-        const { consolidated, expense, refunds } = await runRefundScenario({
-            title: 'FOP TESTOVYI PRODUCTS',
-            refundTitle: REJECTED_PAYMENT_PRINCIPAL_TITLE,
-            expenseAmount: REJECTED_PAYMENT_EXPENSE_AMOUNT,
-            refundAmounts: [REJECTED_PAYMENT_EXPENSE_AMOUNT],
-            refundDelaySeconds: 4_380
-        });
-
-        expect(consolidated).toBe(1);
-        expect(testQueryService.fetchTransactionById(expense.id).consolidationType).toBe(TransactionConsolidationTypeEnum.REFUND);
-        expect(testQueryService.fetchTransactionById(refunds[0].id).consolidationParentTransactionId).toBe(expense.id);
+        await runRejectedPaymentPrincipalRefundScenarioAndAssert(REJECTED_PAYMENT_PRINCIPAL_TITLE);
     });
 
     it('auto-consolidates an ALL-CAPS PrivatBank rejected-payment principal refund matched by title prefix', async () => {
-        const { consolidated, expense, refunds } = await runRefundScenario({
-            title: 'FOP TESTOVYI PRODUCTS',
-            refundTitle: REJECTED_PAYMENT_PRINCIPAL_TITLE_ALL_CAPS,
-            expenseAmount: REJECTED_PAYMENT_EXPENSE_AMOUNT,
-            refundAmounts: [REJECTED_PAYMENT_EXPENSE_AMOUNT],
-            refundDelaySeconds: 4_380
-        });
-
-        expect(consolidated).toBe(1);
-        expect(testQueryService.fetchTransactionById(expense.id).consolidationType).toBe(TransactionConsolidationTypeEnum.REFUND);
-        expect(testQueryService.fetchTransactionById(refunds[0].id).consolidationParentTransactionId).toBe(expense.id);
+        await runRejectedPaymentPrincipalRefundScenarioAndAssert(REJECTED_PAYMENT_PRINCIPAL_TITLE_ALL_CAPS);
     });
 
     it('does not consolidate a same-title retry expense that occurs after the refund income', async () => {

--- a/tests/consolidation-tests/src/scenarios/refund-pair-rejected-payment.test.ts
+++ b/tests/consolidation-tests/src/scenarios/refund-pair-rejected-payment.test.ts
@@ -6,7 +6,8 @@ import {
     REJECTED_PAYMENT_FEE_AMOUNT,
     REJECTED_PAYMENT_FEE_REFUND_DELAY_SECONDS,
     REJECTED_PAYMENT_FEE_TITLE,
-    REJECTED_PAYMENT_PRINCIPAL_TITLE
+    REJECTED_PAYMENT_PRINCIPAL_TITLE,
+    REJECTED_PAYMENT_PRINCIPAL_TITLE_ALL_CAPS
 } from '../harness/rejected-payment-fixture';
 import { runConsolidation } from '../harness/run-consolidation';
 import { runRefundScenario } from '../harness/run-refund-scenario';
@@ -67,6 +68,20 @@ describe('consolidation/refund-pair-rejected-payment', () => {
         const { consolidated, expense, refunds } = await runRefundScenario({
             title: 'FOP TESTOVYI PRODUCTS',
             refundTitle: REJECTED_PAYMENT_PRINCIPAL_TITLE,
+            expenseAmount: REJECTED_PAYMENT_EXPENSE_AMOUNT,
+            refundAmounts: [REJECTED_PAYMENT_EXPENSE_AMOUNT],
+            refundDelaySeconds: 4_380
+        });
+
+        expect(consolidated).toBe(1);
+        expect(testQueryService.fetchTransactionById(expense.id).consolidationType).toBe(TransactionConsolidationTypeEnum.REFUND);
+        expect(testQueryService.fetchTransactionById(refunds[0].id).consolidationParentTransactionId).toBe(expense.id);
+    });
+
+    it('auto-consolidates an ALL-CAPS PrivatBank rejected-payment principal refund matched by title prefix', async () => {
+        const { consolidated, expense, refunds } = await runRefundScenario({
+            title: 'FOP TESTOVYI PRODUCTS',
+            refundTitle: REJECTED_PAYMENT_PRINCIPAL_TITLE_ALL_CAPS,
             expenseAmount: REJECTED_PAYMENT_EXPENSE_AMOUNT,
             refundAmounts: [REJECTED_PAYMENT_EXPENSE_AMOUNT],
             refundDelaySeconds: 4_380


### PR DESCRIPTION
## Summary

SQLite's `UPPER()` is ASCII-only, so it never folds Cyrillic casing. `rawNormTitle` (`UPPER(TRIM(title))`) therefore leaves Cyrillic title casing untouched, and each PrivatBank rejected-payment reversal title casing variant must be registered as its own `LIKE` literal — the same pattern already used for `AUTO_TITLE_PREFIXES` (both `'ПОВЕРНЕННЯ КОШТІВ, '` and `'Повернення коштів, '` are listed).

`REJECTED_PAYMENT_PRINCIPAL_TITLE_PREFIX` and `REJECTED_PAYMENT_FEE_TITLE_PREFIX` were title-case-only string literals used via `LIKE '<prefix>%'` in two places each (the `confidenceBucket` CASE and the `matchType` CASE inside `buildCompatiblePairsSql`). If PrivatBank ever emits an ALL-CAPS variant of these prefixes, those reversals would silently stop auto-matching.

## Changes

- Converted both constants into `readonly` arrays of casing variants (title-case + ALL-CAPS): `REJECTED_PAYMENT_PRINCIPAL_TITLE_PREFIXES`, `REJECTED_PAYMENT_FEE_TITLE_PREFIXES`.
- Added `buildPrefixLikeSql(column, prefixes)`, a small helper producing an OR'd `LIKE` condition (e.g. `(col LIKE 'a%' OR col LIKE 'b%')`), used in both the `confidenceBucket` and `matchType` CASE expressions, keeping the two aligned.
- Added a regression test in `tests/consolidation-tests/src/scenarios/refund-pair-rejected-payment.test.ts` asserting an ALL-CAPS-prefixed refund title auto-consolidates the same as the title-case one, using a new `REJECTED_PAYMENT_PRINCIPAL_TITLE_ALL_CAPS` fixture constant.

Fixes #608

## Test plan

- [x] Added the regression test first, confirmed it failed against the unfixed factory (`consolidated` was `0` instead of `1`)
- [x] Implemented the fix, confirmed the same test passes
- [x] `yarn workspace @budgie-at/consolidation-tests test` — 24 files / 62 tests passed
- [x] `yarn workspace @budgie/consolidation ts` — clean
- [x] `yarn workspace @budgie-at/consolidation-tests ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic refund matching for rejected-payment transactions with different title capitalization and supported prefixes.
  * Ensured matching and classification remain consistent across rejected-payment principal and fee transactions.

* **Tests**
  * Added coverage confirming refunds with all-caps rejected-payment titles are correctly consolidated and linked to the corresponding expense.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->