### PR TITLE
chore(logger): redact financial identifiers from sync and consolidation logs

### DIFF
--- a/packages/ai/src/embedding/service/embedding-suggestion.service.ts
+++ b/packages/ai/src/embedding/service/embedding-suggestion.service.ts
@@ -29,6 +29,7 @@ import type { SerializedEmbeddingResultInterface } from '../interface/serialized
 import type { SuggestionContextInterface } from '../interface/suggestion-context.interface';
 
 export class EmbeddingSuggestionService {
+    private static readonly LOG_PREVIEW_LENGTH = 16;
     private static readonly MCC_BLEND_WEIGHT = 7 / 10;
 
     constructor(
@@ -42,11 +43,11 @@ export class EmbeddingSuggestionService {
 
     @Log(
         (categories, transactionTitle, mccDescription, comment, aiContext, mccCategoryId) =>
-            `enter title="${transactionTitle}" mcc="${mccDescription ?? 'none'}" comment="${comment}" aiContext="${aiContext}" mccCategoryId=${String(mccCategoryId)} categoryIds=${categories.map(category => category.id).join(',')}`,
+            `enter titlePreview="${transactionTitle.slice(0, EmbeddingSuggestionService.LOG_PREVIEW_LENGTH)}" titleLen=${transactionTitle.length} mcc="${mccDescription ?? 'none'}" commentLen=${comment.length} aiContextLen=${aiContext.length} mccCategoryId=${String(mccCategoryId)} categoryIds=${categories.map(category => category.id).join(',')}`,
         (result, categories, transactionTitle, mccDescription, comment, aiContext, mccCategoryId) =>
-            `done title="${transactionTitle}" mcc="${mccDescription ?? 'none'}" comment="${comment}" aiContext="${aiContext}" mccCategoryId=${String(mccCategoryId)} categoryCount=${categories.length} resolvedIds=${result.map(category => category.id).join(',')}`,
+            `done titlePreview="${transactionTitle.slice(0, EmbeddingSuggestionService.LOG_PREVIEW_LENGTH)}" titleLen=${transactionTitle.length} mcc="${mccDescription ?? 'none'}" commentLen=${comment.length} aiContextLen=${aiContext.length} mccCategoryId=${String(mccCategoryId)} categoryCount=${categories.length} resolvedIds=${result.map(category => category.id).join(',')}`,
         (error, categories, transactionTitle, mccDescription, comment, aiContext, mccCategoryId) =>
-            `throw title="${transactionTitle}" mcc="${mccDescription ?? 'none'}" comment="${comment}" aiContext="${aiContext}" mccCategoryId=${String(mccCategoryId)} categoryCount=${categories.length} error=${getErrorMessage(error)}`
+            `throw titlePreview="${transactionTitle.slice(0, EmbeddingSuggestionService.LOG_PREVIEW_LENGTH)}" titleLen=${transactionTitle.length} mcc="${mccDescription ?? 'none'}" commentLen=${comment.length} aiContextLen=${aiContext.length} mccCategoryId=${String(mccCategoryId)} categoryCount=${categories.length} error=${getErrorMessage(error)}`
     )
     async suggestCategories(
         categories: CategoryEntityInterface[],
@@ -86,11 +87,11 @@ export class EmbeddingSuggestionService {
 
     @Log(
         (allTags, categoryId, transactionTitle, mccDescription, comment, aiContext) =>
-            `enter title="${transactionTitle}" mcc="${mccDescription ?? 'none'}" comment="${comment}" aiContext="${aiContext}" categoryId=${categoryId} tagIds=${allTags.map(tag => tag.id).join(',')}`,
+            `enter titlePreview="${transactionTitle.slice(0, EmbeddingSuggestionService.LOG_PREVIEW_LENGTH)}" titleLen=${transactionTitle.length} mcc="${mccDescription ?? 'none'}" commentLen=${comment.length} aiContextLen=${aiContext.length} categoryId=${categoryId} tagIds=${allTags.map(tag => tag.id).join(',')}`,
         (result, allTags, categoryId, transactionTitle, mccDescription, comment, aiContext) =>
-            `done title="${transactionTitle}" mcc="${mccDescription ?? 'none'}" comment="${comment}" aiContext="${aiContext}" categoryId=${categoryId} tagCount=${allTags.length} resolvedIds=${result.map(tag => tag.id).join(',')}`,
+            `done titlePreview="${transactionTitle.slice(0, EmbeddingSuggestionService.LOG_PREVIEW_LENGTH)}" titleLen=${transactionTitle.length} mcc="${mccDescription ?? 'none'}" commentLen=${comment.length} aiContextLen=${aiContext.length} categoryId=${categoryId} tagCount=${allTags.length} resolvedIds=${result.map(tag => tag.id).join(',')}`,
         (error, allTags, categoryId, transactionTitle, mccDescription, comment, aiContext) =>
-            `throw title="${transactionTitle}" mcc="${mccDescription ?? 'none'}" comment="${comment}" aiContext="${aiContext}" categoryId=${categoryId} tagCount=${allTags.length} error=${getErrorMessage(error)}`
+            `throw titlePreview="${transactionTitle.slice(0, EmbeddingSuggestionService.LOG_PREVIEW_LENGTH)}" titleLen=${transactionTitle.length} mcc="${mccDescription ?? 'none'}" commentLen=${comment.length} aiContextLen=${aiContext.length} categoryId=${categoryId} tagCount=${allTags.length} error=${getErrorMessage(error)}`
     )
     async suggestTags(
         allTags: TagEntityInterface[],
@@ -125,11 +126,11 @@ export class EmbeddingSuggestionService {
 
     @Log(
         (categoryId, transactionTitle, mccDescription, comment, aiContext) =>
-            `enter categoryId=${categoryId} title="${transactionTitle}" mcc="${mccDescription ?? 'none'}" comment="${comment}" aiContext="${aiContext}"`,
+            `enter categoryId=${categoryId} titlePreview="${transactionTitle.slice(0, EmbeddingSuggestionService.LOG_PREVIEW_LENGTH)}" titleLen=${transactionTitle.length} mcc="${mccDescription ?? 'none'}" commentLen=${comment.length} aiContextLen=${aiContext.length}`,
         (result, categoryId, transactionTitle, mccDescription, comment, aiContext) =>
-            `done categoryId=${categoryId} title="${transactionTitle}" mcc="${mccDescription ?? 'none'}" comment="${comment}" aiContext="${aiContext}" count=${result.length}`,
+            `done categoryId=${categoryId} titlePreview="${transactionTitle.slice(0, EmbeddingSuggestionService.LOG_PREVIEW_LENGTH)}" titleLen=${transactionTitle.length} mcc="${mccDescription ?? 'none'}" commentLen=${comment.length} aiContextLen=${aiContext.length} count=${result.length}`,
         (error, categoryId, transactionTitle, mccDescription, comment, aiContext) =>
-            `throw categoryId=${categoryId} title="${transactionTitle}" mcc="${mccDescription ?? 'none'}" comment="${comment}" aiContext="${aiContext}" error=${getErrorMessage(error)}`
+            `throw categoryId=${categoryId} titlePreview="${transactionTitle.slice(0, EmbeddingSuggestionService.LOG_PREVIEW_LENGTH)}" titleLen=${transactionTitle.length} mcc="${mccDescription ?? 'none'}" commentLen=${comment.length} aiContextLen=${aiContext.length} error=${getErrorMessage(error)}`
     )
     async suggestComments(
         categoryId: number,
@@ -154,9 +155,11 @@ export class EmbeddingSuggestionService {
     }
 
     @Log(
-        context => `enter context="${context}"`,
-        (result, context) => `done context="${context}" resolved=${String(isDefined(result))}`,
-        (error, context) => `throw context="${context}" error=${getErrorMessage(error)}`
+        context => `enter contextPreview="${context.slice(0, EmbeddingSuggestionService.LOG_PREVIEW_LENGTH)}" contextLen=${context.length}`,
+        (result, context) =>
+            `done contextPreview="${context.slice(0, EmbeddingSuggestionService.LOG_PREVIEW_LENGTH)}" contextLen=${context.length} resolved=${String(isDefined(result))}`,
+        (error, context) =>
+            `throw contextPreview="${context.slice(0, EmbeddingSuggestionService.LOG_PREVIEW_LENGTH)}" contextLen=${context.length} error=${getErrorMessage(error)}`
     )
     private async generateSerializedEmbedding(context: string): Promise<Uint8Array | null> {
         const service = new EmbeddingService(this.embedding);

--- a/packages/ai/src/embedding/service/embedding.service.ts
+++ b/packages/ai/src/embedding/service/embedding.service.ts
@@ -9,13 +9,15 @@ export class EmbeddingService {
     private static inferenceQueue: Promise<void> = Promise.resolve();
     private static readonly embeddingCache = new Map<string, Promise<Float32Array | null>>();
     private static readonly EMBEDDING_CACHE_LIMIT = 50;
+    private static readonly LOG_PREVIEW_LENGTH = 16;
 
     constructor(private readonly embedding: EmbeddingInvokerInterface) {}
 
     @Log(
-        text => `enter text="${text}"`,
+        text => `enter textPreview="${text.slice(0, EmbeddingService.LOG_PREVIEW_LENGTH)}" textLen=${text.length}`,
         result => `done dimensions=${isDefined(result) ? result.length : 0}`,
-        (error, text) => `throw text="${text}" error=${getErrorMessage(error)}`
+        (error, text) =>
+            `throw textPreview="${text.slice(0, EmbeddingService.LOG_PREVIEW_LENGTH)}" textLen=${text.length} error=${getErrorMessage(error)}`
     )
     async generateEmbedding(text: string): Promise<Float32Array | null> {
         const cached = EmbeddingService.embeddingCache.get(text);

--- a/packages/ai/src/suggestion/service/translation-llm.service.ts
+++ b/packages/ai/src/suggestion/service/translation-llm.service.ts
@@ -8,12 +8,15 @@ import { TAG_GENERATION_SYSTEM_PROMPT, TRANSLATION_SYSTEM_PROMPT, TRANSLATION_TE
 import { TranslationResultInterface } from '../interface/translation-result.interface';
 
 export class TranslationLlmService {
+    private static readonly LOG_PREVIEW_LENGTH = 16;
+
     constructor(private readonly chat: ChatInvokerInterface) {}
 
     @Log(
-        title => `enter title="${title}"`,
+        title => `enter titlePreview="${title.slice(0, TranslationLlmService.LOG_PREVIEW_LENGTH)}" titleLen=${title.length}`,
         result => `done titleEnLen=${result.titleEn.length} tagsLen=${result.titleTags.length}`,
-        (error, title) => `throw title="${title}" error=${getErrorMessage(error)}`
+        (error, title) =>
+            `throw titlePreview="${title.slice(0, TranslationLlmService.LOG_PREVIEW_LENGTH)}" titleLen=${title.length} error=${getErrorMessage(error)}`
     )
     async translate(title: string): Promise<TranslationResultInterface> {
         const trimmedTitleEn = await this.translateToEnglish(title);
@@ -23,9 +26,10 @@ export class TranslationLlmService {
     }
 
     @Log(
-        titleEn => `enter titleEn="${titleEn}"`,
+        titleEn => `enter titleEnPreview="${titleEn.slice(0, TranslationLlmService.LOG_PREVIEW_LENGTH)}" titleEnLen=${titleEn.length}`,
         result => `done tagsLen=${result.length}`,
-        (error, titleEn) => `throw titleEn="${titleEn}" error=${getErrorMessage(error)}`
+        (error, titleEn) =>
+            `throw titleEnPreview="${titleEn.slice(0, TranslationLlmService.LOG_PREVIEW_LENGTH)}" titleEnLen=${titleEn.length} error=${getErrorMessage(error)}`
     )
     private async generateTags(titleEn: string): Promise<string> {
         const tags = await this.chat.generate(TAG_GENERATION_SYSTEM_PROMPT, titleEn, { temperature: TRANSLATION_TEMPERATURE });
@@ -34,9 +38,10 @@ export class TranslationLlmService {
     }
 
     @Log(
-        title => `enter title="${title}"`,
+        title => `enter titlePreview="${title.slice(0, TranslationLlmService.LOG_PREVIEW_LENGTH)}" titleLen=${title.length}`,
         result => `done resultLen=${result.length}`,
-        (error, title) => `throw title="${title}" error=${getErrorMessage(error)}`
+        (error, title) =>
+            `throw titlePreview="${title.slice(0, TranslationLlmService.LOG_PREVIEW_LENGTH)}" titleLen=${title.length} error=${getErrorMessage(error)}`
     )
     private async translateToEnglish(title: string): Promise<string> {
         if (!containsNonLatin(title)) {

--- a/packages/bank-sync/src/erste/mapper/erste.mapper.ts
+++ b/packages/bank-sync/src/erste/mapper/erste.mapper.ts
@@ -15,10 +15,12 @@ import type { ErsteAccountInfoInterface } from '../interface/erste-account-info.
 import type { ErsteRowInterface } from '../interface/erste-row.interface';
 
 class ErsteMapper {
+    private static readonly LOG_PREVIEW_LENGTH = 16;
+
     @Log(
-        account => `enter iban=${account.iban} newBalance=${account.newBalance}`,
-        (result, account) => `done iban=${account.iban} accountId=${result.id}`,
-        (error, account) => `throw iban=${account.iban} error=${getErrorMessage(error)}`
+        account => `enter ibanSuffix=${account.iban.slice(-4)} newBalance=${account.newBalance}`,
+        (result, account) => `done ibanSuffix=${account.iban.slice(-4)} accountIdSuffix=${result.id.slice(-4)}`,
+        (error, account) => `throw ibanSuffix=${account.iban.slice(-4)} error=${getErrorMessage(error)}`
     )
     mapAccount(account: ErsteAccountInfoInterface): BankAccountInterface {
         return {
@@ -34,9 +36,11 @@ class ErsteMapper {
     }
 
     @Log(
-        (row, iban) => `enter iban=${iban} date=${row.date.toISOString()} amount=${row.amount} reference="${row.reference}"`,
-        (result, row, iban) => `done iban=${iban} date=${row.date.toISOString()} externalId=${result.id}`,
-        (error, row, iban) => `throw iban=${iban} date=${row.date.toISOString()} amount=${row.amount} error=${getErrorMessage(error)}`
+        (row, iban) =>
+            `enter ibanSuffix=${iban.slice(-4)} date=${row.date.toISOString()} amount=${row.amount} referencePreview="${row.reference.slice(0, ErsteMapper.LOG_PREVIEW_LENGTH)}" referenceLen=${row.reference.length}`,
+        (result, row, iban) => `done ibanSuffix=${iban.slice(-4)} date=${row.date.toISOString()} externalId=${result.id}`,
+        (error, row, iban) =>
+            `throw ibanSuffix=${iban.slice(-4)} date=${row.date.toISOString()} amount=${row.amount} error=${getErrorMessage(error)}`
     )
     mapTransaction(row: ErsteRowInterface, iban: string): BankTransactionInterface {
         const id = this.generateExternalId(row, iban);

--- a/packages/bank-sync/src/erste/parser/erste-account-info.extractor.ts
+++ b/packages/bank-sync/src/erste/parser/erste-account-info.extractor.ts
@@ -22,7 +22,7 @@ class ErsteAccountInfoExtractor {
     @Log(
         items => `enter itemCount=${items.length}`,
         (result, items) =>
-            `done itemCount=${items.length} iban=${result.iban} oldBalance=${result.oldBalance} newBalance=${result.newBalance}`,
+            `done itemCount=${items.length} ibanSuffix=${result.iban.slice(-4)} oldBalance=${result.oldBalance} newBalance=${result.newBalance}`,
         (error, items) => `throw itemCount=${items.length} error=${getErrorMessage(error)}`
     )
     extract(items: PdfTextItemInterface[]): ErsteAccountInfoInterface {

--- a/packages/bank-sync/src/erste/parser/erste.parser.ts
+++ b/packages/bank-sync/src/erste/parser/erste.parser.ts
@@ -30,7 +30,8 @@ class ErsteParser {
 
     @Log(
         items => `enter itemCount=${items.length}`,
-        (result, items) => `done itemCount=${items.length} iban=${result.account.iban} transactionCount=${result.transactions.length}`,
+        (result, items) =>
+            `done itemCount=${items.length} ibanSuffix=${result.account.iban.slice(-4)} transactionCount=${result.transactions.length}`,
         (error, items) => `throw itemCount=${items.length} error=${getErrorMessage(error)}`
     )
     parse(items: PdfTextItemInterface[]): ErsteParsedDataInterface {

--- a/packages/consolidation/src/executor/service/consolidation-mutation.service.ts
+++ b/packages/consolidation/src/executor/service/consolidation-mutation.service.ts
@@ -16,15 +16,17 @@ import type {
 } from '@budgie/contracts';
 
 export class ConsolidationMutationService {
+    private static readonly LOG_PREVIEW_LENGTH = 16;
+
     constructor(private readonly dependencies: ConsolidationExecutorDependenciesInterface) {}
 
     @Log(
         (input, tx) =>
-            `enter title="${input.title}" fromAccountId=${input.fromAccountId} toAccountId=${input.toAccountId} fromAmount=${input.fromAmount} toAmount=${input.toAmount} type=${input.consolidationType} hasTx=${String(isDefined(tx))}`,
+            `enter titlePreview="${input.title.slice(0, ConsolidationMutationService.LOG_PREVIEW_LENGTH)}" titleLen=${input.title.length} fromAccountId=${input.fromAccountId} toAccountId=${input.toAccountId} fromAmount=${input.fromAmount} toAmount=${input.toAmount} type=${input.consolidationType} hasTx=${String(isDefined(tx))}`,
         (result, input, tx) =>
-            `done title="${input.title}" fromAccountId=${input.fromAccountId} toAccountId=${input.toAccountId} fromAmount=${input.fromAmount} toAmount=${input.toAmount} type=${input.consolidationType} hasTx=${String(isDefined(tx))} canonicalTransactionId=${result.id}`,
+            `done titlePreview="${input.title.slice(0, ConsolidationMutationService.LOG_PREVIEW_LENGTH)}" titleLen=${input.title.length} fromAccountId=${input.fromAccountId} toAccountId=${input.toAccountId} fromAmount=${input.fromAmount} toAmount=${input.toAmount} type=${input.consolidationType} hasTx=${String(isDefined(tx))} canonicalTransactionId=${result.id}`,
         (error, input, tx) =>
-            `throw title="${input.title}" fromAccountId=${input.fromAccountId} toAccountId=${input.toAccountId} fromAmount=${input.fromAmount} toAmount=${input.toAmount} type=${input.consolidationType} hasTx=${String(isDefined(tx))} error=${getErrorMessage(error)}`
+            `throw titlePreview="${input.title.slice(0, ConsolidationMutationService.LOG_PREVIEW_LENGTH)}" titleLen=${input.title.length} fromAccountId=${input.fromAccountId} toAccountId=${input.toAccountId} fromAmount=${input.fromAmount} toAmount=${input.toAmount} type=${input.consolidationType} hasTx=${String(isDefined(tx))} error=${getErrorMessage(error)}`
     )
     async createCanonicalTransfer(input: CanonicalTransferInputInterface, tx: DB): Promise<TransactionEntityInterface> {
         const canonicalTransaction = await this.dependencies.transactionRepository.create(

--- a/packages/consolidation/src/refund/service/refund-consolidation.service.ts
+++ b/packages/consolidation/src/refund/service/refund-consolidation.service.ts
@@ -15,14 +15,17 @@ import type {
 } from '@budgie/contracts';
 
 export class RefundConsolidationService {
+    private static readonly LOG_PREVIEW_LENGTH = 16;
+
     constructor(private readonly dependencies: RefundConsolidationDependenciesInterface) {}
 
     @Log(
-        (refundIncomeTransactionId, search) => `enter refundIncomeTransactionId=${refundIncomeTransactionId} search="${search}"`,
+        (refundIncomeTransactionId, search) =>
+            `enter refundIncomeTransactionId=${refundIncomeTransactionId} searchPreview="${search.slice(0, RefundConsolidationService.LOG_PREVIEW_LENGTH)}" searchLen=${search.length}`,
         (result, refundIncomeTransactionId, search) =>
-            `done refundIncomeTransactionId=${refundIncomeTransactionId} search="${search}" candidateIds=${result.map(candidate => candidate.id).join(',')}`,
+            `done refundIncomeTransactionId=${refundIncomeTransactionId} searchPreview="${search.slice(0, RefundConsolidationService.LOG_PREVIEW_LENGTH)}" searchLen=${search.length} candidateIds=${result.map(candidate => candidate.id).join(',')}`,
         (error, refundIncomeTransactionId, search) =>
-            `throw refundIncomeTransactionId=${refundIncomeTransactionId} search="${search}" error=${getErrorMessage(error)}`
+            `throw refundIncomeTransactionId=${refundIncomeTransactionId} searchPreview="${search.slice(0, RefundConsolidationService.LOG_PREVIEW_LENGTH)}" searchLen=${search.length} error=${getErrorMessage(error)}`
     )
     async findRefundableExpenses(refundIncomeTransactionId: number, search: string): Promise<RefundableExpenseCandidateInterface[]> {
         return await this.dependencies.refundPairRepository.findRefundableExpenseCandidates(refundIncomeTransactionId, search);

--- a/packages/contracts/src/transaction/repository/transaction-pattern.repository.ts
+++ b/packages/contracts/src/transaction/repository/transaction-pattern.repository.ts
@@ -58,7 +58,7 @@ export class TransactionPatternRepository {
         (query, language) =>
             `enter type=${query.type} accountId=${query.accountId ?? 0} categoryId=${query.categoryId ?? 0} weekday=${query.weekday} window=${query.timeWindowStartMinutes}-${query.timeWindowEndMinutes} language=${language}`,
         (result, query, language) =>
-            `done type=${query.type} accountId=${query.accountId ?? 0} categoryId=${query.categoryId ?? 0} weekday=${query.weekday} window=${query.timeWindowStartMinutes}-${query.timeWindowEndMinutes} language=${language} categoryIds=${result.map(pattern => pattern.categoryId).join(',')} titles=${result.map(pattern => pattern.title).join('|')}`,
+            `done type=${query.type} accountId=${query.accountId ?? 0} categoryId=${query.categoryId ?? 0} weekday=${query.weekday} window=${query.timeWindowStartMinutes}-${query.timeWindowEndMinutes} language=${language} categoryIds=${result.map(pattern => pattern.categoryId).join(',')} patternCount=${result.length}`,
         (error, query, language) =>
             `throw type=${query.type} accountId=${query.accountId ?? 0} categoryId=${query.categoryId ?? 0} weekday=${query.weekday} window=${query.timeWindowStartMinutes}-${query.timeWindowEndMinutes} language=${language} error=${getErrorMessage(error)}`
     )
@@ -83,7 +83,7 @@ export class TransactionPatternRepository {
         (query, language) =>
             `enter type=${query.type} defaultInstrumentId=${query.defaultInstrumentId} displayMonth=${query.displayMonth} tzOffset=${query.timezoneOffsetSeconds} language=${language}`,
         (result, query, language) =>
-            `done type=${query.type} displayMonth=${query.displayMonth} language=${language} titles=${result.map(pattern => pattern.title).join('|')} accountIds=${result.map(pattern => pattern.accountId).join(',')}`,
+            `done type=${query.type} displayMonth=${query.displayMonth} language=${language} patternCount=${result.length} accountIds=${result.map(pattern => pattern.accountId).join(',')}`,
         (error, query, language) =>
             `throw type=${query.type} displayMonth=${query.displayMonth} language=${language} error=${getErrorMessage(error)}`
     )
@@ -114,7 +114,7 @@ export class TransactionPatternRepository {
         (query, language) =>
             `enter type=${query.type} accountId=${query.accountId ?? 0} categoryId=${query.categoryId ?? 0} amountMin=${query.amountMin} amountMax=${query.amountMax} language=${language}`,
         (result, query, language) =>
-            `done type=${query.type} accountId=${query.accountId ?? 0} categoryId=${query.categoryId ?? 0} amountMin=${query.amountMin} amountMax=${query.amountMax} language=${language} categoryIds=${result.map(pattern => pattern.categoryId).join(',')} titles=${result.map(pattern => pattern.title).join('|')}`,
+            `done type=${query.type} accountId=${query.accountId ?? 0} categoryId=${query.categoryId ?? 0} amountMin=${query.amountMin} amountMax=${query.amountMax} language=${language} categoryIds=${result.map(pattern => pattern.categoryId).join(',')} patternCount=${result.length}`,
         (error, query, language) =>
             `throw type=${query.type} accountId=${query.accountId ?? 0} categoryId=${query.categoryId ?? 0} amountMin=${query.amountMin} amountMax=${query.amountMax} language=${language} error=${getErrorMessage(error)}`
     )

--- a/packages/contracts/src/transaction/repository/transaction.repository.ts
+++ b/packages/contracts/src/transaction/repository/transaction.repository.ts
@@ -36,6 +36,8 @@ import type { SimilarTransactionStatsQueryInterface } from '../interface/similar
 import type { SimilarTransactionStatsInterface } from '../interface/similar-transaction-stats.interface';
 
 export class TransactionRepository extends BaseTransactionFilterRepository {
+    private static readonly LOG_PREVIEW_LENGTH = 16;
+
     private static readonly NON_INDEXABLE_EMBEDDING_TYPES: TransactionTypeEnum[] = [
         TransactionTypeEnum.TRANSFER,
         TransactionTypeEnum.ADJUSTMENT
@@ -166,11 +168,11 @@ export class TransactionRepository extends BaseTransactionFilterRepository {
 
     @Log(
         query =>
-            `enter transactionId=${query.transactionId} type=${query.type} operatedAt=${query.operatedAt.toISOString()} title="${query.title}" comment="${query.comment}" accountId=${query.accountId} categoryId=${isDefined(query.categoryId) ? query.categoryId : 0} months=${query.months}`,
+            `enter transactionId=${query.transactionId} type=${query.type} operatedAt=${query.operatedAt.toISOString()} titlePreview="${query.title.slice(0, TransactionRepository.LOG_PREVIEW_LENGTH)}" titleLen=${query.title.length} commentLen=${query.comment.length} accountId=${query.accountId} categoryId=${isDefined(query.categoryId) ? query.categoryId : 0} months=${query.months}`,
         (result, query) =>
-            `done transactionId=${query.transactionId} type=${query.type} operatedAt=${query.operatedAt.toISOString()} title="${query.title}" comment="${query.comment}" accountId=${query.accountId} categoryId=${isDefined(query.categoryId) ? query.categoryId : 0} months=${query.months} count=${isDefined(result) ? result.count : 0}`,
+            `done transactionId=${query.transactionId} type=${query.type} operatedAt=${query.operatedAt.toISOString()} titlePreview="${query.title.slice(0, TransactionRepository.LOG_PREVIEW_LENGTH)}" titleLen=${query.title.length} commentLen=${query.comment.length} accountId=${query.accountId} categoryId=${isDefined(query.categoryId) ? query.categoryId : 0} months=${query.months} count=${isDefined(result) ? result.count : 0}`,
         (error, query) =>
-            `throw transactionId=${query.transactionId} type=${query.type} operatedAt=${query.operatedAt.toISOString()} title="${query.title}" comment="${query.comment}" accountId=${query.accountId} categoryId=${isDefined(query.categoryId) ? query.categoryId : 0} months=${query.months} error=${getErrorMessage(error)}`
+            `throw transactionId=${query.transactionId} type=${query.type} operatedAt=${query.operatedAt.toISOString()} titlePreview="${query.title.slice(0, TransactionRepository.LOG_PREVIEW_LENGTH)}" titleLen=${query.title.length} commentLen=${query.comment.length} accountId=${query.accountId} categoryId=${isDefined(query.categoryId) ? query.categoryId : 0} months=${query.months} error=${getErrorMessage(error)}`
     )
     async findSimilarStats(query: SimilarTransactionStatsQueryInterface): Promise<SimilarTransactionStatsInterface | null> {
         if (!isPositiveNumber(query.accountId) || !isPositiveNumber(query.months)) {


### PR DESCRIPTION
Scoped privacy hardening of `@Log` lifecycle messages. **Message text only** — no wrappers, no decorators, no shared helpers, no behavior changes. This is deliberately *not* a rebuild of the closed #601 (which added a `Log.withoutErrorPayload` abstraction and was rejected as oversized).

## Audit scope

Every `@Log(` hook and `getLogger` call site in `packages/bank-sync/src`, `packages/consolidation/src`, `packages/contracts/src`, plus a prompt/PII pass over `packages/ai/src` — 33 files carrying `@Log`, 1 `getLogger` binding (`syncLogger`).

## Findings fixed

| File | Leak class | Before → After |
|---|---|---|
| `packages/bank-sync/src/erste/mapper/erste.mapper.ts` (`mapAccount`, 3 hooks) | Full IBAN (also re-emitted as `accountId`, since the mapped account id *is* the IBAN) | `iban=${account.iban}` / `accountId=${result.id}` → `ibanSuffix=${account.iban.slice(-4)}` / `accountIdSuffix=${result.id.slice(-4)}` |
| `packages/bank-sync/src/erste/mapper/erste.mapper.ts` (`mapTransaction`, 3 hooks) | Full IBAN + verbatim payment reference (counterparty/description text) alongside the amount | `iban=${iban} … reference="${row.reference}"` → `ibanSuffix=…slice(-4) … referencePreview="…slice(0,16)" referenceLen=…` |
| `packages/bank-sync/src/erste/parser/erste-account-info.extractor.ts` | Full IBAN next to old/new balances | `iban=${result.iban}` → `ibanSuffix=${result.iban.slice(-4)}` |
| `packages/bank-sync/src/erste/parser/erste.parser.ts` | Full IBAN | `iban=${result.account.iban}` → `ibanSuffix=…slice(-4)` |
| `packages/consolidation/src/executor/service/consolidation-mutation.service.ts` (3 hooks) | Transfer title + both amounts + both account ids (amount ⨯ identifiable-title combination) | `title="${input.title}"` → `titlePreview="…slice(0,16)" titleLen=…` |
| `packages/consolidation/src/refund/service/refund-consolidation.service.ts` (3 hooks) | User-typed refund search term (names a merchant/counterparty) | `search="${search}"` → `searchPreview="…slice(0,16)" searchLen=…` |
| `packages/contracts/src/transaction/repository/transaction.repository.ts` (`findSimilarStats`, 3 hooks) | Verbatim transaction title **and** user comment | `title="${query.title}" comment="${query.comment}"` → `titlePreview="…slice(0,16)" titleLen=… commentLen=…` |
| `packages/contracts/src/transaction/repository/transaction-pattern.repository.ts` (3 hooks) | Pipe-joined list of every matched merchant title, alongside amount bounds | `titles=${result.map(p => p.title).join('\|')}` → `patternCount=${result.length}` |
| `packages/ai/src/embedding/service/embedding-suggestion.service.ts` (4 hook groups) | Merchant title + user comment + user AI-context free text | `title="…" comment="…" aiContext="…"` → `titlePreview="…" titleLen=… commentLen=… aiContextLen=…`; `context="${context}"` → `contextPreview="…" contextLen=…` |
| `packages/ai/src/embedding/service/embedding.service.ts` | Verbatim embedding input (composed title+comment+MCC context) | `text="${text}"` → `textPreview="…slice(0,16)" textLen=…` |
| `packages/ai/src/suggestion/service/translation-llm.service.ts` (3 hook groups) | Verbatim merchant titles sent to the LLM | `title="…"` / `titleEn="…"` → preview + length |

Preview length is a `private static readonly LOG_PREVIEW_LENGTH` per class, mirroring the pattern already in `packages/ai/src/voice/service/voice-llm.service.ts`. Rule 4 is preserved: every method argument still appears in every hook (as a preview, length, or count).

## Intentionally NOT changed

- **Ids, counts, enum values, dates, booleans, `hasTx` flags** — no identity content. Left verbatim per logging rules 7–9.
- **Bare amounts** without an identifiable title in the same message (`newBalance`, `oldBalance`, `amountMin`/`amountMax`, `bridgeAmount`, `expenseEntryAmount`, `fromAmount`/`toAmount` now paired only with a truncated title) — an amount alone is not attributable.
- **`externalId` / `externalIds`** in `transaction.repository.ts` and `erste.mapper.ts` — these are stable *hashes* from `generate-stable-external-id-hash.util.ts`, not bank references.
- **`mcc="${mccDescription}"`** in `embedding-suggestion.service.ts` — a fixed MCC lookup label (e.g. "Grocery Stores"), not user data.
- **`instrument.repository.ts` `code="${code}"`** — currency/ticker symbols.
- **`consolidation-executor.service.ts` `ibanBridge=…`** — despite the key name, the interpolated values are transaction ids, not IBANs. No change needed.
- **`instrument-market-data-job.repository.ts` `errorMessage="${errorMessage}"`** — a market-data provider failure string; not financial identity data.
- **Secrets** — audited and clean. `MonobankClient` passes the token via the `X-Token` header, `base-bank-provider.client.ts` logs only `provider` + `endpoint` path, and no `fetchJson` endpoint embeds a credential. Nothing to redact.

## Found but out of this issue's scope (follow-up candidate)

The same verbatim-title leak class exists in `packages/app/src`, which #610 does not cover and which #601 was faulted for sweeping into:

- `packages/app/src/account/service/account-debt-opening.service.ts` (6 hooks) — `title="${input.title}"`; debt-account titles are **counterparty person names**.
- `packages/app/src/transaction/service/transaction-debt-settlement.service.ts` — `debtAccountTitle="${result.title}"`.
- `packages/app/src/rule/service/rule-matcher.service.ts` (3 hooks) — `title="${input.title}"`.
- `packages/app/src/ai/service/translation-drainer.service.ts` (4 hooks) — `title=` / `titleEn=`.

Happy to fix these here if you'd prefer one pass, or in a follow-up issue.

## Verification

- `yarn format && yarn ts && yarn lint && yarn deadcode && yarn cpd` — all clean (13/13 ts tasks, 0 clones)
- `tests/consolidation-tests`: 27 files / 76 tests passed
- `tests/bank-sync-tests`: 54 files / 188 tests passed
- No test asserts on log message text, so no test updates were needed

Fixes #610
Part of epic #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Privacy**
  * Improved application logging by redacting sensitive banking identifiers and replacing full personal or financial text with short previews and length metadata.
  * Limited exposure of account references, transaction details, titles, comments, search terms, and translated content in logs.
* **Observability**
  * Enhanced diagnostic logs with result counts, category identifiers, text lengths, and relevant processing outcomes while preserving troubleshooting context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->