### PR TITLE
fix(consolidation): stop cross-bucket rank-1 shadowing unique exact-amount refund match

### DIFF
--- a/packages/consolidation/src/query/repository/sql-factory/refund-ranked-candidate-sql.factory.ts
+++ b/packages/consolidation/src/query/repository/sql-factory/refund-ranked-candidate-sql.factory.ts
@@ -191,8 +191,7 @@ const buildBucketPriorityOrderSql = (): string => `
     END
 `;
 
-const buildLocalizedAmountMismatchOrderSql = (): string =>
-    `CASE WHEN confidenceBucket = 'AUTO_REFUND_LOCALIZED_REFUND_TITLE' AND expenseAmount != refundAmount THEN 1 ELSE 0 END`;
+const buildAmountMismatchOrderSql = (): string => `CASE WHEN refundAmount = ${REFUND_CEILING_SQL} THEN 0 ELSE 1 END`;
 
 const buildRankedPairsSql = (): string => `
     ranked_pairs AS (
@@ -201,11 +200,11 @@ const buildRankedPairsSql = (): string => `
             COUNT(*) OVER (PARTITION BY refundTxId) AS refundCandidateCount,
             ROW_NUMBER() OVER (
                 PARTITION BY refundTxId
-                ORDER BY ${buildBucketPriorityOrderSql()}, ${buildLocalizedAmountMismatchOrderSql()}, timeDiff
+                ORDER BY ${buildAmountMismatchOrderSql()}, ${buildBucketPriorityOrderSql()}, timeDiff
             ) AS refundRank,
             ROW_NUMBER() OVER (
                 PARTITION BY expenseTxId
-                ORDER BY ${buildBucketPriorityOrderSql()}, ${buildLocalizedAmountMismatchOrderSql()}, timeDiff, refundTxId
+                ORDER BY ${buildAmountMismatchOrderSql()}, ${buildBucketPriorityOrderSql()}, timeDiff, refundTxId
             ) AS expenseRank
         FROM compatible_pairs
         WHERE confidenceBucket IS NOT NULL

--- a/tests/consolidation-tests/src/scenarios/refund-pair-competing-refunds.test.ts
+++ b/tests/consolidation-tests/src/scenarios/refund-pair-competing-refunds.test.ts
@@ -36,6 +36,24 @@ const NETFLIX_DECOY_EXPENSE_OPERATED_AT = new Date(COMPETING_YEAR, 4, 6, 8, 0, 0
 const NETFLIX_TARGET_EXPENSE_OPERATED_AT = new Date(COMPETING_YEAR, 4, 6, 18, 0, 0);
 const NETFLIX_REFUND_DELAY_SECONDS = 2 * 60 * 60;
 
+const ROZETKA_TITLE = 'ROZETKA';
+const ROZETKA_EXPENSE_AMOUNT_UAH = 500;
+const ROZETKA_EXPENSE_AMOUNT = ROZETKA_EXPENSE_AMOUNT_UAH * PRECISION;
+const ROZETKA_PARTIAL_REFUND_AMOUNT_UAH = 200;
+const ROZETKA_PARTIAL_REFUND_AMOUNT = ROZETKA_PARTIAL_REFUND_AMOUNT_UAH * PRECISION;
+const ROZETKA_EXPENSE_OPERATED_AT = new Date(COMPETING_YEAR, 5, 8, 9, 0, 0);
+const ROZETKA_REFUND_DELAY_SECONDS = 4 * 60 * 60;
+
+const COMFY_TITLE = 'COMFY';
+const COMFY_EXPENSE_AMOUNT_UAH = 900;
+const COMFY_EXPENSE_AMOUNT = COMFY_EXPENSE_AMOUNT_UAH * PRECISION;
+const COMFY_LARGER_REFUND_AMOUNT_UAH = 500;
+const COMFY_LARGER_REFUND_AMOUNT = COMFY_LARGER_REFUND_AMOUNT_UAH * PRECISION;
+const COMFY_SMALLER_REFUND_AMOUNT_UAH = 400;
+const COMFY_SMALLER_REFUND_AMOUNT = COMFY_SMALLER_REFUND_AMOUNT_UAH * PRECISION;
+const COMFY_EXPENSE_OPERATED_AT = new Date(COMPETING_YEAR, 5, 20, 9, 0, 0);
+const COMFY_REFUND_DELAY_SECONDS = 4 * 60 * 60;
+
 const seedExactTitleRefunds = async (input: {
     readonly expenseAmount: number;
     readonly expenseOperatedAt: Date;
@@ -123,6 +141,65 @@ describe('consolidation/refund-pair-competing-refunds', () => {
         expect(testQueryService.fetchTransactionById(refunds[0].id).consolidationParentTransactionId).toBe(expense.id);
         expect(testQueryService.fetchTransactionById(refunds[1].id).consolidationParentTransactionId).toBe(expense.id);
         expect(testQueryService.fetchTransactionById(refunds[2].id).consolidationParentTransactionId).toBeNull();
+    });
+});
+
+describe('consolidation/refund-pair-competing-refunds expense fill ordering', () => {
+    it('fills the expense with its exact-amount refund and reviews the earlier partial that no longer fits', async () => {
+        const { autoCandidates, expense, refunds, reviewCandidates } = await seedExactTitleRefunds({
+            title: ROZETKA_TITLE,
+            expenseAmount: ROZETKA_EXPENSE_AMOUNT,
+            refundAmounts: [ROZETKA_PARTIAL_REFUND_AMOUNT, ROZETKA_EXPENSE_AMOUNT],
+            expenseOperatedAt: ROZETKA_EXPENSE_OPERATED_AT,
+            refundDelaySeconds: ROZETKA_REFUND_DELAY_SECONDS,
+            externalIdPrefix: 'rozetka'
+        });
+
+        expectSoleGroup(autoCandidates, {
+            expenseTransactionId: expense.id,
+            refundIncomeTransactionIds: [refunds[1].id],
+            refundsTotal: ROZETKA_EXPENSE_AMOUNT
+        });
+        expectSoleGroup(reviewCandidates, {
+            expenseTransactionId: expense.id,
+            refundIncomeTransactionIds: [refunds[0].id],
+            refundsTotal: ROZETKA_PARTIAL_REFUND_AMOUNT
+        });
+
+        const result = await runConsolidation();
+
+        expect(result.consolidated).toBe(1);
+        expect(testQueryService.fetchTransactionById(expense.id).consolidationType).toBe(TransactionConsolidationTypeEnum.REFUND);
+        expect(refunds.map(refund => testQueryService.fetchTransactionById(refund.id).consolidationParentTransactionId)).toEqual([
+            null,
+            expense.id
+        ]);
+    });
+
+    it('still absorbs both partial refunds when their total fits the expense ceiling', async () => {
+        const { autoCandidates, expense, refunds, reviewCandidates } = await seedExactTitleRefunds({
+            title: COMFY_TITLE,
+            expenseAmount: COMFY_EXPENSE_AMOUNT,
+            refundAmounts: [COMFY_LARGER_REFUND_AMOUNT, COMFY_SMALLER_REFUND_AMOUNT],
+            expenseOperatedAt: COMFY_EXPENSE_OPERATED_AT,
+            refundDelaySeconds: COMFY_REFUND_DELAY_SECONDS,
+            externalIdPrefix: 'comfy'
+        });
+
+        expectSoleGroup(autoCandidates, {
+            expenseTransactionId: expense.id,
+            refundIncomeTransactionIds: [refunds[0].id, refunds[1].id],
+            refundsTotal: COMFY_EXPENSE_AMOUNT
+        });
+        expect(reviewCandidates).toHaveLength(0);
+
+        const result = await runConsolidation();
+
+        expect(result.consolidated).toBe(1);
+        expect(refunds.map(refund => testQueryService.fetchTransactionById(refund.id).consolidationParentTransactionId)).toEqual([
+            expense.id,
+            expense.id
+        ]);
     });
 });
 

--- a/tests/consolidation-tests/src/scenarios/refund-pair-cross-bucket-rank.test.ts
+++ b/tests/consolidation-tests/src/scenarios/refund-pair-cross-bucket-rank.test.ts
@@ -1,0 +1,184 @@
+import { PRECISION, TransactionConsolidationTypeEnum } from '@budgie/contracts';
+import { describe, expect, it } from 'vitest';
+
+import { runConsolidation } from '../harness/run-consolidation';
+import { refundPairRepository, testQueryService, testSeedService } from '../harness/test-context';
+
+import type { RefundCandidateInterface, RefundReviewCandidateInterface, TransactionEntityInterface } from '@budgie/contracts';
+
+const CROSS_BUCKET_YEAR = 2026;
+const CROSS_BUCKET_REFUND_DELAY_SECONDS = 2 * 60 * 60;
+
+const UBER_TITLE = 'UBER TRIP';
+const UBER_REVERSAL_TITLE = 'Скасування. UBER TRIP';
+const UBER_REFUND_AMOUNT_UAH = 340;
+const UBER_REFUND_AMOUNT = UBER_REFUND_AMOUNT_UAH * PRECISION;
+const UBER_SHADOW_AMOUNT_UAH = 500;
+const UBER_SHADOW_AMOUNT = UBER_SHADOW_AMOUNT_UAH * PRECISION;
+const UBER_SHADOW_EXPENSE_OPERATED_AT = new Date(CROSS_BUCKET_YEAR, 2, 5, 9, 0, 0);
+const UBER_MATCHED_EXPENSE_OPERATED_AT = new Date(CROSS_BUCKET_YEAR, 2, 5, 18, 0, 0);
+
+const LIME_TITLE = 'LIME RIDE';
+const LIME_REVERSAL_TITLE = 'Скасування. LIME RIDE';
+const LIME_REFUND_AMOUNT_UAH = 340;
+const LIME_REFUND_AMOUNT = LIME_REFUND_AMOUNT_UAH * PRECISION;
+const LIME_SHADOW_AMOUNT_UAH = 120;
+const LIME_SHADOW_AMOUNT = LIME_SHADOW_AMOUNT_UAH * PRECISION;
+const LIME_SHADOW_EXPENSE_OPERATED_AT = new Date(CROSS_BUCKET_YEAR, 2, 12, 9, 0, 0);
+const LIME_TWIN_EXPENSE_OPERATED_AT = new Date(CROSS_BUCKET_YEAR, 2, 12, 10, 0, 0);
+const LIME_MATCHED_EXPENSE_OPERATED_AT = new Date(CROSS_BUCKET_YEAR, 2, 12, 18, 0, 0);
+
+const SPOTIFY_TITLE = 'SPOTIFY';
+const SPOTIFY_REVERSAL_TITLE = 'Скасування. SPOTIFY';
+const SPOTIFY_AMOUNT_UAH = 200;
+const SPOTIFY_AMOUNT = SPOTIFY_AMOUNT_UAH * PRECISION;
+const SPOTIFY_SHADOW_EXPENSE_OPERATED_AT = new Date(CROSS_BUCKET_YEAR, 2, 20, 9, 0, 0);
+const SPOTIFY_MATCHED_EXPENSE_OPERATED_AT = new Date(CROSS_BUCKET_YEAR, 2, 20, 18, 0, 0);
+
+const seedShadowedRefund = (input: {
+    readonly accountId: number;
+    readonly matchedAmount: number;
+    readonly matchedOperatedAt: Date;
+    readonly matchedTitle: string;
+    readonly refundTitle: string;
+    readonly shadowAmount: number;
+    readonly shadowOperatedAt: Date;
+    readonly shadowTitle: string;
+}): {
+    readonly matchedExpense: TransactionEntityInterface;
+    readonly refunds: TransactionEntityInterface[];
+    readonly shadowExpense: TransactionEntityInterface;
+} => {
+    const shadowExpense = testSeedService.refundedExpense({
+        accountId: input.accountId,
+        title: input.shadowTitle,
+        expenseAmount: input.shadowAmount,
+        refundAmounts: [],
+        expenseOperatedAt: input.shadowOperatedAt,
+        externalIdPrefix: 'cross-bucket-shadow'
+    }).expense;
+    const matched = testSeedService.refundedExpense({
+        accountId: input.accountId,
+        title: input.matchedTitle,
+        expenseAmount: input.matchedAmount,
+        refundAmounts: [input.matchedAmount],
+        refundTitle: input.refundTitle,
+        expenseOperatedAt: input.matchedOperatedAt,
+        refundDelaySeconds: CROSS_BUCKET_REFUND_DELAY_SECONDS,
+        externalIdPrefix: 'cross-bucket-matched'
+    });
+
+    return { shadowExpense, matchedExpense: matched.expense, refunds: matched.refunds };
+};
+
+const fetchRankedCandidates = async (): Promise<{
+    readonly auto: RefundCandidateInterface[];
+    readonly review: RefundReviewCandidateInterface[];
+}> => ({ auto: await refundPairRepository.findCandidates(), review: await refundPairRepository.findReviewCandidates() });
+
+describe('consolidation/refund-pair-cross-bucket-rank', () => {
+    it('auto-consolidates the unique localized exact-amount match shadowed by an exact-title candidate of another expense', async () => {
+        const account = testSeedService.account({ externalId: 'mono-card' });
+        const { matchedExpense, refunds, shadowExpense } = seedShadowedRefund({
+            accountId: account.id,
+            shadowTitle: UBER_REVERSAL_TITLE,
+            shadowAmount: UBER_SHADOW_AMOUNT,
+            shadowOperatedAt: UBER_SHADOW_EXPENSE_OPERATED_AT,
+            matchedTitle: UBER_TITLE,
+            matchedAmount: UBER_REFUND_AMOUNT,
+            matchedOperatedAt: UBER_MATCHED_EXPENSE_OPERATED_AT,
+            refundTitle: UBER_REVERSAL_TITLE
+        });
+
+        const { auto, review } = await fetchRankedCandidates();
+
+        expect(auto).toEqual([
+            expect.objectContaining({
+                confidenceBucket: 'AUTO_REFUND_LOCALIZED_REFUND_TITLE',
+                expenseTransactionId: matchedExpense.id,
+                refundIncomeTransactionIds: [refunds[0].id],
+                refundsTotal: UBER_REFUND_AMOUNT
+            })
+        ]);
+        expect(review).toHaveLength(0);
+
+        const result = await runConsolidation();
+
+        expect(result.consolidated).toBe(1);
+        expect(testQueryService.fetchTransactionById(matchedExpense.id).consolidationType).toBe(TransactionConsolidationTypeEnum.REFUND);
+        expect(testQueryService.fetchTransactionById(refunds[0].id).consolidationParentTransactionId).toBe(matchedExpense.id);
+        expect(testQueryService.fetchTransactionById(shadowExpense.id).consolidationType).toBeNull();
+    });
+
+    it('surfaces an ambiguous localized candidate for review instead of dropping the refund behind an exact-title shadow', async () => {
+        const account = testSeedService.account({ externalId: 'mono-card' });
+        testSeedService.refundedExpense({
+            accountId: account.id,
+            title: LIME_TITLE,
+            expenseAmount: LIME_REFUND_AMOUNT,
+            refundAmounts: [],
+            expenseOperatedAt: LIME_TWIN_EXPENSE_OPERATED_AT,
+            externalIdPrefix: 'lime-twin'
+        });
+        const { matchedExpense, refunds } = seedShadowedRefund({
+            accountId: account.id,
+            shadowTitle: LIME_REVERSAL_TITLE,
+            shadowAmount: LIME_SHADOW_AMOUNT,
+            shadowOperatedAt: LIME_SHADOW_EXPENSE_OPERATED_AT,
+            matchedTitle: LIME_TITLE,
+            matchedAmount: LIME_REFUND_AMOUNT,
+            matchedOperatedAt: LIME_MATCHED_EXPENSE_OPERATED_AT,
+            refundTitle: LIME_REVERSAL_TITLE
+        });
+
+        const { auto, review } = await fetchRankedCandidates();
+
+        expect(auto).toHaveLength(0);
+        expect(review).toEqual([
+            expect.objectContaining({
+                confidenceBucket: 'AUTO_REFUND_LOCALIZED_REFUND_TITLE',
+                expenseTransactionId: matchedExpense.id,
+                refundIncomeTransactionIds: [refunds[0].id],
+                refundsTotal: LIME_REFUND_AMOUNT
+            })
+        ]);
+
+        const result = await runConsolidation();
+
+        expect(result.consolidated).toBe(0);
+        expect(testQueryService.fetchTransactionById(refunds[0].id).consolidationParentTransactionId).toBeNull();
+    });
+});
+
+describe('consolidation/refund-pair-cross-bucket-rank exact-title precedence', () => {
+    it('keeps an equally exact-amount exact-title candidate ahead of a localized alternative', async () => {
+        const account = testSeedService.account({ externalId: 'mono-card' });
+        const { matchedExpense, refunds, shadowExpense } = seedShadowedRefund({
+            accountId: account.id,
+            shadowTitle: SPOTIFY_REVERSAL_TITLE,
+            shadowAmount: SPOTIFY_AMOUNT,
+            shadowOperatedAt: SPOTIFY_SHADOW_EXPENSE_OPERATED_AT,
+            matchedTitle: SPOTIFY_TITLE,
+            matchedAmount: SPOTIFY_AMOUNT,
+            matchedOperatedAt: SPOTIFY_MATCHED_EXPENSE_OPERATED_AT,
+            refundTitle: SPOTIFY_TITLE
+        });
+
+        const { auto, review } = await fetchRankedCandidates();
+
+        expect(auto).toHaveLength(0);
+        expect(review).toEqual([
+            expect.objectContaining({
+                confidenceBucket: 'AUTO_REFUND_EXACT_TITLE',
+                expenseTransactionId: matchedExpense.id,
+                refundIncomeTransactionIds: [refunds[0].id]
+            })
+        ]);
+
+        const result = await runConsolidation();
+
+        expect(result.consolidated).toBe(0);
+        expect(testQueryService.fetchTransactionById(refunds[0].id).consolidationParentTransactionId).toBeNull();
+        expect(testQueryService.fetchTransactionById(shadowExpense.id).consolidationType).toBeNull();
+    });
+});


### PR DESCRIPTION
## What / Why

`refundRank` (`PARTITION BY refundTxId`) ordered candidates by **bucket priority first**, and both `REFUND_AUTO_CANDIDATES_SQL` and `REFUND_REVIEW_CANDIDATES_SQL` hard-filter `refundRank = 1`. Because `AUTO_REFUND_EXACT_TITLE` imposes **no amount condition**, a same-raw-title expense with a completely different amount seized rank 1 for a refund, hiding that refund's *unique localized exact-amount* match at rank 2 — where neither the auto query nor the review query could reach it.

Fixes #605. Part of epic #632.

## Pre-fix behavior observed (post-#633, measured — not assumed)

Both severity tiers from the issue survived #633's `gated_candidates` / `filled_candidates` rework:

| Scenario | Pre-fix auto | Pre-fix review | Tier |
| --- | --- | --- | --- |
| Refund 340 UAH; shadow `Скасування. UBER TRIP` expense 500 UAH (EXACT_TITLE); true `UBER TRIP` expense 340 UAH (LOCALIZED, exact) | `[]` | one row pointing at the **wrong** (shadow) expense, 340 ≤ 500 passes `HAVING` | **misrouted review** |
| Refund 340 UAH; shadow `Скасування. LIME RIDE` expense 120 UAH (EXACT_TITLE); two `LIME RIDE` expenses 340 UAH (LOCALIZED, ambiguous) | `[]` | `[]` — the rank-1 shadow row is killed by `HAVING SUM(refundAmount) <= expenseAmount` (340 ≤ 120 fails) and rank-2 rows are filtered out | **silent drop** (refund vanishes entirely) |

## Chosen design: option 2 (reorder ranking keys)

`buildLocalizedAmountMismatchOrderSql` (localized-bucket-only, applied *after* bucket priority) is replaced by a bucket-agnostic `buildAmountMismatchOrderSql` placed *before* bucket priority:

```sql
ORDER BY CASE WHEN refundAmount = <REFUND_CEILING_SQL> THEN 0 ELSE 1 END,
         <bucketPriority>, timeDiff
```

Why option 2 over per-bucket ranking (option 1):

- Option 1 (rank per `(refundTxId, confidenceBucket)`, accept in bucket order) **fails the precedence guard**: acceptance would fall through an unacceptable-but-plausible EXACT_TITLE row to a localized-exact-sole row even when the exact-title expense has the *same* exact amount. The real discriminator between "wrong rank-1" and "genuinely better rank-1" is amount-exactness, not bucket membership.
- Option 2 keeps `refundRank = 1` everywhere, so #633's single-winner-per-refund invariant is preserved *by construction* — no new CTE level, no new gate, no risk of a refund being auto-consolidated onto two expenses via two buckets.
- The new key is a strict generalisation of the key it replaces: for `AUTO_REFUND_LOCALIZED_REFUND_TITLE` rows it is identical, and `REJECTED_PAYMENT_PRINCIPAL/FEE` rows are exact by their own bucket conditions (`inc.amount = exp.amount` / `inc.amount = exp.feeAmount`), so only `AUTO_REFUND_EXACT_TITLE` and review rows change relative order — and only against a competing exact-amount candidate.
- Symmetric application to `expenseRank` keeps both windows on the same ordering keys (no divergence between "the refund's best expense" and "the expense's best refund").

## Invariants

| Invariant | Before | After |
| --- | --- | --- |
| At most one auto-eligible row per refund | `refundRank = 1` | unchanged |
| Bucket priority decides between equally exact candidates | yes | yes (bucket key still ahead of `timeDiff`) |
| Amount-exact candidate outranks an inexact one | localized bucket only, below bucket priority | all buckets, above bucket priority |
| Localized-exact-sole auto acceptance (#603) | `localizedExactAmountMatchCount = 1` | unchanged |
| Mutual-best gate / running fill / fee ceiling (#633, #612) | `rejectedBetterRankedRefundCount`, `expenseFilledRefundTotal` | unchanged |
| Refund never vanishes when nothing auto-fires | violated (silent drop) | review falls through to the best exact-amount candidate |

## Test evidence

New file `tests/consolidation-tests/src/scenarios/refund-pair-cross-bucket-rank.test.ts` (written first, confirmed failing on `origin/main`):

- **E** cross-bucket shadow → the unique localized exact-amount match auto-consolidates, review is empty, shadow expense untouched.
- **F** same shadow with ambiguous localized twins → nothing auto-consolidates, the refund still surfaces for review against its nearest exact-amount localized candidate.
- **Guard** equally exact-amount EXACT_TITLE candidate vs localized alternative → EXACT_TITLE stays rank 1, the localized row does not steal the refund, nothing auto-consolidates.

Assertions cover both `refundPairRepository.findCandidates()` / `findReviewCandidates()` and post-`runConsolidation()` database state.

| Suite | Before | After |
| --- | --- | --- |
| `tests/consolidation-tests` | 25 files / 66 tests passing | 26 files / **69 tests passing**, 0 regressions |

Untouched-by-design suites verified green: `refund-pair-competing-refunds`, `refund-pair-localized-exact-amount`, `refund-pair-by-title`, `refund-pair-rejected-payment`(+ statistics), `refund-pair-multiple-refunds`, `refund-pair-manual-review`.

## EXPLAIN QUERY PLAN

Captured for `REFUND_AUTO_CANDIDATES_SQL(null)` and `REFUND_REVIEW_CANDIDATES_SQL` on the migrated test schema, before and after:

- Base-table access unchanged, still all index searches: `transactions_visible_type_operated_idx` for both `income_tx` and `expense_tx`, `transaction_entries_live_transaction_account_amount_idx` for both entry joins, `INTEGER PRIMARY KEY` for the account joins.
- No new full-table scans (`SCAN` line count identical at 20; every `SCAN` is a CTE co-routine, not a table).
- Only delta: the ordering key references the refund ceiling, so SQLite evaluates the `expense_fee_entry` correlated scalar subquery once more per query (9 → 10 instances), each an index search with its existing `LIMIT 1` temp B-tree. No new temp B-tree kinds; `GROUP BY` / `group_concat(ORDER BY)` B-trees unchanged.

## Validation

`yarn format && yarn ts && yarn lint && yarn deadcode && yarn cpd` — all clean. No new eslint-disables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved refund matching by prioritizing candidates with amounts that align with applicable refund limits.
  - Ensured consistent ranking across refund and expense candidates.
  - Unique exact-amount matches can now be consolidated automatically, even when title matches conflict.
  - Ambiguous matches are surfaced for review instead of being consolidated incorrectly.
  - Exact title and amount matches retain priority over localized alternatives.

- **Tests**
  - Added coverage for cross-category refund matching and ranking scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->