### PR TITLE
fix(consolidation): cross-bucket priority can hide a unique localized exact-amount refund match

### DIFF
--- a/packages/consolidation/src/query/repository/sql-factory/refund-ranked-candidate-sql.factory.ts
+++ b/packages/consolidation/src/query/repository/sql-factory/refund-ranked-candidate-sql.factory.ts
@@ -238,15 +238,14 @@ export const REFUND_AUTO_CANDIDATES_SQL = (scope: ConsolidationScanScopeInterfac
         SUM(refundAmount) AS refundsTotal,
         GROUP_CONCAT(refundTxId, ',' ORDER BY refundTxId) AS refundIncomeTransactionIds
     FROM (${buildRankedCandidateSql(scope)})
-    WHERE refundRank = 1
-        AND confidenceBucket IN (
+    WHERE confidenceBucket IN (
             'AUTO_REFUND_EXACT_TITLE',
             'AUTO_REFUND_LOCALIZED_REFUND_TITLE',
             'AUTO_REFUND_REJECTED_PAYMENT_PRINCIPAL_TITLE',
             'AUTO_REFUND_REJECTED_PAYMENT_FEE_TITLE'
         )
         AND (
-            refundCandidateCount = 1
+            (refundRank = 1 AND refundCandidateCount = 1)
             OR (
                 confidenceBucket = 'AUTO_REFUND_LOCALIZED_REFUND_TITLE'
                 AND expenseAmount = refundAmount

--- a/tests/consolidation-tests/src/scenarios/refund-pair-cross-bucket-localized-exact-amount.test.ts
+++ b/tests/consolidation-tests/src/scenarios/refund-pair-cross-bucket-localized-exact-amount.test.ts
@@ -1,0 +1,61 @@
+import { PRECISION, TransactionConsolidationTypeEnum } from '@budgie/contracts';
+import { describe, expect, it } from 'vitest';
+
+import { runConsolidation } from '../harness/run-consolidation';
+import { refundPairRepository, testQueryService, testSeedService } from '../harness/test-context';
+
+const REFUND_TITLE = 'Скасування. Netflix';
+const LOCALIZED_EXPENSE_TITLE = 'Netflix';
+const CONTESTED_AMOUNT = 700 * PRECISION;
+const LOCALIZED_AMOUNT = 500 * PRECISION;
+const CONTESTED_EXPENSE_OPERATED_AT = new Date(2026, 0, 10, 8, 0, 0);
+const LOCALIZED_EXPENSE_OPERATED_AT = new Date(2026, 0, 12, 8, 0, 0);
+const ONE_DAY_SECONDS = 24 * 60 * 60;
+
+describe('consolidation/refund-pair-cross-bucket-localized-exact-amount', () => {
+    it('recovers a unique localized exact-amount refund hidden behind a higher-priority exact-title collision', async () => {
+        const account = testSeedService.account({ externalId: 'mono-card' });
+
+        const { expense: exactTitleExpense } = testSeedService.refundedExpense({
+            accountId: account.id,
+            title: REFUND_TITLE,
+            refundTitle: REFUND_TITLE,
+            expenseAmount: CONTESTED_AMOUNT,
+            refundAmounts: [CONTESTED_AMOUNT],
+            expenseOperatedAt: CONTESTED_EXPENSE_OPERATED_AT,
+            refundDelaySeconds: ONE_DAY_SECONDS,
+            externalIdPrefix: 'exact-title'
+        });
+
+        const { expense: localizedExpense, refunds } = testSeedService.refundedExpense({
+            accountId: account.id,
+            title: LOCALIZED_EXPENSE_TITLE,
+            refundTitle: REFUND_TITLE,
+            expenseAmount: LOCALIZED_AMOUNT,
+            refundAmounts: [LOCALIZED_AMOUNT],
+            expenseOperatedAt: LOCALIZED_EXPENSE_OPERATED_AT,
+            refundDelaySeconds: ONE_DAY_SECONDS,
+            externalIdPrefix: 'localized'
+        });
+
+        const refund = refunds[0];
+
+        const autoCandidates = await refundPairRepository.findCandidates();
+        const reviewCandidates = await refundPairRepository.findReviewCandidates();
+
+        expect(autoCandidates).toContainEqual(
+            expect.objectContaining({
+                confidenceBucket: 'AUTO_REFUND_LOCALIZED_REFUND_TITLE',
+                expenseTransactionId: localizedExpense.id,
+                refundIncomeTransactionIds: [refund.id]
+            })
+        );
+        expect(autoCandidates.some(candidate => candidate.expenseTransactionId === exactTitleExpense.id && candidate.refundIncomeTransactionIds.includes(refund.id))).toBe(false);
+        expect(reviewCandidates.some(candidate => candidate.refundIncomeTransactionIds.includes(refund.id))).toBe(false);
+
+        await runConsolidation();
+
+        expect(testQueryService.fetchTransactionById(refund.id).consolidationParentTransactionId).toBe(localizedExpense.id);
+        expect(testQueryService.fetchTransactionById(localizedExpense.id).consolidationType).toBe(TransactionConsolidationTypeEnum.REFUND);
+    });
+});

--- a/tests/consolidation-tests/src/scenarios/refund-pair-cross-bucket-localized-exact-amount.test.ts
+++ b/tests/consolidation-tests/src/scenarios/refund-pair-cross-bucket-localized-exact-amount.test.ts
@@ -50,7 +50,12 @@ describe('consolidation/refund-pair-cross-bucket-localized-exact-amount', () => 
                 refundIncomeTransactionIds: [refund.id]
             })
         );
-        expect(autoCandidates.some(candidate => candidate.expenseTransactionId === exactTitleExpense.id && candidate.refundIncomeTransactionIds.includes(refund.id))).toBe(false);
+        expect(
+            autoCandidates.some(
+                candidate =>
+                    candidate.expenseTransactionId === exactTitleExpense.id && candidate.refundIncomeTransactionIds.includes(refund.id)
+            )
+        ).toBe(false);
         expect(reviewCandidates.some(candidate => candidate.refundIncomeTransactionIds.includes(refund.id))).toBe(false);
 
         await runConsolidation();


### PR DESCRIPTION
## Root cause

Both `REFUND_AUTO_CANDIDATES_SQL` and `REFUND_REVIEW_CANDIDATES_SQL` in `refund-ranked-candidate-sql.factory.ts` filter to `refundRank = 1` per refund income. The rank ordering is bucket priority first (`EXACT_TITLE` = 1 > `LOCALIZED` = 2 > ...), then localized amount-mismatch, then `timeDiff`.

So when a refund's rank-1 row is an `AUTO_REFUND_EXACT_TITLE` candidate against expense E1, while its unique localized exact-amount match (`AUTO_REFUND_LOCALIZED_REFUND_TITLE` against E2, with `expenseAmount = refundAmount`, mutual-best, `expenseRank = 1`) sits at rank 2, the localized row never reaches either WHERE clause. If the rank-1 `EXACT_TITLE` row then fails auto-acceptance (`refundCandidateCount > 1`, and the localized mutual-best branch does not apply to its bucket), it has no review fallback (review only covered `AUTO_REFUND_LOCALIZED_REFUND_TITLE`). The refund is silently dropped: neither consolidated nor reviewable.

## Chosen design — option (a)

Allow the localized mutual-best acceptance branch (`confidenceBucket = 'AUTO_REFUND_LOCALIZED_REFUND_TITLE' AND expenseAmount = refundAmount AND expenseRank = 1 AND localizedExactAmountMatchCount = 1`) to accept its row **regardless of `refundRank`**, while the other buckets still require `refundRank = 1 AND refundCandidateCount = 1`.

Why (a) over generalizing the review fallback (b):

- The rank-1 row in this collision is the *contested* exact-title candidate against the wrong expense (E1). Option (b) would surface *that* weaker pairing for manual review while still hiding the genuinely strong, unique localized exact-amount match (E2). Option (a) recovers the correct match (E2) automatically.
- **Provably free of double consolidation.** When the localized branch fires, `refundCandidateCount > 1`, so the `(refundRank = 1 AND refundCandidateCount = 1)` clause is false for every row of that refund; and `localizedExactAmountMatchCount = 1` guarantees exactly one qualifying row per refund. A refund is therefore never consolidated against two expenses. Because the strong match is recovered by auto (not review), there is no double-surfacing across the auto/review queries.
- The exact-title / rejected-payment buckets are unchanged (they were previously `refundRank = 1 AND refundCandidateCount = 1` in effect, and remain so). The only behavioral change is that a unique localized exact-amount mutual-best row at `refundRank > 1` is now accepted — precisely the reported gap.

## Tests

Added `tests/consolidation-tests/src/scenarios/refund-pair-cross-bucket-localized-exact-amount.test.ts`, constructing the cross-bucket collision via `testSeedService`: refund R matches E1 by exact-title (E1 also claimed by another refund R2) and matches E2 by a unique localized exact-amount mutual-best. The test was confirmed to fail on the pre-fix code (R vanishes from both auto and review candidates) and passes after the fix (R auto-consolidates against E2, and never surfaces paired with E1 nor in review).

- `yarn workspace @budgie-at/consolidation-tests test` — 62 passed (25 files)
- `yarn workspace @budgie/consolidation ts` — pass
- `yarn workspace @budgie-at/consolidation-tests ts` — pass
- `yarn workspace @budgie/consolidation lint` — pass

Fixes #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)