### PR TITLE
fix(consolidation): fx-tolerant bridge chain reclaim with rebuild fallback

### DIFF
--- a/packages/consolidation/src/auto/service/iban-bridge-chain-transfer-consolidation-family.service.ts
+++ b/packages/consolidation/src/auto/service/iban-bridge-chain-transfer-consolidation-family.service.ts
@@ -1,5 +1,4 @@
-import { TransactionConsolidationTypeEnum } from '@budgie/contracts';
-
+import { buildIbanBridgeChainCanonicalInput } from '../../executor/utils/build-iban-bridge-chain-canonical-input.util';
 import { ConsolidationFamilyKeyEnum } from '../enum/consolidation-family-key.enum';
 
 import { ConsolidationFamilyStrategyService } from './consolidation-family-strategy.service';
@@ -41,7 +40,7 @@ export class IbanBridgeChainTransferConsolidationFamilyService extends Consolida
         return {
             sourceTransactionIds: this.getSourceTransactionIds(candidate),
             allowedMovedSourceTransactionIds: [],
-            canonicalInput: {
+            canonicalInput: buildIbanBridgeChainCanonicalInput({
                 title:
                     candidate.bridgeExpenseTransactionTitle ??
                     candidate.sourceExpenseTransactionTitle ??
@@ -54,11 +53,8 @@ export class IbanBridgeChainTransferConsolidationFamilyService extends Consolida
                 fromAmount: candidate.sourceAmount,
                 toAmount: candidate.targetAmount,
                 exchangeRate: candidate.exchangeRate,
-                consolidationType: TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER,
-                fromEntryExchangeRate: candidate.exchangeRate,
-                toEntryExchangeRate: 1,
                 fromEntryToIban: candidate.sourceExpenseEntryToIban
-            }
+            })
         };
     }
 }

--- a/packages/consolidation/src/auto/service/iban-bridge-transfer-consolidation-family.service.ts
+++ b/packages/consolidation/src/auto/service/iban-bridge-transfer-consolidation-family.service.ts
@@ -1,7 +1,5 @@
 import { TransactionConsolidationTypeEnum } from '@budgie/contracts';
 
-import { isDefined } from '@rnw-community/shared';
-
 import { ConsolidationFamilyKeyEnum } from '../enum/consolidation-family-key.enum';
 
 import { ConsolidationFamilyStrategyService } from './consolidation-family-strategy.service';
@@ -31,13 +29,7 @@ export class IbanBridgeTransferConsolidationFamilyService extends ConsolidationF
     }
 
     protected getSourceTransactionIds(candidate: IbanBridgeTransferCandidateInterface): number[] {
-        const sourceTransactionIds = [candidate.expenseTransactionId, candidate.incomeTransactionId];
-
-        if (isDefined(candidate.existingDirectTransferId)) {
-            return [...sourceTransactionIds, candidate.existingDirectTransferId];
-        }
-
-        return sourceTransactionIds;
+        return [candidate.expenseTransactionId, candidate.incomeTransactionId];
     }
 
     private buildConsolidationPlan(candidate: IbanBridgeTransferCandidateInterface): ConsolidationPlanInterface {

--- a/packages/consolidation/src/executor/interface/iban-bridge-chain-canonical-input.interface.ts
+++ b/packages/consolidation/src/executor/interface/iban-bridge-chain-canonical-input.interface.ts
@@ -1,0 +1,6 @@
+import type { CanonicalTransferInputInterface } from './canonical-transfer-input.interface';
+
+export type IbanBridgeChainCanonicalInputInterface = Omit<
+    CanonicalTransferInputInterface,
+    'consolidationType' | 'fromEntryExchangeRate' | 'toEntryExchangeRate'
+>;

--- a/packages/consolidation/src/executor/service/consolidation-executor.service.ts
+++ b/packages/consolidation/src/executor/service/consolidation-executor.service.ts
@@ -60,7 +60,7 @@ export class ConsolidationExecutorService {
         (candidate, consolidationPlan) =>
             `enter ibanBridge=${candidate.expenseTransactionId}/${candidate.incomeTransactionId} route=${candidate.sourceAccountId}->${candidate.bridgeAccountId}->${candidate.targetAccountId} rate=${candidate.exchangeRate} plan=${consolidationPlan.sourceTransactionIds.join(',')}/${consolidationPlan.canonicalInput.consolidationType}`,
         (result, candidate, consolidationPlan) =>
-            `done ibanBridgeResult=${String(result)} direct=${candidate.existingDirectTransferId ?? ''} plan=${consolidationPlan.sourceTransactionIds.join(',')}/${consolidationPlan.canonicalInput.consolidationType}`,
+            `done ibanBridgeResult=${String(result)} bridgeAccountId=${candidate.bridgeAccountId} plan=${consolidationPlan.sourceTransactionIds.join(',')}/${consolidationPlan.canonicalInput.consolidationType}`,
         (error, candidate, consolidationPlan) =>
             `throw ibanBridge=${candidate.expenseTransactionId}/${candidate.incomeTransactionId} amount=${candidate.bridgeAmount} plan=${consolidationPlan.sourceTransactionIds.join(',')}/${consolidationPlan.canonicalInput.consolidationType} error=${getErrorMessage(error)}`
     )

--- a/packages/consolidation/src/executor/service/consolidation-repair-executor.service.ts
+++ b/packages/consolidation/src/executor/service/consolidation-repair-executor.service.ts
@@ -1,7 +1,10 @@
-import { TransactionConsolidationTypeEnum } from '@budgie/contracts';
+import { TransactionConsolidationTypeEnum, TransactionEntryTypeEnum } from '@budgie/contracts';
 import { Log } from '@budgie/logger';
 
-import { getErrorMessage } from '@rnw-community/shared';
+import { getErrorMessage, isDefined, isPositiveNumber } from '@rnw-community/shared';
+
+import { IBAN_BRIDGE_CHAIN_FX_TOLERANCE } from '../../shared/constant/iban-bridge-chain-fx-tolerance.constant';
+import { buildIbanBridgeChainCanonicalInput } from '../utils/build-iban-bridge-chain-canonical-input.util';
 
 import { ConsolidationEligibilityService } from './consolidation-eligibility.service';
 import { ConsolidationMutationService } from './consolidation-mutation.service';
@@ -12,7 +15,8 @@ import type {
     ExistingTransferChainReclaimCandidateInterface,
     ExistingTransferIncomeDuplicateCandidateInterface,
     IbanBridgeCanonicalDuplicateCandidateInterface,
-    RefundCandidateInterface
+    RefundCandidateInterface,
+    TransactionWithEntriesEntityInterface
 } from '@budgie/contracts';
 
 export class ConsolidationRepairExecutorService {
@@ -98,11 +102,11 @@ export class ConsolidationRepairExecutorService {
         candidate: ExistingTransferChainReclaimCandidateInterface,
         tx: DB
     ): Promise<boolean> {
-        const sourceTransactionIds = [candidate.bridgeIncomeTransactionId, candidate.bridgeExpenseTransactionId];
+        const bridgeSourceTransactionIds = [candidate.bridgeIncomeTransactionId, candidate.bridgeExpenseTransactionId];
 
         if (
             !(await this.consolidationEligibilityService.isExistingTransferConsolidationStillEligible(
-                sourceTransactionIds,
+                bridgeSourceTransactionIds,
                 candidate.existingTransferId,
                 tx
             ))
@@ -110,14 +114,97 @@ export class ConsolidationRepairExecutorService {
             return false;
         }
 
+        const [existingTransfer] = await this.dependencies.transactionRepository.findByIds([candidate.existingTransferId], tx);
+
+        if (!isDefined(existingTransfer)) {
+            return false;
+        }
+
+        if (this.hasChainReclaimConsistentLedger(candidate, existingTransfer)) {
+            return this.absorbChainReclaimBridgeLegs(candidate, bridgeSourceTransactionIds, tx);
+        }
+
+        return this.rebuildChainReclaimCanonical(candidate, existingTransfer.title, tx);
+    }
+
+    private async absorbChainReclaimBridgeLegs(
+        candidate: ExistingTransferChainReclaimCandidateInterface,
+        bridgeSourceTransactionIds: number[],
+        tx: DB
+    ): Promise<boolean> {
         await this.dependencies.transactionRepository.setConsolidationType(
             candidate.existingTransferId,
             TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER,
             tx
         );
-        await this.consolidationMutationService.moveSourcesToCanonical(sourceTransactionIds, candidate.existingTransferId, tx);
+        await this.consolidationMutationService.moveSourcesToCanonical(bridgeSourceTransactionIds, candidate.existingTransferId, tx);
 
         return true;
+    }
+
+    private async rebuildChainReclaimCanonical(
+        candidate: ExistingTransferChainReclaimCandidateInterface,
+        existingTransferTitle: string,
+        tx: DB
+    ): Promise<boolean> {
+        const canonicalTransaction = await this.consolidationMutationService.createCanonicalTransfer(
+            buildIbanBridgeChainCanonicalInput({
+                title: existingTransferTitle,
+                operatedAt: candidate.operatedAt,
+                fromAccountId: candidate.sourceAccountId,
+                toAccountId: candidate.targetAccountId,
+                fromAmount: candidate.sourceAmount,
+                toAmount: candidate.targetAmount,
+                exchangeRate: candidate.exchangeRate,
+                fromEntryToIban: candidate.targetAccountIban
+            }),
+            tx
+        );
+
+        await this.consolidationMutationService.moveSourcesToCanonical(
+            [candidate.bridgeIncomeTransactionId, candidate.bridgeExpenseTransactionId, candidate.existingTransferId],
+            canonicalTransaction.id,
+            tx
+        );
+
+        return true;
+    }
+
+    private hasChainReclaimConsistentLedger(
+        candidate: ExistingTransferChainReclaimCandidateInterface,
+        existingTransfer: TransactionWithEntriesEntityInterface
+    ): boolean {
+        if (existingTransfer.fromAccountId !== candidate.sourceAccountId || existingTransfer.toAccountId !== candidate.targetAccountId) {
+            return false;
+        }
+
+        const sourceEntry = existingTransfer.entries.find(
+            entry => entry.accountId === candidate.sourceAccountId && entry.type === TransactionEntryTypeEnum.CREDIT
+        );
+        const targetEntry = existingTransfer.entries.find(
+            entry => entry.accountId === candidate.targetAccountId && entry.type === TransactionEntryTypeEnum.DEBIT
+        );
+
+        if (!isDefined(sourceEntry) || !isDefined(targetEntry)) {
+            return false;
+        }
+
+        return (
+            sourceEntry.amount === candidate.sourceAmount &&
+            targetEntry.amount === candidate.targetAmount &&
+            targetEntry.exchangeRate === 1 &&
+            sourceEntry.toIban === candidate.targetAccountIban &&
+            this.isWithinChainFxTolerance(sourceEntry.exchangeRate, candidate.exchangeRate) &&
+            this.isWithinChainFxTolerance(existingTransfer.exchangeRate, candidate.exchangeRate)
+        );
+    }
+
+    private isWithinChainFxTolerance(actualRate: number, expectedRate: number): boolean {
+        if (!isPositiveNumber(expectedRate)) {
+            return false;
+        }
+
+        return Math.abs(actualRate - expectedRate) / expectedRate <= IBAN_BRIDGE_CHAIN_FX_TOLERANCE;
     }
 
     private async consolidateExistingTransferIncomeDuplicateInner(

--- a/packages/consolidation/src/executor/utils/build-iban-bridge-chain-canonical-input.util.ts
+++ b/packages/consolidation/src/executor/utils/build-iban-bridge-chain-canonical-input.util.ts
@@ -1,0 +1,18 @@
+import { TransactionConsolidationTypeEnum } from '@budgie/contracts';
+
+import type { CanonicalTransferInputInterface } from '../interface/canonical-transfer-input.interface';
+import type { IbanBridgeChainCanonicalInputInterface } from '../interface/iban-bridge-chain-canonical-input.interface';
+
+export const buildIbanBridgeChainCanonicalInput = (input: IbanBridgeChainCanonicalInputInterface): CanonicalTransferInputInterface => ({
+    title: input.title,
+    operatedAt: input.operatedAt,
+    fromAccountId: input.fromAccountId,
+    toAccountId: input.toAccountId,
+    fromAmount: input.fromAmount,
+    toAmount: input.toAmount,
+    exchangeRate: input.exchangeRate,
+    consolidationType: TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER,
+    fromEntryExchangeRate: input.exchangeRate,
+    toEntryExchangeRate: 1,
+    fromEntryToIban: input.fromEntryToIban
+});

--- a/packages/consolidation/src/query/repository/sql-factory/transfer-pair-existing-transfer-chain-reclaim-sql.factory.ts
+++ b/packages/consolidation/src/query/repository/sql-factory/transfer-pair-existing-transfer-chain-reclaim-sql.factory.ts
@@ -1,5 +1,6 @@
 import { TransactionConsolidationTypeEnum, TransactionTypeEnum } from '@budgie/contracts';
 
+import { IBAN_BRIDGE_CHAIN_FX_TOLERANCE } from '../../../shared/constant/iban-bridge-chain-fx-tolerance.constant';
 import { TRANSFER_MCC_GROUP_ID } from '../../../shared/constant/transfer-mcc-group-id.constant';
 import { TRANSFER_PAIR_FAST_TIME_WINDOW_SECONDS } from '../../../shared/constant/transfer-pair-fast-time-window.constant';
 import { applyConsolidationScanScopeSql } from '../../utils/apply-consolidation-scan-scope-sql.util';
@@ -32,6 +33,7 @@ const EXISTING_TRANSFER_CHAIN_RECLAIM_CANDIDATES_BASE_SQL = `
                 bridgeAccountTitle,
                 targetAccountId,
                 targetAccountTitle,
+                targetAccountIban,
                 sourceAmount,
                 bridgeAmount,
                 targetAmount,
@@ -52,6 +54,7 @@ const EXISTING_TRANSFER_CHAIN_RECLAIM_CANDIDATES_BASE_SQL = `
                     bridge_account.title as bridgeAccountTitle,
                     target_account.id as targetAccountId,
                     target_account.title as targetAccountTitle,
+                    target_account.iban as targetAccountIban,
                     existing_source_entry.amount as sourceAmount,
                     bridge_income_entry.amount as bridgeAmount,
                     existing_target_entry.amount as targetAmount,
@@ -128,7 +131,7 @@ const EXISTING_TRANSFER_CHAIN_RECLAIM_CANDIDATES_BASE_SQL = `
                     AND bridge_income_entry.exchange_rate > 0
                     AND bridge_income_entry.amount = existing_target_entry.amount
                     AND bridge_income_entry.to_iban = source_account.iban
-                    AND ROUND(bridge_income_entry.amount / bridge_income_entry.exchange_rate) = existing_source_entry.amount
+                    AND ABS(existing_source_entry.amount - (bridge_income_entry.amount / bridge_income_entry.exchange_rate)) / existing_source_entry.amount <= ${IBAN_BRIDGE_CHAIN_FX_TOLERANCE}
                 INNER JOIN accounts bridge_account ON
                     bridge_account.id = bridge_income_entry.account_id
                     AND bridge_account.deleted_at IS NULL

--- a/packages/consolidation/src/query/repository/sql-factory/transfer-pair-iban-bridge-chain-sql.factory.ts
+++ b/packages/consolidation/src/query/repository/sql-factory/transfer-pair-iban-bridge-chain-sql.factory.ts
@@ -1,5 +1,6 @@
 import { TransactionTypeEnum } from '@budgie/contracts';
 
+import { IBAN_BRIDGE_CHAIN_FX_TOLERANCE } from '../../../shared/constant/iban-bridge-chain-fx-tolerance.constant';
 import { TRANSFER_MCC_GROUP_ID } from '../../../shared/constant/transfer-mcc-group-id.constant';
 import { TRANSFER_PAIR_FAST_TIME_WINDOW_SECONDS } from '../../../shared/constant/transfer-pair-fast-time-window.constant';
 import { applyConsolidationScanScopeSql } from '../../utils/apply-consolidation-scan-scope-sql.util';
@@ -205,7 +206,7 @@ const IBAN_BRIDGE_CHAIN_TRANSFER_CANDIDATES_BASE_SQL = `
                     AND source_account.id != bridge_account.id
                     AND bridge_account.id != target_account.id
                     AND source_account.id != target_account.id
-                    AND ABS(source_expense_entry.amount - (bridge_income_entry.amount / bridge_income_entry.exchange_rate)) / source_expense_entry.amount <= 0.01
+                    AND ABS(source_expense_entry.amount - (bridge_income_entry.amount / bridge_income_entry.exchange_rate)) / source_expense_entry.amount <= ${IBAN_BRIDGE_CHAIN_FX_TOLERANCE}
                     AND (
                         source_expense_mcc.mcc_group_id = ${TRANSFER_MCC_GROUP_ID}
                         OR bridge_income_mcc.mcc_group_id = ${TRANSFER_MCC_GROUP_ID}

--- a/packages/consolidation/src/query/repository/sql-factory/transfer-pair-iban-bridge-transfer-sql.factory.ts
+++ b/packages/consolidation/src/query/repository/sql-factory/transfer-pair-iban-bridge-transfer-sql.factory.ts
@@ -1,5 +1,6 @@
 import { TransactionTypeEnum } from '@budgie/contracts';
 
+import { IBAN_BRIDGE_CHAIN_FX_TOLERANCE } from '../../../shared/constant/iban-bridge-chain-fx-tolerance.constant';
 import { TRANSFER_MCC_GROUP_ID } from '../../../shared/constant/transfer-mcc-group-id.constant';
 import { TRANSFER_PAIR_FAST_TIME_WINDOW_SECONDS } from '../../../shared/constant/transfer-pair-fast-time-window.constant';
 import { applyConsolidationScanScopeSql } from '../../utils/apply-consolidation-scan-scope-sql.util';
@@ -110,37 +111,6 @@ const IBAN_BRIDGE_TRANSFER_CANDIDATES_BASE_SQL = `
                 targetAccountId,
                 targetAccountTitle,
                 sourceAmount * 1.0 / bridgeAmount as exchangeRate,
-                (
-                    SELECT direct_tx.id
-                    FROM transactions direct_tx
-                    WHERE direct_tx.type = '${TransactionTypeEnum.TRANSFER}'
-                        AND direct_tx.deleted_at IS NULL
-                        AND direct_tx.consolidation_parent_transaction_id IS NULL
-                        AND direct_tx.from_account_id = bridge_candidates.sourceAccountId
-                        AND direct_tx.to_account_id = bridge_candidates.targetAccountId
-                        AND direct_tx.operated_at BETWEEN bridge_candidates.operatedAt - ${TRANSFER_PAIR_FAST_TIME_WINDOW_SECONDS}
-                            AND bridge_candidates.operatedAt + ${TRANSFER_PAIR_FAST_TIME_WINDOW_SECONDS}
-                        ${DIRECT_TRANSFER_SCOPE_SQL_PLACEHOLDER}
-                        AND EXISTS (
-                            SELECT 1
-                            FROM transaction_entries direct_source_entry
-                            WHERE direct_source_entry.transaction_id = direct_tx.id
-                                AND direct_source_entry.deleted_at IS NULL
-                                AND direct_source_entry.original_transaction_id IS NULL
-                                AND direct_source_entry.account_id = bridge_candidates.sourceAccountId
-                                AND direct_source_entry.amount = bridge_candidates.sourceAmount
-                        )
-                        AND EXISTS (
-                            SELECT 1
-                            FROM transaction_entries direct_target_entry
-                            WHERE direct_target_entry.transaction_id = direct_tx.id
-                                AND direct_target_entry.deleted_at IS NULL
-                                AND direct_target_entry.original_transaction_id IS NULL
-                                AND direct_target_entry.account_id = bridge_candidates.targetAccountId
-                                AND direct_target_entry.amount = bridge_candidates.bridgeAmount
-                        )
-                    LIMIT 1
-                ) as existingDirectTransferId,
                 timeDiff
             FROM bridge_candidates
             WHERE NOT EXISTS (
@@ -161,7 +131,8 @@ const IBAN_BRIDGE_TRANSFER_CANDIDATES_BASE_SQL = `
                             AND direct_source_entry.deleted_at IS NULL
                             AND direct_source_entry.original_transaction_id IS NULL
                             AND direct_source_entry.account_id = bridge_candidates.sourceAccountId
-                            AND direct_source_entry.amount = bridge_candidates.sourceAmount
+                            AND direct_source_entry.amount > 0
+                            AND ABS(direct_source_entry.amount - bridge_candidates.sourceAmount) / direct_source_entry.amount <= ${IBAN_BRIDGE_CHAIN_FX_TOLERANCE}
                     )
                     AND EXISTS (
                         SELECT 1

--- a/packages/consolidation/src/shared/constant/iban-bridge-chain-fx-tolerance.constant.ts
+++ b/packages/consolidation/src/shared/constant/iban-bridge-chain-fx-tolerance.constant.ts
@@ -1,0 +1,1 @@
+export const IBAN_BRIDGE_CHAIN_FX_TOLERANCE = 0.01;

--- a/packages/contracts/src/transaction/interface/existing-transfer-chain-reclaim-candidate.interface.ts
+++ b/packages/contracts/src/transaction/interface/existing-transfer-chain-reclaim-candidate.interface.ts
@@ -22,4 +22,5 @@ export interface ExistingTransferChainReclaimCandidateInterface extends Pick<
     readonly confidenceBucket: 'AUTO_EXISTING_TRANSFER_CHAIN_RECLAIM';
     readonly existingTransferId: number;
     readonly existingTransferTitle: string | null;
+    readonly targetAccountIban: string;
 }

--- a/packages/contracts/src/transaction/interface/iban-bridge-transfer-candidate.interface.ts
+++ b/packages/contracts/src/transaction/interface/iban-bridge-transfer-candidate.interface.ts
@@ -19,6 +19,5 @@ export interface IbanBridgeTransferCandidateInterface {
     readonly targetAccountId: number;
     readonly targetAccountTitle: string;
     readonly exchangeRate: number;
-    readonly existingDirectTransferId: number | null;
     readonly timeDiff: number;
 }

--- a/tests/consolidation-tests/src/harness/chain-reclaim-fixture.ts
+++ b/tests/consolidation-tests/src/harness/chain-reclaim-fixture.ts
@@ -1,0 +1,185 @@
+import { TransactionConsolidationTypeEnum } from '@budgie/contracts';
+import { expect } from 'vitest';
+
+import { isDefined } from '@rnw-community/shared';
+
+import { testDb, testQueryService, testSeedService } from './test-context';
+
+import type { TransactionEntityInterface, TransactionEntryEntityInterface } from '@budgie/contracts';
+
+export const CHAIN_RECLAIM_SOURCE_IBAN = 'UA-RECLAIM-SOURCE-EUR';
+export const CHAIN_RECLAIM_TARGET_IBAN = 'UA-RECLAIM-TARGET-UAH';
+export const CHAIN_RECLAIM_EUR_AMOUNT = 1_658_290_000;
+export const CHAIN_RECLAIM_UAH_AMOUNT = 84_456_700_000;
+export const CHAIN_RECLAIM_UAH_TO_EUR_RATE = CHAIN_RECLAIM_EUR_AMOUNT / CHAIN_RECLAIM_UAH_AMOUNT;
+export const CHAIN_RECLAIM_ONE_CENT_AMOUNT = 10_000;
+export const CHAIN_RECLAIM_STALE_RATE_MULTIPLIER = 2;
+
+const CHAIN_RECLAIM_BRIDGE_IBAN = 'UA-RECLAIM-BRIDGE-UAH';
+const CHAIN_RECLAIM_EUR_TO_UAH_RATE = CHAIN_RECLAIM_UAH_AMOUNT / CHAIN_RECLAIM_EUR_AMOUNT;
+const CHAIN_RECLAIM_OPERATED_AT = new Date('2026-05-20T18:38:00');
+
+const seedAccounts = () => {
+    const eur = testSeedService.instrument({ code: 'EUR', name: 'Euro', symbol: 'EUR' });
+    const sourceAccount = testSeedService.bankSyncAccount('Reclaim Source EUR', null, CHAIN_RECLAIM_SOURCE_IBAN, eur.id);
+    const bridgeAccount = testSeedService.bankSyncAccount('Reclaim Bridge UAH', null, CHAIN_RECLAIM_BRIDGE_IBAN);
+    const targetAccount = testSeedService.bankSyncAccount('Reclaim Target UAH', null, CHAIN_RECLAIM_TARGET_IBAN);
+
+    return { sourceAccount, bridgeAccount, targetAccount };
+};
+
+const seedDirectTransfer = (input: {
+    readonly consolidationType: TransactionConsolidationTypeEnum | null;
+    readonly exchangeRate: number;
+    readonly sourceAccountId: number;
+    readonly sourceAmount: number;
+    readonly targetAccountId: number;
+    readonly toIban: string;
+}): TransactionEntityInterface =>
+    testSeedService.directTransfer({
+        consolidationType: input.consolidationType,
+        exchangeRate: input.exchangeRate,
+        operatedAt: CHAIN_RECLAIM_OPERATED_AT,
+        sourceAccountId: input.sourceAccountId,
+        sourceAmount: input.sourceAmount,
+        sourceEntryExchangeRate: input.exchangeRate,
+        targetAccountId: input.targetAccountId,
+        targetAmount: CHAIN_RECLAIM_UAH_AMOUNT,
+        toIban: input.toIban
+    });
+
+const seedBridgeLegs = (bridgeAccountId: number, transferMccId: number) => {
+    const bridgeIncome = testSeedService.bankPairIncome(
+        { externalId: 'reclaim-bridge-income', operatedAt: CHAIN_RECLAIM_OPERATED_AT },
+        {
+            accountId: bridgeAccountId,
+            amount: CHAIN_RECLAIM_UAH_AMOUNT,
+            exchangeRate: CHAIN_RECLAIM_EUR_TO_UAH_RATE,
+            mccCategoryId: transferMccId,
+            toIban: CHAIN_RECLAIM_SOURCE_IBAN
+        }
+    );
+    const bridgeExpense = testSeedService.bankPairExpense(
+        { externalId: 'reclaim-bridge-expense', operatedAt: CHAIN_RECLAIM_OPERATED_AT },
+        {
+            accountId: bridgeAccountId,
+            amount: CHAIN_RECLAIM_UAH_AMOUNT,
+            mccCategoryId: transferMccId,
+            toIban: CHAIN_RECLAIM_TARGET_IBAN
+        }
+    );
+
+    return { bridgeIncome, bridgeExpense };
+};
+
+const seedDirectSourceRows = (sourceAccountId: number, targetAccountId: number, transferMccId: number) => {
+    const sourceExpense = testSeedService.bankPairExpense(
+        { externalId: 'reclaim-source-expense', operatedAt: CHAIN_RECLAIM_OPERATED_AT },
+        {
+            accountId: sourceAccountId,
+            amount: CHAIN_RECLAIM_EUR_AMOUNT,
+            exchangeRate: CHAIN_RECLAIM_UAH_TO_EUR_RATE,
+            mccCategoryId: transferMccId,
+            toIban: CHAIN_RECLAIM_TARGET_IBAN
+        }
+    );
+    const targetIncome = testSeedService.bankPairIncome(
+        { externalId: 'reclaim-target-income', operatedAt: CHAIN_RECLAIM_OPERATED_AT },
+        {
+            accountId: targetAccountId,
+            amount: CHAIN_RECLAIM_UAH_AMOUNT,
+            mccCategoryId: transferMccId
+        }
+    );
+
+    return { sourceExpense, targetIncome };
+};
+
+const parentSourceTransaction = async (sourceTransactionId: number, canonicalTransactionId: number): Promise<void> => {
+    await testDb.$client.runAsync(
+        'UPDATE transaction_entries SET original_transaction_id = ?, transaction_id = ? WHERE transaction_id = ?',
+        [sourceTransactionId, canonicalTransactionId, sourceTransactionId]
+    );
+    await testDb.$client.runAsync('UPDATE transactions SET consolidation_parent_transaction_id = ? WHERE id = ?', [
+        canonicalTransactionId,
+        sourceTransactionId
+    ]);
+};
+
+export const seedChainReclaimFixture = (input: {
+    readonly consolidationType: TransactionConsolidationTypeEnum | null;
+    readonly directExchangeRate?: number;
+    readonly directSourceAmount?: number;
+    readonly directToIban?: string;
+}) => {
+    const transferMcc = testQueryService.findMccByCode('4829');
+    const { sourceAccount, bridgeAccount, targetAccount } = seedAccounts();
+    const sourceAmount = input.directSourceAmount ?? CHAIN_RECLAIM_EUR_AMOUNT;
+    const directTransfer = seedDirectTransfer({
+        consolidationType: input.consolidationType,
+        exchangeRate: input.directExchangeRate ?? sourceAmount / CHAIN_RECLAIM_UAH_AMOUNT,
+        sourceAccountId: sourceAccount.id,
+        sourceAmount,
+        targetAccountId: targetAccount.id,
+        toIban: input.directToIban ?? CHAIN_RECLAIM_TARGET_IBAN
+    });
+
+    return {
+        ...seedBridgeLegs(bridgeAccount.id, transferMcc.id),
+        directTransfer,
+        sourceAccount,
+        targetAccount,
+        transferMcc
+    };
+};
+
+export const seedNestedChainReclaimFixture = async () => {
+    const fixture = seedChainReclaimFixture({ consolidationType: TransactionConsolidationTypeEnum.TRANSFER_PAIR });
+    const { sourceExpense, targetIncome } = seedDirectSourceRows(
+        fixture.sourceAccount.id,
+        fixture.targetAccount.id,
+        fixture.transferMcc.id
+    );
+
+    await parentSourceTransaction(sourceExpense.id, fixture.directTransfer.id);
+    await parentSourceTransaction(targetIncome.id, fixture.directTransfer.id);
+
+    return { ...fixture, sourceExpense, targetIncome };
+};
+
+export const expectChainReclaimParent = (sourceTransactionId: number, canonicalTransactionId: number): void => {
+    expect(testQueryService.fetchTransactionById(sourceTransactionId).consolidationParentTransactionId).toBe(canonicalTransactionId);
+};
+
+export const expectChainReclaimUnparented = (sourceTransactionIds: number[]): void => {
+    for (const sourceTransactionId of sourceTransactionIds) {
+        expect(testQueryService.fetchTransactionById(sourceTransactionId).consolidationParentTransactionId).toBeNull();
+    }
+};
+
+export const expectAbsorbedIntoExistingTransfer = (directTransferId: number, bridgeIncomeId: number, bridgeExpenseId: number): void => {
+    const canonicals = testQueryService.fetchCanonicalsOfType(TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER);
+
+    expect(canonicals).toHaveLength(1);
+    expect(canonicals[0].id).toBe(directTransferId);
+    expectChainReclaimParent(bridgeIncomeId, directTransferId);
+    expectChainReclaimParent(bridgeExpenseId, directTransferId);
+};
+
+export const fetchChainReclaimMovedSourceIds = (canonicalTransactionId: number): number[] =>
+    testQueryService
+        .fetchEntriesByTransactionId(canonicalTransactionId)
+        .flatMap(entry => (isDefined(entry.originalTransactionId) ? [entry.originalTransactionId] : []));
+
+export const fetchChainReclaimOwnLedger = (canonicalTransactionId: number): TransactionEntryEntityInterface[] =>
+    testQueryService.fetchEntriesByTransactionId(canonicalTransactionId).filter(entry => !isDefined(entry.originalTransactionId));
+
+export const fetchChainReclaimLedgerEntry = (canonicalTransactionId: number, accountId: number): TransactionEntryEntityInterface => {
+    const entry = fetchChainReclaimOwnLedger(canonicalTransactionId).find(candidate => candidate.accountId === accountId);
+
+    if (!isDefined(entry)) {
+        throw new Error(`Ledger entry for account ${accountId} on transaction ${canonicalTransactionId} not found`);
+    }
+
+    return entry;
+};

--- a/tests/consolidation-tests/src/scenarios/iban-bridge-chain-reclaim-rebuild.test.ts
+++ b/tests/consolidation-tests/src/scenarios/iban-bridge-chain-reclaim-rebuild.test.ts
@@ -1,0 +1,96 @@
+import { TransactionConsolidationTypeEnum } from '@budgie/contracts';
+import { describe, expect, it } from 'vitest';
+
+import {
+    CHAIN_RECLAIM_EUR_AMOUNT,
+    CHAIN_RECLAIM_SOURCE_IBAN,
+    CHAIN_RECLAIM_STALE_RATE_MULTIPLIER,
+    CHAIN_RECLAIM_TARGET_IBAN,
+    CHAIN_RECLAIM_UAH_AMOUNT,
+    CHAIN_RECLAIM_UAH_TO_EUR_RATE,
+    expectChainReclaimParent,
+    expectChainReclaimUnparented,
+    fetchChainReclaimLedgerEntry,
+    fetchChainReclaimOwnLedger,
+    seedChainReclaimFixture,
+    seedNestedChainReclaimFixture
+} from '../harness/chain-reclaim-fixture';
+import { runConsolidation } from '../harness/run-consolidation';
+import { testDb, testQueryService, unconsolidationService } from '../harness/test-context';
+
+const RATE_PRECISION_DIGITS = 10;
+const REBUILT_LEDGER_ENTRY_COUNT = 2;
+
+const fetchRebuiltCanonicalId = (): number => {
+    const canonicals = testQueryService.fetchCanonicalsOfType(TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER);
+
+    expect(canonicals).toHaveLength(1);
+
+    return canonicals[0].id;
+};
+
+const expectRebuiltCanonicalLedger = (canonicalId: number, sourceAccountId: number, targetAccountId: number): void => {
+    const sourceLedgerEntry = fetchChainReclaimLedgerEntry(canonicalId, sourceAccountId);
+
+    expect(testQueryService.fetchTransactionById(canonicalId).exchangeRate).toBeCloseTo(
+        CHAIN_RECLAIM_UAH_TO_EUR_RATE,
+        RATE_PRECISION_DIGITS
+    );
+    expect(sourceLedgerEntry.amount).toBe(CHAIN_RECLAIM_EUR_AMOUNT);
+    expect(sourceLedgerEntry.toIban).toBe(CHAIN_RECLAIM_TARGET_IBAN);
+    expect(sourceLedgerEntry.exchangeRate).toBeCloseTo(CHAIN_RECLAIM_UAH_TO_EUR_RATE, RATE_PRECISION_DIGITS);
+    expect(fetchChainReclaimLedgerEntry(canonicalId, targetAccountId).amount).toBe(CHAIN_RECLAIM_UAH_AMOUNT);
+};
+
+describe('consolidation/iban-bridge-chain-reclaim-rebuild', () => {
+    it('rebuilds an fx-correct canonical when the existing transfer ledger diverges', async () => {
+        const { bridgeExpense, bridgeIncome, directTransfer, sourceAccount, targetAccount } = seedChainReclaimFixture({
+            consolidationType: TransactionConsolidationTypeEnum.TRANSFER_PAIR,
+            directExchangeRate: CHAIN_RECLAIM_UAH_TO_EUR_RATE * CHAIN_RECLAIM_STALE_RATE_MULTIPLIER,
+            directToIban: CHAIN_RECLAIM_SOURCE_IBAN
+        });
+
+        const result = await runConsolidation();
+        const rebuiltCanonicalId = fetchRebuiltCanonicalId();
+
+        expect(result.found).toBe(1);
+        expect(result.consolidated).toBe(1);
+        expect(rebuiltCanonicalId).not.toBe(directTransfer.id);
+        expectChainReclaimParent(directTransfer.id, rebuiltCanonicalId);
+        expectChainReclaimParent(bridgeIncome.id, rebuiltCanonicalId);
+        expectChainReclaimParent(bridgeExpense.id, rebuiltCanonicalId);
+        expectRebuiltCanonicalLedger(rebuiltCanonicalId, sourceAccount.id, targetAccount.id);
+    });
+
+    it('restores the original transfer pair when a rebuilt chain canonical is reverted', async () => {
+        const { bridgeExpense, bridgeIncome, directTransfer } = seedChainReclaimFixture({
+            consolidationType: TransactionConsolidationTypeEnum.TRANSFER_PAIR,
+            directExchangeRate: CHAIN_RECLAIM_UAH_TO_EUR_RATE * CHAIN_RECLAIM_STALE_RATE_MULTIPLIER,
+            directToIban: CHAIN_RECLAIM_SOURCE_IBAN
+        });
+
+        await runConsolidation();
+        await unconsolidationService.unconsolidateById(fetchRebuiltCanonicalId(), testDb);
+
+        expect(testQueryService.fetchCanonicalsOfType(TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER)).toHaveLength(0);
+        expect(testQueryService.fetchTransactionById(directTransfer.id).consolidationType).toBe(
+            TransactionConsolidationTypeEnum.TRANSFER_PAIR
+        );
+        expectChainReclaimUnparented([directTransfer.id, bridgeIncome.id, bridgeExpense.id]);
+        expect(fetchChainReclaimOwnLedger(directTransfer.id)).toHaveLength(REBUILT_LEDGER_ENTRY_COUNT);
+    });
+
+    it('restores every chain leg when a fast-path reclaim is reverted', async () => {
+        const { bridgeExpense, bridgeIncome, directTransfer, sourceExpense, targetIncome } = await seedNestedChainReclaimFixture();
+
+        await runConsolidation();
+        await unconsolidationService.unconsolidateById(directTransfer.id, testDb);
+
+        expect(testQueryService.fetchCanonicalsOfType(TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER)).toHaveLength(0);
+        expectChainReclaimUnparented([sourceExpense.id, targetIncome.id, bridgeIncome.id, bridgeExpense.id]);
+        expect(fetchChainReclaimOwnLedger(sourceExpense.id)).toHaveLength(1);
+        expect(fetchChainReclaimOwnLedger(targetIncome.id)).toHaveLength(1);
+        expect(fetchChainReclaimOwnLedger(bridgeIncome.id)).toHaveLength(1);
+        expect(fetchChainReclaimOwnLedger(bridgeExpense.id)).toHaveLength(1);
+    });
+});

--- a/tests/consolidation-tests/src/scenarios/iban-bridge-chain-reclaim.test.ts
+++ b/tests/consolidation-tests/src/scenarios/iban-bridge-chain-reclaim.test.ts
@@ -1,184 +1,89 @@
 import { TransactionConsolidationTypeEnum } from '@budgie/contracts';
 import { describe, expect, it } from 'vitest';
 
-import { isDefined } from '@rnw-community/shared';
-
+import {
+    CHAIN_RECLAIM_EUR_AMOUNT,
+    CHAIN_RECLAIM_ONE_CENT_AMOUNT,
+    expectAbsorbedIntoExistingTransfer,
+    expectChainReclaimParent,
+    expectChainReclaimUnparented,
+    fetchChainReclaimMovedSourceIds,
+    seedChainReclaimFixture,
+    seedNestedChainReclaimFixture
+} from '../harness/chain-reclaim-fixture';
 import { runConsolidation } from '../harness/run-consolidation';
-import { testDb, testQueryService, testSeedService } from '../harness/test-context';
+import { testQueryService } from '../harness/test-context';
 
-import type { TransactionEntityInterface } from '@budgie/contracts';
-
-const SOURCE_IBAN = 'UA-RECLAIM-SOURCE-EUR';
-const BRIDGE_IBAN = 'UA-RECLAIM-BRIDGE-UAH';
-const TARGET_IBAN = 'UA-RECLAIM-TARGET-UAH';
-const EUR_AMOUNT = 1_658_290_000;
-const UAH_AMOUNT = 84_456_700_000;
-const EUR_TO_UAH_RATE = UAH_AMOUNT / EUR_AMOUNT;
-const UAH_TO_EUR_RATE = EUR_AMOUNT / UAH_AMOUNT;
-
-const seedAccounts = () => {
-    const eur = testSeedService.instrument({ code: 'EUR', name: 'Euro', symbol: 'EUR' });
-    const sourceAccount = testSeedService.bankSyncAccount('Reclaim Source EUR', null, SOURCE_IBAN, eur.id);
-    const bridgeAccount = testSeedService.bankSyncAccount('Reclaim Bridge UAH', null, BRIDGE_IBAN);
-    const targetAccount = testSeedService.bankSyncAccount('Reclaim Target UAH', null, TARGET_IBAN);
-
-    return { sourceAccount, bridgeAccount, targetAccount };
-};
-
-const seedDirectTransfer = (
-    operatedAt: Date,
-    sourceAccountId: number,
-    targetAccountId: number,
-    consolidationType: TransactionConsolidationTypeEnum | null
-): TransactionEntityInterface =>
-    testSeedService.directTransfer({
-        consolidationType,
-        exchangeRate: UAH_TO_EUR_RATE,
-        operatedAt,
-        sourceAccountId,
-        sourceAmount: EUR_AMOUNT,
-        sourceEntryExchangeRate: UAH_TO_EUR_RATE,
-        targetAccountId,
-        targetAmount: UAH_AMOUNT,
-        toIban: TARGET_IBAN
-    });
-
-const seedBridgeLegs = (operatedAt: Date, bridgeAccountId: number, transferMccId: number) => {
-    const bridgeIncome = testSeedService.bankPairIncome(
-        { externalId: 'reclaim-bridge-income', operatedAt },
-        {
-            accountId: bridgeAccountId,
-            amount: UAH_AMOUNT,
-            exchangeRate: EUR_TO_UAH_RATE,
-            mccCategoryId: transferMccId,
-            toIban: SOURCE_IBAN
-        }
-    );
-    const bridgeExpense = testSeedService.bankPairExpense(
-        { externalId: 'reclaim-bridge-expense', operatedAt },
-        {
-            accountId: bridgeAccountId,
-            amount: UAH_AMOUNT,
-            mccCategoryId: transferMccId,
-            toIban: TARGET_IBAN
-        }
-    );
-
-    return { bridgeIncome, bridgeExpense };
-};
-
-const seedDirectSourceRows = (operatedAt: Date, sourceAccountId: number, targetAccountId: number, transferMccId: number) => {
-    const sourceExpense = testSeedService.bankPairExpense(
-        { externalId: 'reclaim-source-expense', operatedAt },
-        {
-            accountId: sourceAccountId,
-            amount: EUR_AMOUNT,
-            exchangeRate: UAH_TO_EUR_RATE,
-            mccCategoryId: transferMccId,
-            toIban: TARGET_IBAN
-        }
-    );
-    const targetIncome = testSeedService.bankPairIncome(
-        { externalId: 'reclaim-target-income', operatedAt },
-        {
-            accountId: targetAccountId,
-            amount: UAH_AMOUNT,
-            mccCategoryId: transferMccId
-        }
-    );
-
-    return { sourceExpense, targetIncome };
-};
-
-const parentSourceTransaction = async (sourceTransactionId: number, canonicalTransactionId: number): Promise<void> => {
-    await testDb.$client.runAsync(
-        'UPDATE transaction_entries SET original_transaction_id = ?, transaction_id = ? WHERE transaction_id = ?',
-        [sourceTransactionId, canonicalTransactionId, sourceTransactionId]
-    );
-    await testDb.$client.runAsync('UPDATE transactions SET consolidation_parent_transaction_id = ? WHERE id = ?', [
-        canonicalTransactionId,
-        sourceTransactionId
-    ]);
-};
-
-const seedTransferReclaimFixture = (consolidationType: TransactionConsolidationTypeEnum | null) => {
-    const operatedAt = new Date(2026, 4, 20, 18, 38, 0);
-    const transferMcc = testQueryService.findMccByCode('4829');
-    const { sourceAccount, bridgeAccount, targetAccount } = seedAccounts();
-    const directTransfer = seedDirectTransfer(operatedAt, sourceAccount.id, targetAccount.id, consolidationType);
-    const bridgeLegs = seedBridgeLegs(operatedAt, bridgeAccount.id, transferMcc.id);
-
-    return {
-        ...bridgeLegs,
-        directTransfer,
-        operatedAt,
-        sourceAccount,
-        targetAccount,
-        transferMcc
-    };
-};
-
-const expectParent = (sourceTransactionId: number, canonicalTransactionId: number): void => {
-    expect(testQueryService.fetchTransactionById(sourceTransactionId).consolidationParentTransactionId).toBe(canonicalTransactionId);
-};
-
-const fetchMovedSourceIds = (canonicalTransactionId: number): number[] =>
-    testQueryService
-        .fetchEntriesByTransactionId(canonicalTransactionId)
-        .flatMap(entry => (isDefined(entry.originalTransactionId) ? [entry.originalTransactionId] : []));
+const byTransactionId = (left: number, right: number): number => left - right;
 
 describe('consolidation/iban-bridge-chain-reclaim', () => {
     it('reclaims late bridge legs into an existing generated transfer pair', async () => {
-        const { bridgeExpense, bridgeIncome, directTransfer } = seedTransferReclaimFixture(TransactionConsolidationTypeEnum.TRANSFER_PAIR);
+        const { bridgeExpense, bridgeIncome, directTransfer } = seedChainReclaimFixture({
+            consolidationType: TransactionConsolidationTypeEnum.TRANSFER_PAIR
+        });
 
         const result = await runConsolidation();
 
         expect(result.found).toBe(1);
         expect(result.consolidated).toBe(1);
         expect(testQueryService.fetchCanonicalsOfType(TransactionConsolidationTypeEnum.TRANSFER_PAIR)).toHaveLength(0);
-        const canonicals = testQueryService.fetchCanonicalsOfType(TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER);
-        expect(canonicals).toHaveLength(1);
-        expect(canonicals[0].id).toBe(directTransfer.id);
-        expectParent(bridgeIncome.id, directTransfer.id);
-        expectParent(bridgeExpense.id, directTransfer.id);
-        expect(fetchMovedSourceIds(directTransfer.id).sort((left, right) => left - right)).toEqual(
-            [bridgeIncome.id, bridgeExpense.id].sort((left, right) => left - right)
+        expectAbsorbedIntoExistingTransfer(directTransfer.id, bridgeIncome.id, bridgeExpense.id);
+        expect(fetchChainReclaimMovedSourceIds(directTransfer.id).sort(byTransactionId)).toEqual(
+            [bridgeIncome.id, bridgeExpense.id].sort(byTransactionId)
         );
     });
 
     it('preserves original moved source rows when reclaiming bridge legs into an existing generated transfer pair', async () => {
-        const { bridgeExpense, bridgeIncome, directTransfer, operatedAt, sourceAccount, targetAccount, transferMcc } =
-            seedTransferReclaimFixture(TransactionConsolidationTypeEnum.TRANSFER_PAIR);
-        const { sourceExpense, targetIncome } = seedDirectSourceRows(operatedAt, sourceAccount.id, targetAccount.id, transferMcc.id);
-
-        await parentSourceTransaction(sourceExpense.id, directTransfer.id);
-        await parentSourceTransaction(targetIncome.id, directTransfer.id);
+        const { bridgeExpense, bridgeIncome, directTransfer, sourceExpense, targetIncome } = await seedNestedChainReclaimFixture();
 
         const result = await runConsolidation();
 
         expect(result.found).toBe(1);
         expect(result.consolidated).toBe(1);
-        expect(testQueryService.fetchTransactionById(directTransfer.id).consolidationType).toBe(
-            TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER
-        );
-        expectParent(sourceExpense.id, directTransfer.id);
-        expectParent(targetIncome.id, directTransfer.id);
-        expectParent(bridgeIncome.id, directTransfer.id);
-        expectParent(bridgeExpense.id, directTransfer.id);
-        expect(fetchMovedSourceIds(directTransfer.id).sort((left, right) => left - right)).toEqual(
-            [sourceExpense.id, targetIncome.id, bridgeIncome.id, bridgeExpense.id].sort((left, right) => left - right)
+        expectAbsorbedIntoExistingTransfer(directTransfer.id, bridgeIncome.id, bridgeExpense.id);
+        expectChainReclaimParent(sourceExpense.id, directTransfer.id);
+        expectChainReclaimParent(targetIncome.id, directTransfer.id);
+        expect(fetchChainReclaimMovedSourceIds(directTransfer.id).sort(byTransactionId)).toEqual(
+            [sourceExpense.id, targetIncome.id, bridgeIncome.id, bridgeExpense.id].sort(byTransactionId)
         );
     });
 
     it('does not reclaim or duplicate bridge legs when the direct transfer is source-less', async () => {
-        const { bridgeIncome, bridgeExpense, directTransfer } = seedTransferReclaimFixture(null);
+        const { bridgeIncome, bridgeExpense, directTransfer } = seedChainReclaimFixture({ consolidationType: null });
 
         const result = await runConsolidation();
 
         expect(result.found).toBe(0);
         expect(result.consolidated).toBe(0);
         expect(testQueryService.fetchTransactionById(directTransfer.id).consolidationType).toBeNull();
-        expect(testQueryService.fetchTransactionById(bridgeIncome.id).consolidationParentTransactionId).toBeNull();
-        expect(testQueryService.fetchTransactionById(bridgeExpense.id).consolidationParentTransactionId).toBeNull();
+        expectChainReclaimUnparented([bridgeIncome.id, bridgeExpense.id]);
+    });
+
+    it('reclaims an off-by-cents chain instead of creating a duplicate bridge canonical', async () => {
+        const { bridgeExpense, bridgeIncome, directTransfer } = seedChainReclaimFixture({
+            consolidationType: TransactionConsolidationTypeEnum.TRANSFER_PAIR,
+            directSourceAmount: CHAIN_RECLAIM_EUR_AMOUNT + CHAIN_RECLAIM_ONE_CENT_AMOUNT
+        });
+
+        const result = await runConsolidation();
+
+        expect(result.found).toBe(1);
+        expect(result.consolidated).toBe(1);
+        expect(testQueryService.fetchCanonicalsOfType(TransactionConsolidationTypeEnum.IBAN_BRIDGE_TRANSFER)).toHaveLength(0);
+        expectAbsorbedIntoExistingTransfer(directTransfer.id, bridgeIncome.id, bridgeExpense.id);
+    });
+
+    it('leaves an already reclaimed chain untouched on a repeated consolidation run', async () => {
+        const { bridgeExpense, bridgeIncome, directTransfer } = seedChainReclaimFixture({
+            consolidationType: TransactionConsolidationTypeEnum.TRANSFER_PAIR,
+            directSourceAmount: CHAIN_RECLAIM_EUR_AMOUNT + CHAIN_RECLAIM_ONE_CENT_AMOUNT
+        });
+
+        await runConsolidation();
+        const repeatedResult = await runConsolidation();
+
+        expect(repeatedResult.found).toBe(0);
+        expect(repeatedResult.consolidated).toBe(0);
+        expectAbsorbedIntoExistingTransfer(directTransfer.id, bridgeIncome.id, bridgeExpense.id);
     });
 });


### PR DESCRIPTION
## What / Why

`EXISTING_TRANSFER_CHAIN_RECLAIM` (shipped in #558) absorbs late-syncing bridge legs into an existing generated `TRANSFER_PAIR`, but only on an **exact integer-microunit match**:

```sql
ROUND(bridge_income_entry.amount / bridge_income_entry.exchange_rate) = existing_source_entry.amount
```

The forward chain family (`transfer-pair-iban-bridge-chain-sql.factory.ts`) has always used a 1% FX tolerance for the same relationship. The asymmetry meant any chain off by even a cent — fee-splitting source legs (`mainAmount = amount − feeAmount`), 2-decimal `operationAmount` reporting, cent-level FX rounding — was invisible to reclaim.

### The double-count failure mode

`IBAN_BRIDGE_TRANSFER` (registry index 4, runs *after* reclaim) has a stand-down `NOT EXISTS` guard carrying the **same exact-equality predicate**. So when reclaim missed by a cent, that family did not stand down and consolidated the same two bridge legs into a **duplicate** source→target canonical, sitting next to the untouched direct `TRANSFER_PAIR`. One physical transfer, two outflows from the source account.

Reproduced before the fix by the new off-by-cents test:

```
[ConsolidationExecutorService::consolidateIbanBridgeTransfer] done ibanBridgeResult=true plan=3,2/IBAN_BRIDGE_TRANSFER
[ConsolidationAutoCandidateService::process] done found=1 consolidated=1

AssertionError: expected [ { id: 4, …(18) } ] to have a length of +0 but got 1
```

i.e. reclaim found nothing, and a second `IBAN_BRIDGE_TRANSFER` canonical (`id=4`) was created alongside the existing `TRANSFER_PAIR`.

### Class A metadata bug

The absorb gate checked amounts only — never `existing_transfer.exchange_rate`, the entry exchange rates, or `existing_source_entry.to_iban`. A direct pair carrying stale FX metadata was absorbed **in place**, keeping the wrong `exchangeRate` / `toIban` on the now-`IBAN_BRIDGE_CHAIN_TRANSFER` canonical. Confirmed pre-fix by the divergent-ledger test (`expected 1 not to be 1` — the stale pair was absorbed in place instead of rebuilt).

## Design

1. **Shared tolerance constant.** `IBAN_BRIDGE_CHAIN_FX_TOLERANCE = 0.01` in `packages/consolidation/src/shared/constant/`, consumed by three SQL factories and the repair executor. Replaces the hardcoded `0.01` literal in the forward chain factory (no behavior change there).

2. **Complementary guards.** The reclaim gate becomes a relative tolerance band, and the `IBAN_BRIDGE_TRANSFER` stand-down `NOT EXISTS` gets the *same* band with the same denominator (`direct_source_entry.amount` ↔ `existing_source_entry.amount`). Reclaim-fires ⟺ bridge-family-stands-down is now structurally complementary, so a duplicate canonical is unrepresentable at either tolerance outcome. Belt and braces: the family registry also adds reclaim's source ids to `blockedSourceTransactionIds` before `IBAN_BRIDGE_TRANSFER` runs.

3. **Fast-path / rebuild gate in the repair executor.** After eligibility, the executor re-reads the existing transfer with its live ledger (`transactionRepository.findByIds`, which filters `original_transaction_id IS NULL AND deleted_at IS NULL`) and checks endpoints, entry amounts, `toDebitEntry.exchangeRate === 1`, `fromCreditEntry.toIban === targetAccountIban`, and both `fromCreditEntry.exchangeRate` / `existingTransfer.exchangeRate` within the tolerance band.
   - **Consistent ledger** → absorb in place (previous behavior).
   - **Divergent ledger** → build a fresh FX-correct `IBAN_BRIDGE_CHAIN_TRANSFER` canonical and nest the old `TRANSFER_PAIR` under it via `moveSourcesToCanonical`, so `unconsolidateById` restores the original pair (its own ledger moves back, its grandchildren stay attached because `moveToConsolidatedTransaction` only touches `original_transaction_id IS NULL` rows).

4. **Dead code removed.** The `existingDirectTransferId` scalar subquery in `transfer-pair-iban-bridge-transfer-sql.factory.ts` carried predicate-for-predicate the same conditions as its sibling `NOT EXISTS`, so it was **always** `NULL` and the `isDefined(candidate.existingDirectTransferId)` branch in `IbanBridgeTransferConsolidationFamilyService.getSourceTransactionIds` was unreachable (visible in the logs above as `direct=`). Deleted the projection, the interface field, the branch, and switched the `@Log` `done` tag to `bridgeAccountId`. Deletion (rather than repair) is correct: the widened stand-down guard is now the single authority on "a direct transfer already covers this chain", and it is strictly broader than reclaim's gate — reclaim additionally requires `consolidation_type = 'TRANSFER_PAIR'`, so hand-created transfers keep the bridge family standing down without ever being reclaimed.

## Ported from #557 vs redesigned

| From #557 (concepts) | Redesigned for current main |
| --- | --- |
| `isChainReclaimFastPathEligible` endpoint / live-entry / rate checks | Renamed `hasChainReclaimConsistentLedger`, moved onto `ConsolidationRepairExecutorService` (the #558 repair-executor split), reads the live ledger through `ConsolidationEligibilityService`-adjacent repository calls instead of #557's monolithic executor |
| `rebuildChainReclaimCanonical` + `allowedMovedSourceTransactionIds` nesting | Implemented via `ConsolidationMutationService.createCanonicalTransfer` + `moveSourcesToCanonical`; no `allowedMovedSourceTransactionIds` needed because `isExistingTransferConsolidationStillEligible` already scopes the moved-entry check to the bridge legs only |
| `IBAN_BRIDGE_CHAIN_FX_TOLERANCE` in contracts | Lives in `packages/consolidation/src/shared/constant/` next to the other consolidation tolerances (the consolidation package did not exist at #557) |
| `targetAccountIban` on the candidate + SQL projection | Kept as-is |
| #557's full SQL rewrite (fee-exclusion guards, `instrument_id` matching, restructured joins) | **Not ported** — main's factory gained MCC transfer-group gating and `BETWEEN` time windows after #557; only the amount predicate and the IBAN projection changed, to keep the query plan and family semantics stable |
| `buildIbanBridgeChainCanonicalInput` | Ported, promoted to `executor/utils/` since it now has two consumers (chain family + repair executor); this also removes the newly-introduced `yarn cpd` clones |

## Invariants

| Invariant | Enforcement |
| --- | --- |
| A hand-created / source-less direct transfer (`consolidation_type` NULL) is never absorbed or rebuilt | SQL requires `existing_transfer.consolidation_type = 'TRANSFER_PAIR'`; covered by the existing negative test |
| Revert restores all four legs | `moveBackToOriginalTransactions` + `clearConsolidationParent`; covered by the fast-path revert test |
| Revert of a rebuilt canonical restores the original `TRANSFER_PAIR` | Old pair is nested, not mutated; its `consolidationType` is untouched — covered by the rebuild revert test |
| No duplicate canonical for one physical transfer under any tolerance outcome | Complementary tolerance bands in reclaim + stand-down guard; covered by the off-by-cents test |
| Re-running consolidation after a reclaim is a no-op | Absorbed pair is no longer `TRANSFER_PAIR`; bridge legs are parented — covered by the idempotency test |

## Test evidence

`tests/consolidation-tests`: **26 files / 71 tests → 27 files / 76 tests**, all passing, zero regressions. (The gap-analysis note said 74 on main; the verified baseline on `origin/main` @ `ac6d126dc` is 71.)

Repo-wide `yarn test`: bank-sync-tests 54/188 ✅, budget-tests 6/10 ✅, consolidation-tests 27/76 ✅.

New tests (all written first and observed failing on unfixed code):

- `iban-bridge-chain-reclaim.test.ts`
  - `reclaims an off-by-cents chain instead of creating a duplicate bridge canonical` — **pre-fix: silent duplicate `IBAN_BRIDGE_TRANSFER` canonical `id=4`**
  - `leaves an already reclaimed chain untouched on a repeated consolidation run` — pre-fix: no canonical at all
- `iban-bridge-chain-reclaim-rebuild.test.ts`
  - `rebuilds an fx-correct canonical when the existing transfer ledger diverges` — pre-fix: absorbed in place with the stale rate and wrong `to_iban`
  - `restores the original transfer pair when a rebuilt chain canonical is reverted`
  - `restores every chain leg when a fast-path reclaim is reverted`

The three pre-existing reclaim tests are unchanged in behavior and stay green. Shared seeding/assertion helpers moved to `tests/consolidation-tests/src/harness/chain-reclaim-fixture.ts` (test files under `tests/` are linted by lint-staged with the strict non-spec rule set, so the scenario was split across two files to stay inside `max-lines` / `max-lines-per-function` / `max-statements` without new disables).

## EXPLAIN QUERY PLAN

`EXPLAIN QUERY PLAN` diffed before/after on a migrated test database for all three modified queries:

- **`EXISTING_TRANSFER_CHAIN_RECLAIM`** — join order swaps (`existing_source_entry` now drives with `amount>?`, `existing_target_entry` takes the `amount=?` seek) because the equality predicate moved. Both remain `SEARCH … USING INDEX transaction_entries_live_transaction_account_amount_idx`. No new scans. Temp B-tree count unchanged (3, all `USE TEMP B-TREE FOR ORDER BY` from the `ROW_NUMBER()` windows).
- **`IBAN_BRIDGE_CHAIN_TRANSFER`** — plan byte-identical (literal → constant of the same value).
- **`IBAN_BRIDGE_TRANSFER`** — strictly cheaper: the dead correlated scalar subquery (4 plan rows, including a `transactions_operated_at_idx` range scan) is gone. The remaining stand-down guard's `direct_source_entry` probe degrades from index equality `(transaction_id=? AND account_id=? AND amount=?)` to index range `(transaction_id=? AND account_id=? AND amount>?)` — still an index `SEARCH` on the same composite index, still pinned by `transaction_id` + `account_id` (a handful of rows), no full-table scan, no new temp B-tree.

## Validation

`yarn format && yarn ts && yarn lint && yarn deadcode && yarn cpd` — all clean. `yarn cpd` reports **0 clones** (the refactors above resolved the 6 clones the first draft introduced). No new eslint-disables.

Fixes #556
Part of epic #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved IBAN bridge transfer consolidation and chain reclaim handling.
  * Transfers can now be rebuilt or absorbed while preserving related transaction history and ledger entries.
  * Added tolerance for minor foreign-exchange and amount differences, including one-cent discrepancies.
  * Repeated consolidation runs no longer create duplicate bridge transfers.

* **Bug Fixes**
  * Improved restoration of original transfer relationships and ledger data when a consolidation is reversed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->