### PR TITLE
fix(consolidation): route overflow shared-expense refunds to review instead of dropping the group

### DIFF
--- a/packages/consolidation/src/query/repository/sql-factory/refund-ranked-candidate-sql.factory.ts
+++ b/packages/consolidation/src/query/repository/sql-factory/refund-ranked-candidate-sql.factory.ts
@@ -206,9 +206,32 @@ const buildRankedCandidatesSql = (): string => `
                         AND expenseRank = 1
                     THEN 1 ELSE 0
                 END
-            ) OVER (PARTITION BY refundTxId) AS localizedExactAmountMatchCount
+            ) OVER (PARTITION BY refundTxId) AS localizedExactAmountMatchCount,
+            SUM(CASE WHEN refundRank = 1 THEN refundAmount ELSE 0 END) OVER (
+                PARTITION BY expenseTxId, accountId, confidenceBucket, matchType, expenseAmount
+                ORDER BY expenseRank
+                ROWS UNBOUNDED PRECEDING
+            ) AS expenseRunningRefundTotal
         FROM ranked_pairs
     )
+`;
+
+const buildAutoAcceptanceGateSql = (): string => `
+        confidenceBucket IN (
+            'AUTO_REFUND_EXACT_TITLE',
+            'AUTO_REFUND_LOCALIZED_REFUND_TITLE',
+            'AUTO_REFUND_REJECTED_PAYMENT_PRINCIPAL_TITLE',
+            'AUTO_REFUND_REJECTED_PAYMENT_FEE_TITLE'
+        )
+        AND (
+            refundCandidateCount = 1
+            OR (
+                confidenceBucket = 'AUTO_REFUND_LOCALIZED_REFUND_TITLE'
+                AND expenseAmount = refundAmount
+                AND expenseRank = 1
+                AND localizedExactAmountMatchCount = 1
+            )
+        )
 `;
 
 const buildRankedCandidateSql = (scope: ConsolidationScanScopeInterface | null): string => {
@@ -239,21 +262,8 @@ export const REFUND_AUTO_CANDIDATES_SQL = (scope: ConsolidationScanScopeInterfac
         GROUP_CONCAT(refundTxId, ',' ORDER BY refundTxId) AS refundIncomeTransactionIds
     FROM (${buildRankedCandidateSql(scope)})
     WHERE refundRank = 1
-        AND confidenceBucket IN (
-            'AUTO_REFUND_EXACT_TITLE',
-            'AUTO_REFUND_LOCALIZED_REFUND_TITLE',
-            'AUTO_REFUND_REJECTED_PAYMENT_PRINCIPAL_TITLE',
-            'AUTO_REFUND_REJECTED_PAYMENT_FEE_TITLE'
-        )
-        AND (
-            refundCandidateCount = 1
-            OR (
-                confidenceBucket = 'AUTO_REFUND_LOCALIZED_REFUND_TITLE'
-                AND expenseAmount = refundAmount
-                AND expenseRank = 1
-                AND localizedExactAmountMatchCount = 1
-            )
-        )
+        AND ${buildAutoAcceptanceGateSql()}
+        AND expenseRunningRefundTotal <= expenseAmount
     GROUP BY confidenceBucket, matchType, expenseTxId, accountId, expenseAmount
     HAVING SUM(refundAmount) <= expenseAmount
 `;
@@ -277,6 +287,10 @@ export const REFUND_REVIEW_CANDIDATES_SQL = `
                     AND expenseRank = 1
                     AND localizedExactAmountMatchCount = 1
                 )
+            )
+            OR (
+                ${buildAutoAcceptanceGateSql()}
+                AND expenseRunningRefundTotal > expenseAmount
             )
         )
     GROUP BY confidenceBucket, matchType, expenseTxId, accountId, expenseAmount

--- a/tests/consolidation-tests/src/scenarios/refund-pair-shared-expense.test.ts
+++ b/tests/consolidation-tests/src/scenarios/refund-pair-shared-expense.test.ts
@@ -1,0 +1,55 @@
+import { PRECISION, TransactionConsolidationTypeEnum } from '@budgie/contracts';
+import { describe, expect, it } from 'vitest';
+
+import { runConsolidation } from '../harness/run-consolidation';
+import { refundPairRepository, testQueryService, testSeedService } from '../harness/test-context';
+
+const SHARED_EXPENSE_AMOUNT = 100 * PRECISION;
+const SHARED_TITLE = 'SHARED MERCHANT #42';
+
+describe('consolidation/refund-pair-shared-expense', () => {
+    it('auto-consolidates the best-ranked refund and routes the overflow refund to review instead of dropping the group', async () => {
+        const account = testSeedService.account({ externalId: 'mono-card' });
+        const { expense, refunds } = testSeedService.refundedExpense({
+            accountId: account.id,
+            expenseAmount: SHARED_EXPENSE_AMOUNT,
+            refundAmounts: [SHARED_EXPENSE_AMOUNT, SHARED_EXPENSE_AMOUNT],
+            title: SHARED_TITLE
+        });
+
+        const [winner, loser] = refunds;
+
+        const autoCandidates = await refundPairRepository.findCandidates();
+        const reviewCandidates = await refundPairRepository.findReviewCandidates();
+
+        expect(autoCandidates).toEqual([
+            {
+                confidenceBucket: 'AUTO_REFUND_EXACT_TITLE',
+                matchType: 'exact-title',
+                accountId: account.id,
+                expenseTransactionId: expense.id,
+                expenseEntryAmount: SHARED_EXPENSE_AMOUNT,
+                refundIncomeTransactionIds: [winner.id],
+                refundsTotal: SHARED_EXPENSE_AMOUNT
+            }
+        ]);
+        expect(reviewCandidates).toEqual([
+            {
+                confidenceBucket: 'AUTO_REFUND_EXACT_TITLE',
+                matchType: 'exact-title',
+                accountId: account.id,
+                expenseTransactionId: expense.id,
+                expenseEntryAmount: SHARED_EXPENSE_AMOUNT,
+                refundIncomeTransactionIds: [loser.id],
+                refundsTotal: SHARED_EXPENSE_AMOUNT
+            }
+        ]);
+
+        const result = await runConsolidation();
+
+        expect(result.consolidated).toBe(1);
+        expect(testQueryService.fetchTransactionById(expense.id).consolidationType).toBe(TransactionConsolidationTypeEnum.REFUND);
+        expect(testQueryService.fetchTransactionById(winner.id).consolidationParentTransactionId).toBe(expense.id);
+        expect(testQueryService.fetchTransactionById(loser.id).consolidationParentTransactionId).toBeNull();
+    });
+});


### PR DESCRIPTION
## Root cause

In `REFUND_AUTO_CANDIDATES_SQL` the acceptance branch `refundCandidateCount = 1` fires **per refund** with no expense-side coordination. When two refund incomes each have the same exact-amount expense as their *only* candidate, both are accepted, both land in the same auto `GROUP BY` group `(confidenceBucket, matchType, expenseTxId, accountId, expenseAmount)`, and the `HAVING SUM(refundAmount) <= expenseAmount` guard silently drops the **whole** group. The legitimate winner is then neither auto-consolidated nor surfaced for manual review — it just vanishes.

## Fix

`packages/consolidation/src/query/repository/sql-factory/refund-ranked-candidate-sql.factory.ts`:

- **Running total window** — `ranked_candidates` now computes `expenseRunningRefundTotal`: `SUM(CASE WHEN refundRank = 1 THEN refundAmount ELSE 0 END) OVER (PARTITION BY expenseTxId, accountId, confidenceBucket, matchType, expenseAmount ORDER BY expenseRank ROWS UNBOUNDED PRECEDING)`. Only primary (`refundRank = 1`) refunds — the ones actually competing to consolidate onto that expense — accumulate against its capacity, ordered by `expenseRank` so the best-ranked refund wins the room first.
- **Auto path** — additionally requires `expenseRunningRefundTotal <= expenseAmount`, so only the best-ranked refund(s) that fit are auto-accepted.
- **Review path** — gains a fallback branch: refunds that pass an auto-acceptance gate but overflow the running-total bound (`expenseRunningRefundTotal > expenseAmount`) now surface for manual review instead of disappearing.
- The shared acceptance predicate is extracted into `buildAutoAcceptanceGateSql()` consumed by both paths (no duplicated SQL), and the defensive `HAVING` invariant is kept.

Legitimate multiple partial refunds (e.g. 30 + 30 against a 100 expense) still auto-consolidate together, because their cumulative running total stays within the expense amount.

## Tests

- New scenario `tests/consolidation-tests/src/scenarios/refund-pair-shared-expense.test.ts`: two refund incomes competing for one exact-amount expense where the loser has no other candidate. Asserts the winner appears as the sole auto candidate and auto-consolidates, while the loser surfaces as a review candidate (not silently dropped) and stays unconsolidated. Confirmed failing on `main` before the fix.
- Full suite green: `@budgie-at/consolidation-tests` 62/62 pass; `@budgie/consolidation` and `@budgie-at/consolidation-tests` typecheck clean; consolidation lint clean.

Fixes #604

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved refund matching for expenses with multiple refunds.
  - Automatically consolidates eligible refunds only while the combined refund amount remains within the expense total.
  - Routes refunds that exceed the expense amount to review instead of auto-consolidating them.

- **Tests**
  - Added coverage validating shared-expense refund handling, including successful consolidation and review routing for overflow refunds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->