### PR TITLE
build: fix Vercel landing deploys (logger tsbuildinfo emit skip + turbo env vars)

### DIFF
--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -2,7 +2,7 @@
     "extends": "../../tsconfig.json",
     "compilerOptions": {
         "composite": true,
-        "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo.json",
+        "tsBuildInfoFile": "./dist/tsbuildinfo.json",
         "rootDir": "./src",
         "lib": ["esnext"],
         "outDir": "dist/esm",

--- a/turbo.json
+++ b/turbo.json
@@ -29,7 +29,15 @@
         },
         "build": {
             "dependsOn": ["^build"],
-            "env": ["ADMIN_SECRET", "INDEXNOW_KEY"],
+            "env": [
+                "ADMIN_SECRET",
+                "INDEXNOW_KEY",
+                "KV_REST_API_READ_ONLY_TOKEN",
+                "KV_REST_API_TOKEN",
+                "KV_REST_API_URL",
+                "KV_URL",
+                "REDIS_URL"
+            ],
             "outputs": ["dist/**", ".next/**"]
         },
         "test": {


### PR DESCRIPTION
## Update: real root cause found and fixed

The env-var commit below is correct and stays (the waitlist action genuinely uses Redis/KV, so those vars belong in Turbo's strict env mode), but it wasn't the actual cause of the Vercel deploy failures — it just happened to force a cache-key change that masked the real bug for one deploy.

**Real root cause:** `packages/logger/tsconfig.json` had `"composite": true` with `"tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo.json"` and `"outDir": "dist/esm"`. Vercel's build cache preserves `node_modules` between deployments but not `dist/`. Every deploy therefore started with a stale `tsbuildinfo.json` and no `dist/`. Incremental `tsc` compared the stale build info against source, decided everything was already up to date, skipped emit, and exited 0 — so turbo packed an empty artifact (`no output files found for task @budgie/logger#build` warning in the deploy log). Landing then failed with `Module not found: Can't resolve '@budgie/logger'`.

The already-committed turbo.json env change in this PR is what proved this: forcing a cache miss made the logger build task execute, and it still emitted nothing — because the stale tsbuildinfo survived in `node_modules/.cache` regardless of cache-key changes.

**Fix (new commit):** moved `tsBuildInfoFile` to `./dist/tsbuildinfo.json`, inside the build output directory. Now whenever `dist/` is missing (cold cache, clean checkout, or Vercel's node_modules-only cache), the build info is missing too, so `tsc` can no longer no-op and always fully re-emits.

**Validation performed:**
1. Clean build from scratch (`dist` + old `.cache` removed) — verified both `dist/esm/index.js` and `dist/tsbuildinfo.json` are produced.
2. Key test simulating Vercel's poisoned cache: built once (so tsbuildinfo exists), removed only `dist/`, rebuilt — `dist/esm/index.js` was fully re-emitted (previously this sequence would have no-op'd since tsbuildinfo used to survive outside `dist/`).
3. `yarn workspace @budgie-at/landing build` — passes.
4. `yarn ts` — passes across all 13 packages.
5. `yarn format:check` — passes.

Other packages (`app`, `budget`, `ai`, `consolidation`, `contracts`, `bank-sync`, `screen-chrome`) share the same `tsBuildInfoFile` pattern under `node_modules/.cache`, but none of them are landing's workspace dependencies (landing's only `@budgie/*` workspace dependency is `@budgie/logger`), so they're left untouched here as follow-up candidates.

---

## Symptom

Every Vercel deployment of `budgie-landing` (production and preview) has failed since ~2026-07-24 with:

```
./packages/landing/src/generic/action/waitlist.action.ts:4:1
Module not found: Can't resolve '@budgie/logger'
```

## Root cause

On Vercel, `@budgie/logger:build` is a turbo remote-cache hit whose artifact does not restore the package's `dist/` output, so `@budgie-at/landing` (whose waitlist server action imports `@budgie/logger`, with `exports` pointing into `./dist/esm/`) builds against an empty package. The poisoned artifact dates to the v6.0.0 version bump / git history rewrite window and is replayed on every deploy since.

Additionally, Vercel's build log warns that env vars used by the landing build are not declared in `turbo.json` and are stripped by Turbo's strict env mode:

```
[warn] @budgie-at/landing#build
  - KV_URL
  - KV_REST_API_READ_ONLY_TOKEN
  - REDIS_URL
  - KV_REST_API_TOKEN
  - KV_REST_API_URL
```

## Local reproduction

Removing `packages/logger/dist` and running `yarn workspace @budgie-at/landing build` locally yields the byte-identical Turbopack "Module not found: Can't resolve '@budgie/logger'" error.

## The change

Adds the five missing KV/Redis env vars to `tasks.build.env` in root `turbo.json`. This has two effects:

1. **Correct configuration in its own right** — the waitlist action genuinely uses Redis/KV, so these vars need to be declared under Turbo's strict env mode.
2. **The operative fix** — changing the `build` task definition rotates every build task hash, forcing a cache miss on `@budgie/logger:build` so a fresh, complete artifact (with `dist/**`) gets seeded, unblocking Vercel deploys.

Only `turbo.json` is touched by this commit; the logger `tsconfig.json` fix is a separate commit (see the "Update" section above for why it's the real fix).

## Verification

This PR's own Vercel check going green is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to support additional key-value store and Redis environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
