### PR TITLE
ci: let dependabot pull requests reach a passing state

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,6 +18,10 @@ concurrency:
 
 jobs:
   claude-review:
+    # Dependabot-triggered runs are never given repository secrets, so
+    # CLAUDE_CODE_OAUTH_TOKEN arrives empty and this job can only ever fail.
+    if: github.actor != 'dependabot[bot]'
+
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -84,6 +84,9 @@ jobs:
               run: yarn i18n:check
 
             - name: Lint the PR Title
+              # Dependabot titles carry the 'deps' scope, which config-lerna-scopes
+              # rejects because it only accepts workspace package names.
+              if: github.actor != 'dependabot[bot]'
               run: printf '%s\n' "$PR_TITLE" | node_modules/.bin/commitlint
 
             - name: Formatting checks
@@ -152,7 +155,9 @@ jobs:
                   use_oidc: true
 
     eas-update-preview:
-        if: needs.detect-mobile-impact.outputs.mobile == 'true'
+        # Dependabot-triggered runs are never given repository secrets, so
+        # EXPO_TOKEN arrives empty and the preview export can only ever fail.
+        if: needs.detect-mobile-impact.outputs.mobile == 'true' && github.actor != 'dependabot[bot]'
         needs: [detect-mobile-impact]
         name: EAS Update Preview
         # Expo's Hermes compiler package ships an x86-64 Linux host binary.


### PR DESCRIPTION
Every Dependabot PR currently fails three independent checks, so dependency and security bumps can never be merged.

| job / step | failure | cause |
| --- | --- | --- |
| `Claude Code Review` | empty token | `claude_code_oauth_token` resolves to `""` |
| `EAS Update Preview` → `Check for EXPO_TOKEN` | `if [ -z "" ]` | `EXPO_TOKEN` resolves to `""` |
| `Code quality checks` → `Lint the PR Title` | `scope must be one of [ai, app, bank-sync, …]` | Dependabot writes `chore(deps):`; `@commitlint/config-lerna-scopes` only accepts workspace package names |

The first two are GitHub deliberately withholding repository secrets from Dependabot-triggered runs — structural, not a regression. The third is independent of secrets.

Skipping all three for `dependabot[bot]` is the minimal fix. Rejected alternatives: `pull_request_target` would hand secrets to untrusted PR code, and adding `deps` to the commitlint scope list would loosen commit conventions for humans too. Creating a `.github/dependabot.yml` just to change the commit prefix would also switch on version updates, which is a much larger behaviour change.

Observed on 9 Dependabot runs (`ws`, `undici`, `shell-quote`, `js-yaml`) — all failed, while every human-branch run of the same workflows passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated automated pull request workflows to skip unsupported review, title-linting, and mobile preview steps for Dependabot-generated pull requests.
  * Prevents workflow failures caused by unavailable credentials in automated dependency updates.
  * Preserves existing behavior for standard pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->