### PR TITLE
ci: remove the App Store Connect key after the iOS publish job

### DIFF
--- a/.github/workflows/native-publish.yml
+++ b/.github/workflows/native-publish.yml
@@ -77,3 +77,7 @@ jobs:
       - name: Submit iOS app
         working-directory: packages/app
         run: eas submit --platform ios --profile production --path ../../artifacts/budgie-production.ipa --non-interactive
+
+      - name: Remove App Store Connect key
+        if: always()
+        run: rm -f packages/app/asc_api_key.p8


### PR DESCRIPTION
## What

Adds a single cleanup step to the end of the iOS store publish job in `.github/workflows/native-publish.yml`:

```yaml
      - name: Remove App Store Connect key
        if: always()
        run: rm -f packages/app/asc_api_key.p8
```

Nothing else in the workflow changes.

## Why

The `ASC API Key file creation` step writes the App Store Connect signing key to `packages/app/asc_api_key.p8` in the checked-out workspace, and the job has no step that removes it.

**This is defense-in-depth, not a host-level key leak.** budgie's runners are ephemeral Tart VMs: the fleet clones a fresh VM per job, the runner registers as ephemeral, and the VM is destroyed at job end (`gh api .../actions/runners` reports 0 runners while idle, and there are no `.p8` files anywhere on the host). The key never outlives its own VM.

It is still worth closing, for these reasons:

1. **Parity.** The sibling repository (`vitalyiegorov/suuudokuuu`) already removes the file with `if: always()` in the same position. The two publish workflows were needlessly divergent; this converges them.
2. **In-VM blast radius.** For the VM's lifetime the key sits in the checked-out workspace, readable by any later step of that same job.
3. **Lifetime assumptions can change.** If a VM is ever reused, a workspace cached, or a base image snapshotted mid-job, the key would escape its intended lifetime. The cleanup makes the workflow correct independently of the VM lifecycle.
4. **House standard.** The fleet's contributor contract (rule 7) requires never logging or persisting tokens or private keys.

## Design notes

- **Placement** mirrors the sibling exactly: last step, after `Submit iOS app`. `if: always()` puts it on the failure and cancellation paths as well — those are precisely the paths that leave the key behind today, since a failed build or submission currently exits the job with the file still in place.
- **`rm -f`** is idempotent: the step succeeds when the file was never created, so it cannot turn a failed build into a second, confusing failure.
- The step prints nothing. It does not read, echo, or hash the key.

## Validation

- `actionlint`: no new findings. The only report on this file is the pre-existing `macos-tartelet` custom self-hosted label on line 15, which every workflow in the repository already produces, and which is unchanged in count and location by this PR.
- YAML parses; the job's step list ends with `Remove App Store Connect key` carrying `if: always()`, `run: rm -f packages/app/asc_api_key.p8`, and no `working-directory` (so the path resolves from the workspace root, as in the sibling).
- `bash -n` clean on the step.
- The step was executed against a scratch tree containing a dummy file: the file is gone and the exit code is 0; a second run with the file already absent also exits 0, confirming idempotence. No real key was involved.

## Scope

Signing, credential creation, artifact upload, submission, and version/build-number logic are untouched. No other job, workflow, or package is modified.

Split out of #617 deliberately: that PR is an Android build-time change and should stay independently revertible. This branch is cut from `main`, so the two do not depend on each other.
