### PR TITLE
ci: adopt mobile-ci v1.1.0 for native cache, publish and dev-release

### DIFF
--- a/.github/workflows/ios-native-cache.yml
+++ b/.github/workflows/ios-native-cache.yml
@@ -5,199 +5,27 @@ on:
     push:
         branches: [main]
 
-concurrency:
-    group: ios-native-cache-main
-    cancel-in-progress: false
-
 permissions:
     contents: read
 
-env:
-    EAS_CLI_VERSION: '20.5.1'
-    APP_VARIANT: e2e
-    EXPO_PUBLIC_AI_DISABLE: 'true'
-    EXPO_PUBLIC_LOGGING_DISABLE: 'true'
-    EXPO_USE_PRECOMPILED_MODULES: '1'
-    RCT_USE_PREBUILT_RNCORE: '1'
-    RCT_USE_RN_DEP: '1'
-    IOS_DERIVED_DATA: ${{ github.workspace }}/.ci-cache/DerivedData/budgie-e2e
-    USE_CCACHE: '1'
-    CCACHE_DIR: ${{ github.workspace }}/.ci-cache/ccache
-    CCACHE_BASEDIR: ${{ github.workspace }}
-    CCACHE_COMPRESS: 'true'
-    CCACHE_MAXSIZE: 2G
-    CCACHE_NOHASHDIR: 'true'
-
 jobs:
     seed:
-        name: Seed fingerprinted native app
-        runs-on: [self-hosted, macOS, ARM64, macos-builder]
-        timeout-minutes: 120
-        steps:
-            - uses: actions/checkout@v5
-              with:
-                  persist-credentials: false
-
-            - name: Setup macOS toolchain PATH
-              shell: bash
-              run: |
-                  echo "$HOME/.rbenv/shims" >> "$GITHUB_PATH"
-                  echo '/opt/homebrew/bin' >> "$GITHUB_PATH"
-                  echo '/opt/homebrew/sbin' >> "$GITHUB_PATH"
-
-            - uses: actions/setup-node@v6
-              with:
-                  node-version: 22.x
-
-            - name: Install dependencies
-              run: yarn install
-
-            - name: Build internal workspace packages
-              run: yarn turbo build --filter=@budgie/contracts --filter=@budgie/ai --filter=@budgie/bank-sync --filter=@budgie/consolidation --filter=@budgie/budget
-
-            - name: Setup EAS CLI
-              uses: expo/expo-github-action@v9
-              with:
-                  eas-version: ${{ env.EAS_CLI_VERSION }}
-                  token: ${{ secrets.EXPO_TOKEN }}
-
-            - name: Generate native fingerprint
-              id: fingerprint
-              working-directory: packages/app
-              shell: bash
-              run: |
-                  set -euo pipefail
-                  eas fingerprint:generate \
-                    --build-profile e2e \
-                    --platform ios \
-                    --json \
-                    --non-interactive > "$RUNNER_TEMP/ios-fingerprint.json"
-                  hash=$(jq -er '.hash' "$RUNNER_TEMP/ios-fingerprint.json")
-                  echo "hash=$hash" >> "$GITHUB_OUTPUT"
-                  echo "Native fingerprint: $hash"
-
-            - name: Restore canonical native app
-              id: native-app-cache
-              uses: actions/cache/restore@v5
-              with:
-                  path: .ci-cache/ios-native-app
-                  key: ios-native-v1-budgie-e2e-${{ runner.os }}-arm64-xcode26_4_1-17E202-${{ steps.fingerprint.outputs.hash }}
-
-            - name: Report cache hit
-              if: steps.native-app-cache.outputs.cache-hit == 'true'
-              run: echo 'Canonical native app already exists for this fingerprint.'
-
-            - name: Select Xcode 26.4.1
-              if: steps.native-app-cache.outputs.cache-hit != 'true'
-              run: |
-                  XCODE_APP=/Applications/Xcode_26.4.1.app
-                  if [ ! -d "$XCODE_APP" ]; then
-                    echo '::error::Xcode 26.4.1 is not installed on this runner.'
-                    exit 1
-                  fi
-                  echo "DEVELOPER_DIR=$XCODE_APP/Contents/Developer" >> "$GITHUB_ENV"
-                  xcode_version=$("$XCODE_APP/Contents/Developer/usr/bin/xcodebuild" -version)
-                  printf '%s\n' "$xcode_version"
-                  grep -qx 'Xcode 26.4.1' <<< "$xcode_version"
-                  grep -qx 'Build version 17E202' <<< "$xcode_version"
-
-            - name: Restore CocoaPods cache
-              if: steps.native-app-cache.outputs.cache-hit != 'true'
-              uses: actions/cache/restore@v5
-              with:
-                  path: |
-                      ~/Library/Caches/CocoaPods
-                      ~/.cocoapods
-                  key: pods-${{ runner.os }}-xcode26_4_1-${{ hashFiles('yarn.lock', 'packages/app/package.json', 'packages/app/app.config.js', 'packages/app/ios/Podfile.properties.json') }}
-                  restore-keys: |
-                      pods-${{ runner.os }}-xcode26_4_1-
-                      pods-${{ runner.os }}-
-
-            - name: Setup ccache
-              if: steps.native-app-cache.outputs.cache-hit != 'true'
-              run: |
-                  mkdir -p "$CCACHE_DIR" "$IOS_DERIVED_DATA"
-                  if ! command -v ccache >/dev/null; then
-                    command -v brew >/dev/null || {
-                      echo '::error::ccache is not installed and Homebrew is unavailable.'
-                      exit 1
-                    }
-                    brew list ccache >/dev/null 2>&1 || brew install ccache
-                  fi
-                  command -v ccache
-                  ccache --version
-                  ccache --zero-stats || true
-                  if command -v brew >/dev/null; then
-                    echo "$(brew --prefix ccache)/libexec" >> "$GITHUB_PATH"
-                  fi
-
-            - name: Restore ccache
-              if: steps.native-app-cache.outputs.cache-hit != 'true'
-              uses: actions/cache/restore@v5
-              with:
-                  path: ${{ env.CCACHE_DIR }}
-                  key: ccache-${{ runner.os }}-xcode26_4_1-e2e-${{ hashFiles('yarn.lock', 'packages/app/package.json', 'packages/app/app.config.js', 'packages/app/ios/Podfile.properties.json') }}
-                  restore-keys: |
-                      ccache-${{ runner.os }}-xcode26_4_1-e2e-
-                      ccache-${{ runner.os }}-
-
-            - name: Generate native project
-              if: steps.native-app-cache.outputs.cache-hit != 'true'
-              working-directory: packages/app
-              run: npx expo prebuild -p ios --clean --no-install
-
-            - name: Install pods
-              if: steps.native-app-cache.outputs.cache-hit != 'true'
-              working-directory: packages/app/ios
-              run: |
-                  command -v pod
-                  pod --version
-                  pod install
-
-            - name: Build native Release base
-              if: steps.native-app-cache.outputs.cache-hit != 'true'
-              working-directory: packages/app/ios
-              shell: bash
-              run: |
-                  set -euo pipefail
-                  workspace=$(find . -maxdepth 1 -name '*.xcworkspace' -print -quit)
-                  scheme=$(basename "$workspace" .xcworkspace)
-                  test -n "$workspace"
-                  xcodebuild build \
-                    -workspace "$workspace" \
-                    -scheme "$scheme" \
-                    -sdk iphonesimulator \
-                    -configuration Release \
-                    -derivedDataPath "$IOS_DERIVED_DATA" \
-                    -destination 'generic/platform=iOS Simulator' \
-                    -jobs 5 \
-                    CODE_SIGN_IDENTITY='-' \
-                    AD_HOC_CODE_SIGNING_ALLOWED=YES \
-                    PROVISIONING_PROFILE_SPECIFIER='' \
-                    COMPILER_INDEX_STORE_ENABLE=NO \
-                    ONLY_ACTIVE_ARCH=YES \
-                    ARCHS=arm64 \
-                    EXCLUDED_ARCHS=x86_64
-
-            - name: Validate and package native base
-              if: steps.native-app-cache.outputs.cache-hit != 'true'
-              shell: bash
-              run: |
-                  set -euo pipefail
-                  app_path=$(find "$IOS_DERIVED_DATA" -name '*.app' -path '*Release-iphonesimulator*' -print -quit)
-                  test -n "$app_path"
-                  test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$app_path/Info.plist")" = 'com.vitalyiegorov.budgie.e2e'
-                  if /usr/libexec/PlistBuddy -c 'Print :DEV_CLIENT_DEFAULT_LAUNCHER_URL' "$app_path/Info.plist" >/dev/null 2>&1; then
-                    echo '::error::Native E2E base unexpectedly contains a development-client launch URL.'
-                    exit 1
-                  fi
-                  find "$app_path" -name 'main.jsbundle' -type f -print -quit | grep -q .
-                  mkdir -p .ci-cache/ios-native-app
-                  ditto "$app_path" .ci-cache/ios-native-app/Base.app
-
-            - name: Save canonical native app
-              if: steps.native-app-cache.outputs.cache-hit != 'true'
-              uses: actions/cache/save@v5
-              with:
-                  path: .ci-cache/ios-native-app
-                  key: ios-native-v1-budgie-e2e-${{ runner.os }}-arm64-xcode26_4_1-17E202-${{ steps.fingerprint.outputs.hash }}
+        name: Seed native cache
+        permissions:
+            contents: read
+        uses: rnw-community/mobile-ci/.github/workflows/seed-native-cache.yml@0eadcb345bc704b1ccc8e9965634af1ff3d2e25e # v1.1.0
+        with:
+            ios-runner-labels: '["self-hosted","macOS","ARM64","macos-builder"]'
+            ios-targets: >-
+                [{"name":"e2e","appDir":"packages/app","workspace":"budgieE2E.xcworkspace","scheme":"budgieE2E",
+                "prebuildCommand":"npx expo prebuild -p ios --clean --no-install"}]
+            android-targets: '[]'
+            ios-cache-profile: ios-e2e-budgie-v2
+            build-env: |
+                APP_VARIANT=e2e
+                EXPO_PUBLIC_AI_DISABLE=true
+                EXPO_PUBLIC_LOGGING_DISABLE=true
+            build-command: yarn turbo build --filter=@budgie/contracts --filter=@budgie/ai --filter=@budgie/bank-sync --filter=@budgie/consolidation --filter=@budgie/budget
+            rct-use-prebuilt-rncore: true
+            rct-use-rn-dep: true
+            expo-use-precompiled-modules: true

--- a/.github/workflows/native-dev-build.yml
+++ b/.github/workflows/native-dev-build.yml
@@ -1,147 +1,24 @@
 name: Build Development build
-env:
-  EXPO_APPLE_TEAM_TYPE: INDIVIDUAL
-  EXPO_APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
 
 on:
   workflow_dispatch:
-
-concurrency:
-  group: ios-dev-prerelease
-  cancel-in-progress: false
 
 permissions:
   contents: write
 
 jobs:
-  build:
-    name: Local iOS Development Build
-    runs-on: [self-hosted, macOS, ARM64, macos-tartelet]
-    timeout-minutes: 120
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-        with:
-          persist-credentials: false
-          ref: main
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 22.x
-
-      - name: Select Xcode
-        run: |
-          if [ -d /Applications/Xcode_26.4.1.app ]; then
-            XCODE_APP=/Applications/Xcode_26.4.1.app
-          elif [ -d /Applications/Xcode.app ]; then
-            XCODE_APP=/Applications/Xcode.app
-          else
-            echo "::error::Xcode is not installed on this runner."
-            ls -1 /Applications | grep -i Xcode || true
-            exit 1
-          fi
-
-          echo "DEVELOPER_DIR=$XCODE_APP/Contents/Developer" >> "$GITHUB_ENV"
-          xcodebuild -version
-
-      - name: Setup Expo and EAS
-        uses: expo/expo-github-action@v9
-        with:
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: ASC API Key file creation
-        uses: MobileDevOps/secret-to-file-action@v1.0.0
-        with:
-          base64-encoded-secret: ${{ secrets.EXPO_IOS_ASC_API_KEY }}
-          filename: "packages/app/asc_api_key.p8"
-
-      - name: Install dependencies
-        run: yarn install
-
-      - name: Build iOS app locally
-        working-directory: packages/app
-        env:
-          EXPO_USE_PRECOMPILED_MODULES: "1"
-          RCT_USE_PREBUILT_RNCORE: "1"
-          RCT_USE_RN_DEP: "1"
-        run: |
-          mkdir -p ../../artifacts
-          eas build --platform ios --profile development --local --non-interactive --output ../../artifacts/budgie-development.ipa
-
-      - name: Upload iOS artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: budgie-development-ios
-          path: artifacts/budgie-development.ipa
-          if-no-files-found: error
-          retention-days: 14
-
-      - name: Ensure GitHub CLI is available
-        run: command -v gh >/dev/null 2>&1 || brew install gh
-
-      - name: Publish iOS dev prerelease
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          BRANCH_NAME="${GITHUB_REF_NAME}"
-          BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          TAG="ios-dev-${GITHUB_RUN_NUMBER}"
-
-          NOTES_FILE=$(mktemp)
-          {
-            echo "Budgie iOS development build"
-            echo ""
-            echo "Version: ${VERSION}"
-            echo "Commit: ${SHORT_SHA}"
-            echo "Branch: ${BRANCH_NAME}"
-            echo "Built: ${BUILD_DATE}"
-            echo "Workflow run: ${RUN_URL}"
-          } > "$NOTES_FILE"
-
-          gh release create "$TAG" artifacts/budgie-development.ipa --repo "${GITHUB_REPOSITORY}" --draft --prerelease --target "${GITHUB_SHA}" --title "Budgie iOS Dev Build v${VERSION} (${SHORT_SHA})" --notes-file "$NOTES_FILE"
-
-          RELEASE_ID=$(gh api "repos/${GITHUB_REPOSITORY}/releases" | jq -r --arg tag "$TAG" '[.[] | select(.draft and .tag_name == $tag)][0].id')
-
-          gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" -F draft=false > /dev/null
-
-          rm -f "$NOTES_FILE"
-
-      - name: Prune old iOS dev releases
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -uo pipefail
-          KEEP_COUNT=5
-
-          RELEASES_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate --jq '.')
-
-          PRUNE_PUBLISHED_TAGS=$(echo "$RELEASES_JSON" | jq -r --argjson keep "$KEEP_COUNT" '
-            [.[] | select(.draft == false) | select(.tag_name | test("^ios-dev-[0-9]+$"))]
-            | sort_by(.tag_name | capture("^ios-dev-(?<run>[0-9]+)$").run | tonumber)
-            | reverse
-            | .[$keep:]
-            | .[].tag_name
-          ')
-
-          for tag in $PRUNE_PUBLISHED_TAGS; do
-            echo "Pruning old published release: $tag"
-            gh release delete "$tag" --repo "${GITHUB_REPOSITORY}" --yes --cleanup-tag || echo "Failed to delete $tag"
-          done
-
-          STALE_DRAFT_TAGS=$(echo "$RELEASES_JSON" | jq -r --arg currentRun "${GITHUB_RUN_NUMBER}" '
-            [.[] | select(.draft == true) | select(.tag_name | test("^ios-dev-[0-9]+$"))]
-            | .[]
-            | select((.tag_name | capture("^ios-dev-(?<run>[0-9]+)$").run | tonumber) < ($currentRun | tonumber))
-            | .tag_name
-          ')
-
-          for tag in $STALE_DRAFT_TAGS; do
-            echo "Pruning stale draft release: $tag"
-            gh release delete "$tag" --repo "${GITHUB_REPOSITORY}" --yes --cleanup-tag || echo "Failed to delete draft $tag"
-          done
+  dev-release:
+    name: iOS development build and release
+    permissions:
+      contents: write
+    uses: rnw-community/mobile-ci/.github/workflows/native-dev-release.yml@0eadcb345bc704b1ccc8e9965634af1ff3d2e25e # v1.1.0
+    with:
+      enable-ios: true
+      enable-android: false
+      ios-runner-labels: '["self-hosted","macOS","ARM64","macos-tartelet"]'
+      app-dir: packages/app
+      tag-prefix: dev
+      keep-releases: 5
+    secrets:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      ASC_API_KEY: ${{ secrets.EXPO_IOS_ASC_API_KEY }}

--- a/.github/workflows/native-publish.yml
+++ b/.github/workflows/native-publish.yml
@@ -1,7 +1,4 @@
 name: Build and Publish to Stores
-env:
-  EXPO_APPLE_TEAM_TYPE: INDIVIDUAL
-  EXPO_APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
 
 on:
   workflow_dispatch:
@@ -10,77 +7,19 @@ permissions:
   contents: read
 
 jobs:
-  build-and-publish:
-    name: Build & Submit iOS to App Store
-    runs-on: [self-hosted, macOS, ARM64, macos-tartelet]
-    timeout-minutes: 120
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-        with:
-          persist-credentials: false
-          ref: main
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 22.x
-
-      - name: Select Xcode
-        run: |
-          if [ -d /Applications/Xcode_26.4.1.app ]; then
-            XCODE_APP=/Applications/Xcode_26.4.1.app
-          elif [ -d /Applications/Xcode.app ]; then
-            XCODE_APP=/Applications/Xcode.app
-          else
-            echo "::error::Xcode is not installed on this runner."
-            ls -1 /Applications | grep -i Xcode || true
-            exit 1
-          fi
-
-          echo "DEVELOPER_DIR=$XCODE_APP/Contents/Developer" >> "$GITHUB_ENV"
-          xcodebuild -version
-
-      - name: Setup Expo and EAS
-        uses: expo/expo-github-action@v9
-        with:
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: ASC API Key file creation
-        uses: MobileDevOps/secret-to-file-action@v1.0.0
-        with:
-          base64-encoded-secret: ${{ secrets.EXPO_IOS_ASC_API_KEY }}
-          filename: "packages/app/asc_api_key.p8"
-
-      - name: Install dependencies
-        run: yarn install
-
-      - name: Build iOS app locally
-        working-directory: packages/app
-        env:
-          EXPO_USE_PRECOMPILED_MODULES: "1"
-          RCT_USE_PREBUILT_RNCORE: "1"
-          RCT_USE_RN_DEP: "1"
-        run: |
-          mkdir -p ../../artifacts
-          eas build --platform ios --profile production --local --non-interactive --output ../../artifacts/budgie-production.ipa
-
-      - name: Upload iOS artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: budgie-production-ios
-          path: artifacts/budgie-production.ipa
-          if-no-files-found: error
-          retention-days: 14
-
-      - name: Submit iOS app
-        working-directory: packages/app
-        run: eas submit --platform ios --profile production --path ../../artifacts/budgie-production.ipa --non-interactive
-
-      - name: Remove App Store Connect key
-        if: always()
-        run: rm -f packages/app/asc_api_key.p8
+  publish:
+    name: iOS build and publish
+    permissions:
+      contents: read
+    uses: rnw-community/mobile-ci/.github/workflows/native-publish.yml@0eadcb345bc704b1ccc8e9965634af1ff3d2e25e # v1.1.0
+    with:
+      enable-ios: true
+      enable-android: false
+      ios-runner-labels: '["self-hosted","macOS","ARM64","macos-tartelet"]'
+      app-dir: packages/app
+    secrets:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      ASC_API_KEY: ${{ secrets.EXPO_IOS_ASC_API_KEY }}
 
   # Android Lint is excluded from the production Gradle command in
   # packages/app/eas.json, because the Android Gradle plugin wires
@@ -91,6 +30,12 @@ jobs:
   # This repository has no Android build and submit job yet. When one is added
   # it must declare `needs: android-release-lint` so a fatal lint finding still
   # blocks the Google Play submission.
+  #
+  # This job stays a hand-rolled standalone gate (not part of the
+  # rnw-community/mobile-ci native-publish.yml call above): it is a policy
+  # check independent of whether Android publishing is enabled, and
+  # mobile-ci's own android-lint-gate job only runs when enable-android is
+  # true.
   android-release-lint:
     name: Android release lint gate
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

Migrates the three remaining hand-rolled iOS CI workflows to
`rnw-community/mobile-ci@v1.1.0` reusable workflows, pinned to
`0eadcb345bc704b1ccc8e9965634af1ff3d2e25e # v1.1.0` (same pin already used by
`ios-maestro.yml` on `ci/adopt-mobile-ci-ios-maestro`, PR #628). Does **not**
touch `pr.yml` — the iOS e2e migration lives on that other branch/PR.

| File | Before | After |
| --- | --- | --- |
| `ios-native-cache.yml` | hand-rolled EAS-fingerprint + xcodebuild seed job | `uses: .../seed-native-cache.yml@v1.1.0`, `ios-targets` only (`android-targets: '[]'`) |
| `native-publish.yml` | hand-rolled `eas build --local` + `eas submit` job, plus a standalone Android lint gate job | `uses: .../native-publish.yml@v1.1.0` with `enable-ios: true`, `enable-android: false`; Android lint gate job **kept as a standalone hand-rolled job**, unchanged |
| `native-dev-build.yml` | hand-rolled `eas build --local --profile development` + `gh release create`/prune, tag `ios-dev-<run_number>` | `uses: .../native-dev-release.yml@v1.1.0` with `enable-ios: true`, `tag-prefix: dev` → new tags `dev-ios-<run_number>` |

## Input mapping

### `ios-native-cache.yml` → `seed-native-cache.yml`

| Old | New |
| --- | --- |
| `runs-on: [self-hosted, macOS, ARM64, macos-builder]` | `ios-runner-labels: '["self-hosted","macOS","ARM64","macos-builder"]'` |
| `appDir`/`workspace`/`scheme`/`prebuildCommand` (hand-rolled steps) | `ios-targets: [{"name":"e2e","appDir":"packages/app","workspace":"budgieE2E.xcworkspace","scheme":"budgieE2E","prebuildCommand":"npx expo prebuild -p ios --clean --no-install"}]` |
| top-level `env: APP_VARIANT/EXPO_PUBLIC_AI_DISABLE/EXPO_PUBLIC_LOGGING_DISABLE` | `build-env:` (same three vars) |
| `yarn turbo build --filter=...` step | `build-command:` (same command) |
| top-level `EXPO_USE_PRECOMPILED_MODULES/RCT_USE_PREBUILT_RNCORE/RCT_USE_RN_DEP=1` | `rct-use-prebuilt-rncore: true`, `rct-use-rn-dep: true`, `expo-use-precompiled-modules: true` |
| `ios-native-v1-budgie-e2e-...` cache key literal | `ios-cache-profile: ios-e2e-budgie-v2` (matches `ios-maestro.yml`'s `cache-profile` on PR #628's branch — both compose the final key as `<profile>-<target.name>` = `ios-e2e-budgie-v2-e2e`, so a `push:main` seed run and a PR `ios-maestro` run share the cache) |
| Xcode `26.4.1` / `17E202` pin | left as default (matches) |

**Cache-key basis change (flag for reviewers):** the old workflow fingerprinted
the native app with `eas fingerprint:generate --build-profile e2e` (needs
`EXPO_TOKEN`). `seed-native-cache.yml`'s `native-fingerprint` action uses
tokenless `@expo/fingerprint` directly instead. This changes what the cache
key is derived from — the first run after merge will be a guaranteed cache
miss (full cold build) regardless of whether the previous EAS-fingerprint-keyed
cache entry is still warm, and `EXPO_TOKEN` is no longer required by this
workflow at all.

### `native-publish.yml` → `native-publish.yml`

| Old | New |
| --- | --- |
| `runs-on: [self-hosted, macOS, ARM64, macos-tartelet]` | `ios-runner-labels: '["self-hosted","macOS","ARM64","macos-tartelet"]'` |
| n/a (Android never published) | `enable-android: false` (default) |
| `eas-version: latest` | left as default (`eas-cli-version: 20.5.1`, pinned) — intentional tightening, flag if you want `latest` preserved instead |
| `yarn install` | left as default (`yarn install --immutable`) — matches what `ios-maestro.yml` already accepted on PR #628 |
| **Android release lint job** | **kept verbatim, standalone**, *not* replaced by `native-publish.yml`'s `android-lint-gate` — that job only runs when `enable-android: true`, but budgie's lint job is a Play-policy gate that must keep running even though Android isn't published yet (see the job's own comment about a future `android-publish` job needing `needs: android-release-lint`) |

### `native-dev-build.yml` → `native-dev-release.yml`

| Old | New |
| --- | --- |
| `runs-on: [self-hosted, macOS, ARM64, macos-tartelet]` | `ios-runner-labels: '["self-hosted","macOS","ARM64","macos-tartelet"]'` |
| `TAG="ios-dev-${GITHUB_RUN_NUMBER}"` | `tag-prefix: dev` → mobile-ci always composes `<tag-prefix>-ios-<run_number>`, so `ios-dev` as a prefix would have produced `ios-dev-ios-<n>` (double "ios"). Chose `dev` → new tags are `dev-ios-<run_number>`, cleanly evolving the old scheme. **Existing `ios-dev-*` releases/tags are untouched** — the reusable workflow's prune step only matches tags starting with the new prefix. |
| `KEEP_COUNT=5` | `keep-releases: 5` (same) |

## Secrets mapping

| Consumer secret (unchanged names) | Reusable workflow secret |
| --- | --- |
| `EXPO_TOKEN` | `EXPO_TOKEN` |
| `EXPO_IOS_ASC_API_KEY` | `ASC_API_KEY` (name differs, so an explicit `secrets:` block is used instead of `secrets: inherit`) |

`EXPO_TOKEN` is no longer needed by `ios-native-cache.yml` (see cache-key-basis
note above).

## mobile-ci feature gap found

The old `native-publish.yml`/`native-dev-build.yml` set top-level
`EXPO_APPLE_TEAM_TYPE: INDIVIDUAL` and
`EXPO_APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_PASSWORD }}` env vars.
`native-publish.yml`/`native-dev-release.yml` have no equivalent env
passthrough into the actual `eas build`/`eas submit` steps — only
`ios-pre-submit-command`/`ios-post-submit-command` hooks exist, and those run
with the job's normal env (`EXPO_TOKEN` only), not arbitrary secrets. I did
not work around this with a `pre-submit-command` that exports the secret via
`$GITHUB_ENV`, since that means embedding a raw secret reference into a
plain-string `with:` input, which isn't clean.

I dropped both vars from the migrated workflows: `packages/app/eas.json`'s
`submit.production.ios` block already fully configures non-interactive App
Store Connect API-key auth (`ascApiKeyId`, `ascApiKeyIssuerId`,
`ascApiKeyPath`), which per Expo's own docs should make Apple-ID/password auth
unnecessary. **This is an assumption, not a verified fact** — please watch the
first live `native-publish`/`native-dev-build` run closely. If `eas
build`/`eas submit` do turn out to need `EXPO_APPLE_APP_SPECIFIC_PASSWORD`,
that's a real mobile-ci gap: `native-publish.yml`/`native-dev-release.yml`
should grow a `build-env`-style passthrough analogous to
`seed-native-cache.yml`'s.

## Validation

- `actionlint` clean on all three changed files (ran across the whole
  `.github/workflows/*.yml` directory too — the only findings are pre-existing
  unknown-self-hosted-label warnings in files this PR doesn't touch).
- No `shellcheck`-relevant `run:` blocks were added (all shell logic now lives
  in the reusable workflows); the Android lint job's script was carried over
  unchanged.
- **Not yet validated end-to-end**: `ios-native-cache.yml` only triggers on
  `push: [main]` + `workflow_dispatch`, so it won't run on this PR. First
  validation happens post-merge, or it can be dispatched manually on this
  branch beforehand (`workflow_dispatch` is one of its triggers).
  `native-publish.yml` and `native-dev-build.yml` are also
  `workflow_dispatch`-only and were not dispatched as part of this PR (they
  build/submit to real stores and cut real GitHub releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined iOS development build and release automation.
  * Improved native build caching to support faster, more consistent iOS builds.
  * Simplified iOS publishing workflows for App Store distribution.
  * Standardized development release tagging and retention.
  * Android publishing remains disabled, while the independent Android quality check continues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->