### PR TITLE
test(consolidation): reversibility audit harness across all consolidation families

### DIFF
--- a/tests/consolidation-tests/src/harness/chain-reclaim-fixture.ts
+++ b/tests/consolidation-tests/src/harness/chain-reclaim-fixture.ts
@@ -1,32 +1,24 @@
 import { TransactionConsolidationTypeEnum } from '@budgie/contracts';
 import { expect } from 'vitest';
 
-import { isDefined } from '@rnw-community/shared';
+import { expectConsolidationParent } from './consolidation-revert-audit';
+import {
+    IBAN_BRIDGE_EUR_AMOUNT,
+    IBAN_BRIDGE_OPERATED_AT,
+    IBAN_BRIDGE_TARGET_IBAN,
+    IBAN_BRIDGE_UAH_AMOUNT,
+    parentConsolidationSource,
+    seedIbanBridgeLegs,
+    seedIbanBridgeSourceExpense,
+    seedIbanBridgeTargetIncome,
+    seedIbanBridgeTopology
+} from './iban-bridge-topology';
+import { testQueryService, testSeedService } from './test-context';
 
-import { testDb, testQueryService, testSeedService } from './test-context';
+import type { AccountEntityInterface, TransactionEntityInterface } from '@budgie/contracts';
 
-import type { TransactionEntityInterface, TransactionEntryEntityInterface } from '@budgie/contracts';
-
-export const CHAIN_RECLAIM_SOURCE_IBAN = 'UA-RECLAIM-SOURCE-EUR';
-export const CHAIN_RECLAIM_TARGET_IBAN = 'UA-RECLAIM-TARGET-UAH';
-export const CHAIN_RECLAIM_EUR_AMOUNT = 1_658_290_000;
-export const CHAIN_RECLAIM_UAH_AMOUNT = 84_456_700_000;
-export const CHAIN_RECLAIM_UAH_TO_EUR_RATE = CHAIN_RECLAIM_EUR_AMOUNT / CHAIN_RECLAIM_UAH_AMOUNT;
 export const CHAIN_RECLAIM_ONE_CENT_AMOUNT = 10_000;
 export const CHAIN_RECLAIM_STALE_RATE_MULTIPLIER = 2;
-
-const CHAIN_RECLAIM_BRIDGE_IBAN = 'UA-RECLAIM-BRIDGE-UAH';
-const CHAIN_RECLAIM_EUR_TO_UAH_RATE = CHAIN_RECLAIM_UAH_AMOUNT / CHAIN_RECLAIM_EUR_AMOUNT;
-const CHAIN_RECLAIM_OPERATED_AT = new Date('2026-05-20T18:38:00');
-
-const seedAccounts = () => {
-    const eur = testSeedService.instrument({ code: 'EUR', name: 'Euro', symbol: 'EUR' });
-    const sourceAccount = testSeedService.bankSyncAccount('Reclaim Source EUR', null, CHAIN_RECLAIM_SOURCE_IBAN, eur.id);
-    const bridgeAccount = testSeedService.bankSyncAccount('Reclaim Bridge UAH', null, CHAIN_RECLAIM_BRIDGE_IBAN);
-    const targetAccount = testSeedService.bankSyncAccount('Reclaim Target UAH', null, CHAIN_RECLAIM_TARGET_IBAN);
-
-    return { sourceAccount, bridgeAccount, targetAccount };
-};
 
 const seedDirectTransfer = (input: {
     readonly consolidationType: TransactionConsolidationTypeEnum | null;
@@ -39,122 +31,64 @@ const seedDirectTransfer = (input: {
     testSeedService.directTransfer({
         consolidationType: input.consolidationType,
         exchangeRate: input.exchangeRate,
-        operatedAt: CHAIN_RECLAIM_OPERATED_AT,
+        operatedAt: IBAN_BRIDGE_OPERATED_AT,
         sourceAccountId: input.sourceAccountId,
         sourceAmount: input.sourceAmount,
         sourceEntryExchangeRate: input.exchangeRate,
         targetAccountId: input.targetAccountId,
-        targetAmount: CHAIN_RECLAIM_UAH_AMOUNT,
+        targetAmount: IBAN_BRIDGE_UAH_AMOUNT,
         toIban: input.toIban
     });
-
-const seedBridgeLegs = (bridgeAccountId: number, transferMccId: number) => {
-    const bridgeIncome = testSeedService.bankPairIncome(
-        { externalId: 'reclaim-bridge-income', operatedAt: CHAIN_RECLAIM_OPERATED_AT },
-        {
-            accountId: bridgeAccountId,
-            amount: CHAIN_RECLAIM_UAH_AMOUNT,
-            exchangeRate: CHAIN_RECLAIM_EUR_TO_UAH_RATE,
-            mccCategoryId: transferMccId,
-            toIban: CHAIN_RECLAIM_SOURCE_IBAN
-        }
-    );
-    const bridgeExpense = testSeedService.bankPairExpense(
-        { externalId: 'reclaim-bridge-expense', operatedAt: CHAIN_RECLAIM_OPERATED_AT },
-        {
-            accountId: bridgeAccountId,
-            amount: CHAIN_RECLAIM_UAH_AMOUNT,
-            mccCategoryId: transferMccId,
-            toIban: CHAIN_RECLAIM_TARGET_IBAN
-        }
-    );
-
-    return { bridgeIncome, bridgeExpense };
-};
-
-const seedDirectSourceRows = (sourceAccountId: number, targetAccountId: number, transferMccId: number) => {
-    const sourceExpense = testSeedService.bankPairExpense(
-        { externalId: 'reclaim-source-expense', operatedAt: CHAIN_RECLAIM_OPERATED_AT },
-        {
-            accountId: sourceAccountId,
-            amount: CHAIN_RECLAIM_EUR_AMOUNT,
-            exchangeRate: CHAIN_RECLAIM_UAH_TO_EUR_RATE,
-            mccCategoryId: transferMccId,
-            toIban: CHAIN_RECLAIM_TARGET_IBAN
-        }
-    );
-    const targetIncome = testSeedService.bankPairIncome(
-        { externalId: 'reclaim-target-income', operatedAt: CHAIN_RECLAIM_OPERATED_AT },
-        {
-            accountId: targetAccountId,
-            amount: CHAIN_RECLAIM_UAH_AMOUNT,
-            mccCategoryId: transferMccId
-        }
-    );
-
-    return { sourceExpense, targetIncome };
-};
-
-const parentSourceTransaction = async (sourceTransactionId: number, canonicalTransactionId: number): Promise<void> => {
-    await testDb.$client.runAsync(
-        'UPDATE transaction_entries SET original_transaction_id = ?, transaction_id = ? WHERE transaction_id = ?',
-        [sourceTransactionId, canonicalTransactionId, sourceTransactionId]
-    );
-    await testDb.$client.runAsync('UPDATE transactions SET consolidation_parent_transaction_id = ? WHERE id = ?', [
-        canonicalTransactionId,
-        sourceTransactionId
-    ]);
-};
 
 export const seedChainReclaimFixture = (input: {
     readonly consolidationType: TransactionConsolidationTypeEnum | null;
     readonly directExchangeRate?: number;
     readonly directSourceAmount?: number;
     readonly directToIban?: string;
-}) => {
-    const transferMcc = testQueryService.findMccByCode('4829');
-    const { sourceAccount, bridgeAccount, targetAccount } = seedAccounts();
-    const sourceAmount = input.directSourceAmount ?? CHAIN_RECLAIM_EUR_AMOUNT;
+}): {
+    readonly bridgeAccount: AccountEntityInterface;
+    readonly bridgeExpense: TransactionEntityInterface;
+    readonly bridgeIncome: TransactionEntityInterface;
+    readonly directTransfer: TransactionEntityInterface;
+    readonly sourceAccount: AccountEntityInterface;
+    readonly targetAccount: AccountEntityInterface;
+    readonly transferMccId: number;
+} => {
+    const { sourceAccount, bridgeAccount, targetAccount, transferMccId } = seedIbanBridgeTopology();
+    const sourceAmount = input.directSourceAmount ?? IBAN_BRIDGE_EUR_AMOUNT;
     const directTransfer = seedDirectTransfer({
         consolidationType: input.consolidationType,
-        exchangeRate: input.directExchangeRate ?? sourceAmount / CHAIN_RECLAIM_UAH_AMOUNT,
+        exchangeRate: input.directExchangeRate ?? sourceAmount / IBAN_BRIDGE_UAH_AMOUNT,
         sourceAccountId: sourceAccount.id,
         sourceAmount,
         targetAccountId: targetAccount.id,
-        toIban: input.directToIban ?? CHAIN_RECLAIM_TARGET_IBAN
+        toIban: input.directToIban ?? IBAN_BRIDGE_TARGET_IBAN
     });
 
     return {
-        ...seedBridgeLegs(bridgeAccount.id, transferMcc.id),
+        ...seedIbanBridgeLegs(bridgeAccount.id, transferMccId),
+        bridgeAccount,
         directTransfer,
         sourceAccount,
         targetAccount,
-        transferMcc
+        transferMccId
     };
 };
 
-export const seedNestedChainReclaimFixture = async () => {
-    const fixture = seedChainReclaimFixture({ consolidationType: TransactionConsolidationTypeEnum.TRANSFER_PAIR });
-    const { sourceExpense, targetIncome } = seedDirectSourceRows(
-        fixture.sourceAccount.id,
-        fixture.targetAccount.id,
-        fixture.transferMcc.id
-    );
+export const seedNestedChainReclaimFixture = async (
+    input: {
+        readonly directExchangeRate?: number;
+        readonly directToIban?: string;
+    } = {}
+) => {
+    const fixture = seedChainReclaimFixture({ consolidationType: TransactionConsolidationTypeEnum.TRANSFER_PAIR, ...input });
+    const sourceExpense = seedIbanBridgeSourceExpense(fixture.sourceAccount.id, fixture.transferMccId);
+    const targetIncome = seedIbanBridgeTargetIncome(fixture.targetAccount.id, fixture.transferMccId);
 
-    await parentSourceTransaction(sourceExpense.id, fixture.directTransfer.id);
-    await parentSourceTransaction(targetIncome.id, fixture.directTransfer.id);
+    await parentConsolidationSource(sourceExpense.id, fixture.directTransfer.id);
+    await parentConsolidationSource(targetIncome.id, fixture.directTransfer.id);
 
     return { ...fixture, sourceExpense, targetIncome };
-};
-
-export const expectChainReclaimParent = (sourceTransactionId: number, canonicalTransactionId: number): void => {
-    expect(testQueryService.fetchTransactionById(sourceTransactionId).consolidationParentTransactionId).toBe(canonicalTransactionId);
-};
-
-export const expectChainReclaimUnparented = (sourceTransactionIds: number[]): void => {
-    for (const sourceTransactionId of sourceTransactionIds) {
-        expect(testQueryService.fetchTransactionById(sourceTransactionId).consolidationParentTransactionId).toBeNull();
-    }
 };
 
 export const expectAbsorbedIntoExistingTransfer = (directTransferId: number, bridgeIncomeId: number, bridgeExpenseId: number): void => {
@@ -162,24 +96,6 @@ export const expectAbsorbedIntoExistingTransfer = (directTransferId: number, bri
 
     expect(canonicals).toHaveLength(1);
     expect(canonicals[0].id).toBe(directTransferId);
-    expectChainReclaimParent(bridgeIncomeId, directTransferId);
-    expectChainReclaimParent(bridgeExpenseId, directTransferId);
-};
-
-export const fetchChainReclaimMovedSourceIds = (canonicalTransactionId: number): number[] =>
-    testQueryService
-        .fetchEntriesByTransactionId(canonicalTransactionId)
-        .flatMap(entry => (isDefined(entry.originalTransactionId) ? [entry.originalTransactionId] : []));
-
-export const fetchChainReclaimOwnLedger = (canonicalTransactionId: number): TransactionEntryEntityInterface[] =>
-    testQueryService.fetchEntriesByTransactionId(canonicalTransactionId).filter(entry => !isDefined(entry.originalTransactionId));
-
-export const fetchChainReclaimLedgerEntry = (canonicalTransactionId: number, accountId: number): TransactionEntryEntityInterface => {
-    const entry = fetchChainReclaimOwnLedger(canonicalTransactionId).find(candidate => candidate.accountId === accountId);
-
-    if (!isDefined(entry)) {
-        throw new Error(`Ledger entry for account ${accountId} on transaction ${canonicalTransactionId} not found`);
-    }
-
-    return entry;
+    expectConsolidationParent(bridgeIncomeId, directTransferId);
+    expectConsolidationParent(bridgeExpenseId, directTransferId);
 };

--- a/tests/consolidation-tests/src/harness/consolidation-revert-audit.ts
+++ b/tests/consolidation-tests/src/harness/consolidation-revert-audit.ts
@@ -1,0 +1,89 @@
+import { expect } from 'vitest';
+
+import { isDefined } from '@rnw-community/shared';
+
+import { runConsolidation } from './run-consolidation';
+import { accountBalanceRepository, testDb, testQueryService, unconsolidationService } from './test-context';
+
+import type { TransactionConsolidationTypeEnum, TransactionEntryEntityInterface } from '@budgie/contracts';
+
+export const expectConsolidationParent = (sourceTransactionId: number, canonicalTransactionId: number): void => {
+    expect(testQueryService.fetchTransactionById(sourceTransactionId).consolidationParentTransactionId).toBe(canonicalTransactionId);
+};
+
+export const fetchOwnLedgerEntries = (transactionId: number): TransactionEntryEntityInterface[] =>
+    testQueryService.fetchEntriesByTransactionId(transactionId).filter(entry => !isDefined(entry.originalTransactionId));
+
+export const fetchMovedSourceIds = (canonicalTransactionId: number): number[] =>
+    testQueryService
+        .fetchEntriesByTransactionId(canonicalTransactionId)
+        .flatMap(entry => (isDefined(entry.originalTransactionId) ? [entry.originalTransactionId] : []))
+        .sort((left, right) => left - right);
+
+export const fetchLedgerEntry = (transactionId: number, accountId: number): TransactionEntryEntityInterface => {
+    const entry = fetchOwnLedgerEntries(transactionId).find(candidate => candidate.accountId === accountId);
+
+    if (!isDefined(entry)) {
+        throw new Error(`Ledger entry for account ${accountId} on transaction ${transactionId} not found`);
+    }
+
+    return entry;
+};
+
+export const expectSourcesRestored = (sourceTransactionIds: number[]): void => {
+    for (const sourceTransactionId of sourceTransactionIds) {
+        const source = testQueryService.fetchTransactionById(sourceTransactionId);
+
+        expect(source.consolidationParentTransactionId).toBeNull();
+        expect(source.deletedAt).toBeNull();
+        expect(fetchMovedSourceIds(sourceTransactionId)).toEqual([]);
+        expect(fetchOwnLedgerEntries(sourceTransactionId).length).toBeGreaterThan(0);
+    }
+};
+
+export const expectCanonicalDeleted = (canonicalTransactionId: number): void => {
+    expect(testQueryService.findTransactionById(canonicalTransactionId)).toBeUndefined();
+    expect(testQueryService.fetchEntriesByTransactionId(canonicalTransactionId)).toEqual([]);
+    expect(testQueryService.fetchChildTransactionIds(canonicalTransactionId)).toEqual([]);
+};
+
+export const expectRevertRemovedCanonical = (canonicalTransactionId: number, sourceTransactionIds: number[]): void => {
+    expectCanonicalDeleted(canonicalTransactionId);
+    expectSourcesRestored(sourceTransactionIds);
+};
+
+export const fetchSingleCanonicalId = (consolidationType: TransactionConsolidationTypeEnum): number => {
+    const canonicals = testQueryService.fetchCanonicalsOfType(consolidationType);
+
+    expect(canonicals).toHaveLength(1);
+
+    return canonicals[0].id;
+};
+
+export const revertSingleCanonical = async (consolidationType: TransactionConsolidationTypeEnum): Promise<number> => {
+    const canonicalId = fetchSingleCanonicalId(consolidationType);
+
+    await unconsolidationService.unconsolidateById(canonicalId, testDb);
+
+    return canonicalId;
+};
+
+export const fetchLedgerBalances = async (accountIds: number[]): Promise<number[][]> => {
+    const balances = await accountBalanceRepository.getNewTransactionEntriesDeltas(accountIds);
+
+    return accountIds.map(accountId => [accountId, balances.get(accountId) ?? 0]);
+};
+
+export const expectRevertRestoresSources = async (input: {
+    readonly accountIds: number[];
+    readonly consolidationType: TransactionConsolidationTypeEnum;
+    readonly sourceTransactionIds: number[];
+}): Promise<void> => {
+    const balancesBeforeConsolidation = await fetchLedgerBalances(input.accountIds);
+    const consolidationResult = await runConsolidation();
+
+    expect(consolidationResult.consolidated).toBe(1);
+
+    expectRevertRemovedCanonical(await revertSingleCanonical(input.consolidationType), input.sourceTransactionIds);
+    expect(await fetchLedgerBalances(input.accountIds)).toEqual(balancesBeforeConsolidation);
+};

--- a/tests/consolidation-tests/src/harness/iban-bridge-topology.ts
+++ b/tests/consolidation-tests/src/harness/iban-bridge-topology.ts
@@ -1,0 +1,96 @@
+import { testDb, testQueryService, testSeedService } from './test-context';
+
+import type { AccountEntityInterface, TransactionEntityInterface } from '@budgie/contracts';
+
+export const IBAN_BRIDGE_SOURCE_IBAN = 'UA-RECLAIM-SOURCE-EUR';
+export const IBAN_BRIDGE_TARGET_IBAN = 'UA-RECLAIM-TARGET-UAH';
+const IBAN_BRIDGE_BRIDGE_IBAN = 'UA-RECLAIM-BRIDGE-UAH';
+export const IBAN_BRIDGE_EUR_AMOUNT = 1_658_290_000;
+export const IBAN_BRIDGE_UAH_AMOUNT = 84_456_700_000;
+export const IBAN_BRIDGE_UAH_TO_EUR_RATE = IBAN_BRIDGE_EUR_AMOUNT / IBAN_BRIDGE_UAH_AMOUNT;
+const IBAN_BRIDGE_EUR_TO_UAH_RATE = IBAN_BRIDGE_UAH_AMOUNT / IBAN_BRIDGE_EUR_AMOUNT;
+export const IBAN_BRIDGE_OPERATED_AT = new Date('2026-05-20T18:38:00');
+export const IBAN_BRIDGE_TRANSFER_MCC = '4829';
+
+export const seedIbanBridgeTopology = (): {
+    readonly bridgeAccount: AccountEntityInterface;
+    readonly sourceAccount: AccountEntityInterface;
+    readonly targetAccount: AccountEntityInterface;
+    readonly transferMccId: number;
+} => {
+    const eur = testSeedService.instrument({ code: 'EUR', name: 'Euro', symbol: 'EUR' });
+
+    return {
+        sourceAccount: testSeedService.bankSyncAccount('Reclaim Source EUR', null, IBAN_BRIDGE_SOURCE_IBAN, eur.id),
+        bridgeAccount: testSeedService.bankSyncAccount('Reclaim Bridge UAH', null, IBAN_BRIDGE_BRIDGE_IBAN),
+        targetAccount: testSeedService.bankSyncAccount('Reclaim Target UAH', null, IBAN_BRIDGE_TARGET_IBAN),
+        transferMccId: testQueryService.findMccByCode(IBAN_BRIDGE_TRANSFER_MCC).id
+    };
+};
+
+export const seedIbanBridgeIncomeLeg = (bridgeAccountId: number, transferMccId: number): TransactionEntityInterface =>
+    testSeedService.bankPairIncome(
+        { externalId: 'reclaim-bridge-income', operatedAt: IBAN_BRIDGE_OPERATED_AT },
+        {
+            accountId: bridgeAccountId,
+            amount: IBAN_BRIDGE_UAH_AMOUNT,
+            exchangeRate: IBAN_BRIDGE_EUR_TO_UAH_RATE,
+            mccCategoryId: transferMccId,
+            toIban: IBAN_BRIDGE_SOURCE_IBAN
+        }
+    );
+
+const seedIbanBridgeExpenseLeg = (bridgeAccountId: number, transferMccId: number): TransactionEntityInterface =>
+    testSeedService.bankPairExpense(
+        { externalId: 'reclaim-bridge-expense', operatedAt: IBAN_BRIDGE_OPERATED_AT },
+        {
+            accountId: bridgeAccountId,
+            amount: IBAN_BRIDGE_UAH_AMOUNT,
+            mccCategoryId: transferMccId,
+            toIban: IBAN_BRIDGE_TARGET_IBAN
+        }
+    );
+
+export const seedIbanBridgeLegs = (
+    bridgeAccountId: number,
+    transferMccId: number
+): {
+    readonly bridgeExpense: TransactionEntityInterface;
+    readonly bridgeIncome: TransactionEntityInterface;
+} => ({
+    bridgeIncome: seedIbanBridgeIncomeLeg(bridgeAccountId, transferMccId),
+    bridgeExpense: seedIbanBridgeExpenseLeg(bridgeAccountId, transferMccId)
+});
+
+export const seedIbanBridgeSourceExpense = (sourceAccountId: number, transferMccId: number): TransactionEntityInterface =>
+    testSeedService.bankPairExpense(
+        { externalId: 'reclaim-source-expense', operatedAt: IBAN_BRIDGE_OPERATED_AT },
+        {
+            accountId: sourceAccountId,
+            amount: IBAN_BRIDGE_EUR_AMOUNT,
+            exchangeRate: IBAN_BRIDGE_UAH_TO_EUR_RATE,
+            mccCategoryId: transferMccId,
+            toIban: IBAN_BRIDGE_TARGET_IBAN
+        }
+    );
+
+export const seedIbanBridgeTargetIncome = (targetAccountId: number, transferMccId: number): TransactionEntityInterface =>
+    testSeedService.bankPairIncome(
+        { externalId: 'reclaim-target-income', operatedAt: IBAN_BRIDGE_OPERATED_AT },
+        {
+            accountId: targetAccountId,
+            amount: IBAN_BRIDGE_UAH_AMOUNT,
+            mccCategoryId: transferMccId
+        }
+    );
+
+export const parentConsolidationSource = async (sourceTransactionId: number, canonicalTransactionId: number): Promise<void> => {
+    await testDb.$client.runAsync(
+        'UPDATE transaction_entries SET original_transaction_id = ?, transaction_id = ? WHERE transaction_id = ?',
+        [sourceTransactionId, canonicalTransactionId, sourceTransactionId]
+    );
+    await testDb.$client.runAsync('UPDATE transactions SET consolidation_parent_transaction_id = ? WHERE id = ?', [
+        canonicalTransactionId,
+        sourceTransactionId
+    ]);
+};

--- a/tests/consolidation-tests/src/scenarios/atm-cash-withdrawal.test.ts
+++ b/tests/consolidation-tests/src/scenarios/atm-cash-withdrawal.test.ts
@@ -1,0 +1,65 @@
+import { AccountTypeEnum, PRECISION, TransactionConsolidationTypeEnum } from '@budgie/contracts';
+import { describe, expect, it } from 'vitest';
+
+import {
+    expectConsolidationParent,
+    expectRevertRestoresSources,
+    fetchLedgerBalances,
+    fetchLedgerEntry,
+    fetchOwnLedgerEntries,
+    fetchSingleCanonicalId
+} from '../harness/consolidation-revert-audit';
+import { runConsolidation } from '../harness/run-consolidation';
+import { testQueryService, testSeedService } from '../harness/test-context';
+
+const ATM_WITHDRAWAL_AMOUNT = 500 * PRECISION;
+const ATM_WITHDRAWAL_FEE_AMOUNT = 5 * PRECISION;
+const ATM_CANONICAL_LEDGER_ENTRY_COUNT = 3;
+const ATM_EXPENSE_LEDGER_ENTRY_COUNT = 2;
+const ATM_MCC = '6011';
+const ATM_OPERATED_AT = new Date('2026-05-20T18:38:00');
+
+const seedAtmCashWithdrawalFixture = () => {
+    const bankAccount = testSeedService.account({ title: 'Atm Bank', type: AccountTypeEnum.BANK_SYNC });
+    const cashAccount = testSeedService.account({ title: 'Atm Cash', type: AccountTypeEnum.CASH });
+    const expense = testSeedService.bankPairExpense(
+        { externalId: 'tx-atm', operatedAt: ATM_OPERATED_AT },
+        { accountId: bankAccount.id, amount: ATM_WITHDRAWAL_AMOUNT, mccCategoryId: testQueryService.findMccByCode(ATM_MCC).id }
+    );
+
+    testSeedService.feeEntry(expense.id, 'tx-atm-fee', { accountId: bankAccount.id, amount: ATM_WITHDRAWAL_FEE_AMOUNT });
+
+    return { bankAccount, cashAccount, expense };
+};
+
+const fetchAtmCanonicalId = (): number => fetchSingleCanonicalId(TransactionConsolidationTypeEnum.ATM_CASH_WITHDRAWAL);
+
+describe('consolidation/atm-cash-withdrawal', () => {
+    it('promotes an ATM expense into a canonical transfer to cash and copies its fee entry', async () => {
+        const { bankAccount, cashAccount, expense } = seedAtmCashWithdrawalFixture();
+
+        const result = await runConsolidation();
+        const canonicalId = fetchAtmCanonicalId();
+
+        expect(result.consolidated).toBe(1);
+        expectConsolidationParent(expense.id, canonicalId);
+        expect(fetchOwnLedgerEntries(canonicalId)).toHaveLength(ATM_CANONICAL_LEDGER_ENTRY_COUNT);
+        expect(fetchLedgerEntry(canonicalId, cashAccount.id).amount).toBe(ATM_WITHDRAWAL_AMOUNT);
+        expect(await fetchLedgerBalances([bankAccount.id, cashAccount.id])).toEqual([
+            [bankAccount.id, -(ATM_WITHDRAWAL_AMOUNT + ATM_WITHDRAWAL_FEE_AMOUNT)],
+            [cashAccount.id, ATM_WITHDRAWAL_AMOUNT]
+        ]);
+    });
+
+    it('restores the ATM expense with its fee entry and clears the cash balance when reverted', async () => {
+        const { bankAccount, cashAccount, expense } = seedAtmCashWithdrawalFixture();
+
+        await expectRevertRestoresSources({
+            accountIds: [bankAccount.id, cashAccount.id],
+            consolidationType: TransactionConsolidationTypeEnum.ATM_CASH_WITHDRAWAL,
+            sourceTransactionIds: [expense.id]
+        });
+
+        expect(fetchOwnLedgerEntries(expense.id)).toHaveLength(ATM_EXPENSE_LEDGER_ENTRY_COUNT);
+    });
+});

--- a/tests/consolidation-tests/src/scenarios/existing-transfer-bridge.test.ts
+++ b/tests/consolidation-tests/src/scenarios/existing-transfer-bridge.test.ts
@@ -1,0 +1,76 @@
+import { TransactionConsolidationTypeEnum } from '@budgie/contracts';
+import { describe, expect, it } from 'vitest';
+
+import {
+    expectConsolidationParent,
+    expectRevertRestoresSources,
+    fetchLedgerEntry,
+    fetchOwnLedgerEntries,
+    fetchSingleCanonicalId
+} from '../harness/consolidation-revert-audit';
+import {
+    IBAN_BRIDGE_EUR_AMOUNT,
+    IBAN_BRIDGE_OPERATED_AT,
+    IBAN_BRIDGE_TARGET_IBAN,
+    IBAN_BRIDGE_UAH_AMOUNT,
+    seedIbanBridgeIncomeLeg,
+    seedIbanBridgeSourceExpense,
+    seedIbanBridgeTopology
+} from '../harness/iban-bridge-topology';
+import { runConsolidation } from '../harness/run-consolidation';
+import { testQueryService, testSeedService } from '../harness/test-context';
+
+const EXISTING_TRANSFER_LEDGER_ENTRY_COUNT = 2;
+
+const seedExistingTransferBridgeFixture = () => {
+    const topology = seedIbanBridgeTopology();
+
+    return {
+        ...topology,
+        sourceExpense: seedIbanBridgeSourceExpense(topology.sourceAccount.id, topology.transferMccId),
+        bridgeIncome: seedIbanBridgeIncomeLeg(topology.bridgeAccount.id, topology.transferMccId),
+        existingTransfer: testSeedService.directTransfer({
+            consolidationType: null,
+            exchangeRate: 1,
+            operatedAt: IBAN_BRIDGE_OPERATED_AT,
+            sourceAccountId: topology.bridgeAccount.id,
+            sourceAmount: IBAN_BRIDGE_UAH_AMOUNT,
+            sourceEntryExchangeRate: 1,
+            targetAccountId: topology.targetAccount.id,
+            targetAmount: IBAN_BRIDGE_UAH_AMOUNT,
+            toIban: IBAN_BRIDGE_TARGET_IBAN
+        })
+    };
+};
+
+const fetchBridgeCanonicalId = (): number => fetchSingleCanonicalId(TransactionConsolidationTypeEnum.IBAN_BRIDGE_TRANSFER);
+
+describe('consolidation/existing-transfer-bridge', () => {
+    it('nests a hand-created bridge transfer under a new source to target canonical', async () => {
+        const { bridgeIncome, existingTransfer, sourceAccount, sourceExpense, targetAccount } = seedExistingTransferBridgeFixture();
+
+        const result = await runConsolidation();
+        const canonicalId = fetchBridgeCanonicalId();
+
+        expect(result.consolidated).toBe(1);
+        expectConsolidationParent(sourceExpense.id, canonicalId);
+        expectConsolidationParent(bridgeIncome.id, canonicalId);
+        expectConsolidationParent(existingTransfer.id, canonicalId);
+        expect(fetchLedgerEntry(canonicalId, sourceAccount.id).amount).toBe(IBAN_BRIDGE_EUR_AMOUNT);
+        expect(fetchLedgerEntry(canonicalId, targetAccount.id).amount).toBe(IBAN_BRIDGE_UAH_AMOUNT);
+    });
+
+    it('restores the hand-created transfer with its own ledger when the bridge canonical is reverted', async () => {
+        const { bridgeAccount, bridgeIncome, existingTransfer, sourceAccount, sourceExpense, targetAccount } =
+            seedExistingTransferBridgeFixture();
+
+        await expectRevertRestoresSources({
+            accountIds: [sourceAccount.id, bridgeAccount.id, targetAccount.id],
+            consolidationType: TransactionConsolidationTypeEnum.IBAN_BRIDGE_TRANSFER,
+            sourceTransactionIds: [sourceExpense.id, bridgeIncome.id, existingTransfer.id]
+        });
+
+        expect(testQueryService.fetchTransactionById(existingTransfer.id).consolidationType).toBeNull();
+        expect(fetchOwnLedgerEntries(existingTransfer.id)).toHaveLength(EXISTING_TRANSFER_LEDGER_ENTRY_COUNT);
+    });
+});

--- a/tests/consolidation-tests/src/scenarios/existing-transfer-income-duplicate.test.ts
+++ b/tests/consolidation-tests/src/scenarios/existing-transfer-income-duplicate.test.ts
@@ -1,0 +1,78 @@
+import { AccountTypeEnum, PRECISION, TransactionConsolidationTypeEnum } from '@budgie/contracts';
+import { describe, expect, it } from 'vitest';
+
+import {
+    expectConsolidationParent,
+    expectSourcesRestored,
+    fetchLedgerBalances,
+    fetchMovedSourceIds
+} from '../harness/consolidation-revert-audit';
+import { IBAN_BRIDGE_TRANSFER_MCC } from '../harness/iban-bridge-topology';
+import { runConsolidation } from '../harness/run-consolidation';
+import { testDb, testQueryService, testSeedService, unconsolidationService } from '../harness/test-context';
+
+const INCOME_DUPLICATE_AMOUNT = 500 * PRECISION;
+const INCOME_DUPLICATE_OPERATED_AT = new Date('2026-05-20T18:38:00');
+
+const seedExistingTransferIncomeDuplicateFixture = () => {
+    const transferMccId = testQueryService.findMccByCode(IBAN_BRIDGE_TRANSFER_MCC).id;
+    const sourceAccount = testSeedService.account({ title: 'Duplicate Source UAH', type: AccountTypeEnum.BANK_SYNC });
+    const targetAccount = testSeedService.account({ title: 'Duplicate Target UAH', type: AccountTypeEnum.BANK_SYNC });
+    const existingTransfer = testSeedService.directTransfer({
+        consolidationType: null,
+        exchangeRate: 1,
+        operatedAt: INCOME_DUPLICATE_OPERATED_AT,
+        sourceAccountId: sourceAccount.id,
+        sourceAmount: INCOME_DUPLICATE_AMOUNT,
+        sourceEntryExchangeRate: 1,
+        targetAccountId: targetAccount.id,
+        targetAmount: INCOME_DUPLICATE_AMOUNT,
+        toIban: null
+    });
+    const duplicateIncome = testSeedService.bankPairIncome(
+        { externalId: 'duplicate-income', operatedAt: INCOME_DUPLICATE_OPERATED_AT },
+        { accountId: targetAccount.id, amount: INCOME_DUPLICATE_AMOUNT, mccCategoryId: transferMccId }
+    );
+
+    return { duplicateIncome, existingTransfer, sourceAccount, targetAccount };
+};
+
+describe('consolidation/existing-transfer-income-duplicate', () => {
+    it('absorbs the duplicate income into the pre-existing transfer and retypes it', async () => {
+        const { duplicateIncome, existingTransfer, sourceAccount, targetAccount } = seedExistingTransferIncomeDuplicateFixture();
+        const accountIds = [sourceAccount.id, targetAccount.id];
+
+        const result = await runConsolidation();
+
+        expect(result.consolidated).toBe(1);
+        expectConsolidationParent(duplicateIncome.id, existingTransfer.id);
+        expect(testQueryService.fetchTransactionById(existingTransfer.id).consolidationType).toBe(
+            TransactionConsolidationTypeEnum.TRANSFER_PAIR
+        );
+        expect(fetchMovedSourceIds(existingTransfer.id)).toEqual([duplicateIncome.id]);
+        expect(await fetchLedgerBalances(accountIds)).toEqual([
+            [sourceAccount.id, -INCOME_DUPLICATE_AMOUNT],
+            [targetAccount.id, INCOME_DUPLICATE_AMOUNT]
+        ]);
+    });
+
+    it('deletes the pre-existing transfer instead of restoring it when the absorbed income duplicate is reverted', async () => {
+        const { duplicateIncome, existingTransfer, sourceAccount, targetAccount } = seedExistingTransferIncomeDuplicateFixture();
+        const accountIds = [sourceAccount.id, targetAccount.id];
+        const balancesBeforeConsolidation = await fetchLedgerBalances(accountIds);
+
+        await runConsolidation();
+        await unconsolidationService.unconsolidateById(existingTransfer.id, testDb);
+
+        expectSourcesRestored([duplicateIncome.id]);
+        expect(testQueryService.findTransactionById(existingTransfer.id)).toBeUndefined();
+        expect(balancesBeforeConsolidation).toEqual([
+            [sourceAccount.id, -INCOME_DUPLICATE_AMOUNT],
+            [targetAccount.id, INCOME_DUPLICATE_AMOUNT + INCOME_DUPLICATE_AMOUNT]
+        ]);
+        expect(await fetchLedgerBalances(accountIds)).toEqual([
+            [sourceAccount.id, 0],
+            [targetAccount.id, INCOME_DUPLICATE_AMOUNT]
+        ]);
+    });
+});

--- a/tests/consolidation-tests/src/scenarios/iban-bridge-canonical-duplicate.test.ts
+++ b/tests/consolidation-tests/src/scenarios/iban-bridge-canonical-duplicate.test.ts
@@ -1,0 +1,83 @@
+import { TransactionConsolidationTypeEnum } from '@budgie/contracts';
+import { describe, expect, it } from 'vitest';
+
+import {
+    expectConsolidationParent,
+    expectRevertRemovedCanonical,
+    fetchLedgerBalances,
+    fetchMovedSourceIds,
+    fetchSingleCanonicalId
+} from '../harness/consolidation-revert-audit';
+import {
+    IBAN_BRIDGE_EUR_AMOUNT,
+    IBAN_BRIDGE_UAH_AMOUNT,
+    seedIbanBridgeLegs,
+    seedIbanBridgeSourceExpense,
+    seedIbanBridgeTargetIncome,
+    seedIbanBridgeTopology
+} from '../harness/iban-bridge-topology';
+import { runConsolidation } from '../harness/run-consolidation';
+import { testDb, unconsolidationService } from '../harness/test-context';
+
+const DUPLICATED_LEG_COUNT = 2;
+
+const byTransactionId = (left: number, right: number): number => left - right;
+
+const fetchBridgeCanonicalId = (): number => fetchSingleCanonicalId(TransactionConsolidationTypeEnum.IBAN_BRIDGE_TRANSFER);
+
+const seedIbanBridgeCanonicalDuplicateFixture = async () => {
+    const topology = seedIbanBridgeTopology();
+    const legs = seedIbanBridgeLegs(topology.bridgeAccount.id, topology.transferMccId);
+
+    await runConsolidation();
+
+    return {
+        ...topology,
+        ...legs,
+        canonicalId: fetchBridgeCanonicalId(),
+        sourceExpense: seedIbanBridgeSourceExpense(topology.sourceAccount.id, topology.transferMccId),
+        targetIncome: seedIbanBridgeTargetIncome(topology.targetAccount.id, topology.transferMccId)
+    };
+};
+
+describe('consolidation/iban-bridge-canonical-duplicate', () => {
+    it('absorbs late direct legs into the existing bridge canonical instead of building a second one', async () => {
+        const { canonicalId, sourceExpense, targetIncome, bridgeIncome, bridgeExpense, sourceAccount, bridgeAccount, targetAccount } =
+            await seedIbanBridgeCanonicalDuplicateFixture();
+        const accountIds = [sourceAccount.id, bridgeAccount.id, targetAccount.id];
+        const balancesBeforeAbsorb = await fetchLedgerBalances(accountIds);
+
+        const result = await runConsolidation();
+
+        expect(result.consolidated).toBe(1);
+        expect(fetchBridgeCanonicalId()).toBe(canonicalId);
+        expectConsolidationParent(sourceExpense.id, canonicalId);
+        expectConsolidationParent(targetIncome.id, canonicalId);
+        expect(fetchMovedSourceIds(canonicalId)).toEqual(
+            [bridgeIncome.id, bridgeExpense.id, sourceExpense.id, targetIncome.id].sort(byTransactionId)
+        );
+        expect(balancesBeforeAbsorb).toEqual([
+            [sourceAccount.id, -DUPLICATED_LEG_COUNT * IBAN_BRIDGE_EUR_AMOUNT],
+            [bridgeAccount.id, 0],
+            [targetAccount.id, DUPLICATED_LEG_COUNT * IBAN_BRIDGE_UAH_AMOUNT]
+        ]);
+        expect(await fetchLedgerBalances(accountIds)).toEqual([
+            [sourceAccount.id, -IBAN_BRIDGE_EUR_AMOUNT],
+            [bridgeAccount.id, 0],
+            [targetAccount.id, IBAN_BRIDGE_UAH_AMOUNT]
+        ]);
+    });
+
+    it('restores every absorbed and original leg when the shared canonical is reverted', async () => {
+        const { bridgeAccount, bridgeExpense, bridgeIncome, canonicalId, sourceAccount, sourceExpense, targetAccount, targetIncome } =
+            await seedIbanBridgeCanonicalDuplicateFixture();
+        const accountIds = [sourceAccount.id, bridgeAccount.id, targetAccount.id];
+
+        await runConsolidation();
+        const balancesAfterAbsorb = await fetchLedgerBalances(accountIds);
+        await unconsolidationService.unconsolidateById(canonicalId, testDb);
+
+        expectRevertRemovedCanonical(canonicalId, [bridgeIncome.id, bridgeExpense.id, sourceExpense.id, targetIncome.id]);
+        expect(await fetchLedgerBalances(accountIds)).toEqual(balancesAfterAbsorb);
+    });
+});

--- a/tests/consolidation-tests/src/scenarios/iban-bridge-chain-reclaim-rebuild.test.ts
+++ b/tests/consolidation-tests/src/scenarios/iban-bridge-chain-reclaim-rebuild.test.ts
@@ -2,52 +2,52 @@ import { TransactionConsolidationTypeEnum } from '@budgie/contracts';
 import { describe, expect, it } from 'vitest';
 
 import {
-    CHAIN_RECLAIM_EUR_AMOUNT,
-    CHAIN_RECLAIM_SOURCE_IBAN,
     CHAIN_RECLAIM_STALE_RATE_MULTIPLIER,
-    CHAIN_RECLAIM_TARGET_IBAN,
-    CHAIN_RECLAIM_UAH_AMOUNT,
-    CHAIN_RECLAIM_UAH_TO_EUR_RATE,
-    expectChainReclaimParent,
-    expectChainReclaimUnparented,
-    fetchChainReclaimLedgerEntry,
-    fetchChainReclaimOwnLedger,
     seedChainReclaimFixture,
     seedNestedChainReclaimFixture
 } from '../harness/chain-reclaim-fixture';
+import {
+    expectConsolidationParent,
+    expectSourcesRestored,
+    fetchLedgerBalances,
+    fetchLedgerEntry,
+    fetchOwnLedgerEntries,
+    fetchSingleCanonicalId
+} from '../harness/consolidation-revert-audit';
+import {
+    IBAN_BRIDGE_EUR_AMOUNT,
+    IBAN_BRIDGE_SOURCE_IBAN,
+    IBAN_BRIDGE_TARGET_IBAN,
+    IBAN_BRIDGE_UAH_AMOUNT,
+    IBAN_BRIDGE_UAH_TO_EUR_RATE
+} from '../harness/iban-bridge-topology';
 import { runConsolidation } from '../harness/run-consolidation';
 import { testDb, testQueryService, unconsolidationService } from '../harness/test-context';
 
 const RATE_PRECISION_DIGITS = 10;
 const REBUILT_LEDGER_ENTRY_COUNT = 2;
-
-const fetchRebuiltCanonicalId = (): number => {
-    const canonicals = testQueryService.fetchCanonicalsOfType(TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER);
-
-    expect(canonicals).toHaveLength(1);
-
-    return canonicals[0].id;
+const STALE_DIRECT_TRANSFER = {
+    directExchangeRate: IBAN_BRIDGE_UAH_TO_EUR_RATE * CHAIN_RECLAIM_STALE_RATE_MULTIPLIER,
+    directToIban: IBAN_BRIDGE_SOURCE_IBAN
 };
 
-const expectRebuiltCanonicalLedger = (canonicalId: number, sourceAccountId: number, targetAccountId: number): void => {
-    const sourceLedgerEntry = fetchChainReclaimLedgerEntry(canonicalId, sourceAccountId);
+const fetchRebuiltCanonicalId = (): number => fetchSingleCanonicalId(TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER);
 
-    expect(testQueryService.fetchTransactionById(canonicalId).exchangeRate).toBeCloseTo(
-        CHAIN_RECLAIM_UAH_TO_EUR_RATE,
-        RATE_PRECISION_DIGITS
-    );
-    expect(sourceLedgerEntry.amount).toBe(CHAIN_RECLAIM_EUR_AMOUNT);
-    expect(sourceLedgerEntry.toIban).toBe(CHAIN_RECLAIM_TARGET_IBAN);
-    expect(sourceLedgerEntry.exchangeRate).toBeCloseTo(CHAIN_RECLAIM_UAH_TO_EUR_RATE, RATE_PRECISION_DIGITS);
-    expect(fetchChainReclaimLedgerEntry(canonicalId, targetAccountId).amount).toBe(CHAIN_RECLAIM_UAH_AMOUNT);
+const expectRebuiltCanonicalLedger = (canonicalId: number, sourceAccountId: number, targetAccountId: number): void => {
+    const sourceLedgerEntry = fetchLedgerEntry(canonicalId, sourceAccountId);
+
+    expect(testQueryService.fetchTransactionById(canonicalId).exchangeRate).toBeCloseTo(IBAN_BRIDGE_UAH_TO_EUR_RATE, RATE_PRECISION_DIGITS);
+    expect(sourceLedgerEntry.amount).toBe(IBAN_BRIDGE_EUR_AMOUNT);
+    expect(sourceLedgerEntry.toIban).toBe(IBAN_BRIDGE_TARGET_IBAN);
+    expect(sourceLedgerEntry.exchangeRate).toBeCloseTo(IBAN_BRIDGE_UAH_TO_EUR_RATE, RATE_PRECISION_DIGITS);
+    expect(fetchLedgerEntry(canonicalId, targetAccountId).amount).toBe(IBAN_BRIDGE_UAH_AMOUNT);
 };
 
 describe('consolidation/iban-bridge-chain-reclaim-rebuild', () => {
     it('rebuilds an fx-correct canonical when the existing transfer ledger diverges', async () => {
         const { bridgeExpense, bridgeIncome, directTransfer, sourceAccount, targetAccount } = seedChainReclaimFixture({
             consolidationType: TransactionConsolidationTypeEnum.TRANSFER_PAIR,
-            directExchangeRate: CHAIN_RECLAIM_UAH_TO_EUR_RATE * CHAIN_RECLAIM_STALE_RATE_MULTIPLIER,
-            directToIban: CHAIN_RECLAIM_SOURCE_IBAN
+            ...STALE_DIRECT_TRANSFER
         });
 
         const result = await runConsolidation();
@@ -56,17 +56,16 @@ describe('consolidation/iban-bridge-chain-reclaim-rebuild', () => {
         expect(result.found).toBe(1);
         expect(result.consolidated).toBe(1);
         expect(rebuiltCanonicalId).not.toBe(directTransfer.id);
-        expectChainReclaimParent(directTransfer.id, rebuiltCanonicalId);
-        expectChainReclaimParent(bridgeIncome.id, rebuiltCanonicalId);
-        expectChainReclaimParent(bridgeExpense.id, rebuiltCanonicalId);
+        expectConsolidationParent(directTransfer.id, rebuiltCanonicalId);
+        expectConsolidationParent(bridgeIncome.id, rebuiltCanonicalId);
+        expectConsolidationParent(bridgeExpense.id, rebuiltCanonicalId);
         expectRebuiltCanonicalLedger(rebuiltCanonicalId, sourceAccount.id, targetAccount.id);
     });
 
     it('restores the original transfer pair when a rebuilt chain canonical is reverted', async () => {
         const { bridgeExpense, bridgeIncome, directTransfer } = seedChainReclaimFixture({
             consolidationType: TransactionConsolidationTypeEnum.TRANSFER_PAIR,
-            directExchangeRate: CHAIN_RECLAIM_UAH_TO_EUR_RATE * CHAIN_RECLAIM_STALE_RATE_MULTIPLIER,
-            directToIban: CHAIN_RECLAIM_SOURCE_IBAN
+            ...STALE_DIRECT_TRANSFER
         });
 
         await runConsolidation();
@@ -76,21 +75,23 @@ describe('consolidation/iban-bridge-chain-reclaim-rebuild', () => {
         expect(testQueryService.fetchTransactionById(directTransfer.id).consolidationType).toBe(
             TransactionConsolidationTypeEnum.TRANSFER_PAIR
         );
-        expectChainReclaimUnparented([directTransfer.id, bridgeIncome.id, bridgeExpense.id]);
-        expect(fetchChainReclaimOwnLedger(directTransfer.id)).toHaveLength(REBUILT_LEDGER_ENTRY_COUNT);
+        expectSourcesRestored([directTransfer.id, bridgeIncome.id, bridgeExpense.id]);
+        expect(fetchOwnLedgerEntries(directTransfer.id)).toHaveLength(REBUILT_LEDGER_ENTRY_COUNT);
     });
 
-    it('restores every chain leg when a fast-path reclaim is reverted', async () => {
-        const { bridgeExpense, bridgeIncome, directTransfer, sourceExpense, targetIncome } = await seedNestedChainReclaimFixture();
+    it('unwinds both consolidation levels and deletes the absorbed transfer pair when a fast-path reclaim is reverted', async () => {
+        const { bridgeAccount, bridgeExpense, bridgeIncome, directTransfer, sourceAccount, sourceExpense, targetAccount, targetIncome } =
+            await seedNestedChainReclaimFixture();
+        const accountIds = [sourceAccount.id, bridgeAccount.id, targetAccount.id];
+        const balancesBeforeConsolidation = await fetchLedgerBalances(accountIds);
 
         await runConsolidation();
         await unconsolidationService.unconsolidateById(directTransfer.id, testDb);
 
         expect(testQueryService.fetchCanonicalsOfType(TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER)).toHaveLength(0);
-        expectChainReclaimUnparented([sourceExpense.id, targetIncome.id, bridgeIncome.id, bridgeExpense.id]);
-        expect(fetchChainReclaimOwnLedger(sourceExpense.id)).toHaveLength(1);
-        expect(fetchChainReclaimOwnLedger(targetIncome.id)).toHaveLength(1);
-        expect(fetchChainReclaimOwnLedger(bridgeIncome.id)).toHaveLength(1);
-        expect(fetchChainReclaimOwnLedger(bridgeExpense.id)).toHaveLength(1);
+        expect(testQueryService.findTransactionById(directTransfer.id)).toBeUndefined();
+        expectSourcesRestored([sourceExpense.id, targetIncome.id, bridgeIncome.id, bridgeExpense.id]);
+        expect(fetchOwnLedgerEntries(sourceExpense.id)).toHaveLength(1);
+        expect(await fetchLedgerBalances(accountIds)).toEqual(balancesBeforeConsolidation);
     });
 });

--- a/tests/consolidation-tests/src/scenarios/iban-bridge-chain-reclaim.test.ts
+++ b/tests/consolidation-tests/src/scenarios/iban-bridge-chain-reclaim.test.ts
@@ -2,15 +2,13 @@ import { TransactionConsolidationTypeEnum } from '@budgie/contracts';
 import { describe, expect, it } from 'vitest';
 
 import {
-    CHAIN_RECLAIM_EUR_AMOUNT,
     CHAIN_RECLAIM_ONE_CENT_AMOUNT,
     expectAbsorbedIntoExistingTransfer,
-    expectChainReclaimParent,
-    expectChainReclaimUnparented,
-    fetchChainReclaimMovedSourceIds,
     seedChainReclaimFixture,
     seedNestedChainReclaimFixture
 } from '../harness/chain-reclaim-fixture';
+import { expectConsolidationParent, expectSourcesRestored, fetchMovedSourceIds } from '../harness/consolidation-revert-audit';
+import { IBAN_BRIDGE_EUR_AMOUNT } from '../harness/iban-bridge-topology';
 import { runConsolidation } from '../harness/run-consolidation';
 import { testQueryService } from '../harness/test-context';
 
@@ -28,9 +26,7 @@ describe('consolidation/iban-bridge-chain-reclaim', () => {
         expect(result.consolidated).toBe(1);
         expect(testQueryService.fetchCanonicalsOfType(TransactionConsolidationTypeEnum.TRANSFER_PAIR)).toHaveLength(0);
         expectAbsorbedIntoExistingTransfer(directTransfer.id, bridgeIncome.id, bridgeExpense.id);
-        expect(fetchChainReclaimMovedSourceIds(directTransfer.id).sort(byTransactionId)).toEqual(
-            [bridgeIncome.id, bridgeExpense.id].sort(byTransactionId)
-        );
+        expect(fetchMovedSourceIds(directTransfer.id)).toEqual([bridgeIncome.id, bridgeExpense.id].sort(byTransactionId));
     });
 
     it('preserves original moved source rows when reclaiming bridge legs into an existing generated transfer pair', async () => {
@@ -41,9 +37,9 @@ describe('consolidation/iban-bridge-chain-reclaim', () => {
         expect(result.found).toBe(1);
         expect(result.consolidated).toBe(1);
         expectAbsorbedIntoExistingTransfer(directTransfer.id, bridgeIncome.id, bridgeExpense.id);
-        expectChainReclaimParent(sourceExpense.id, directTransfer.id);
-        expectChainReclaimParent(targetIncome.id, directTransfer.id);
-        expect(fetchChainReclaimMovedSourceIds(directTransfer.id).sort(byTransactionId)).toEqual(
+        expectConsolidationParent(sourceExpense.id, directTransfer.id);
+        expectConsolidationParent(targetIncome.id, directTransfer.id);
+        expect(fetchMovedSourceIds(directTransfer.id)).toEqual(
             [sourceExpense.id, targetIncome.id, bridgeIncome.id, bridgeExpense.id].sort(byTransactionId)
         );
     });
@@ -56,13 +52,13 @@ describe('consolidation/iban-bridge-chain-reclaim', () => {
         expect(result.found).toBe(0);
         expect(result.consolidated).toBe(0);
         expect(testQueryService.fetchTransactionById(directTransfer.id).consolidationType).toBeNull();
-        expectChainReclaimUnparented([bridgeIncome.id, bridgeExpense.id]);
+        expectSourcesRestored([bridgeIncome.id, bridgeExpense.id]);
     });
 
     it('reclaims an off-by-cents chain instead of creating a duplicate bridge canonical', async () => {
         const { bridgeExpense, bridgeIncome, directTransfer } = seedChainReclaimFixture({
             consolidationType: TransactionConsolidationTypeEnum.TRANSFER_PAIR,
-            directSourceAmount: CHAIN_RECLAIM_EUR_AMOUNT + CHAIN_RECLAIM_ONE_CENT_AMOUNT
+            directSourceAmount: IBAN_BRIDGE_EUR_AMOUNT + CHAIN_RECLAIM_ONE_CENT_AMOUNT
         });
 
         const result = await runConsolidation();
@@ -76,7 +72,7 @@ describe('consolidation/iban-bridge-chain-reclaim', () => {
     it('leaves an already reclaimed chain untouched on a repeated consolidation run', async () => {
         const { bridgeExpense, bridgeIncome, directTransfer } = seedChainReclaimFixture({
             consolidationType: TransactionConsolidationTypeEnum.TRANSFER_PAIR,
-            directSourceAmount: CHAIN_RECLAIM_EUR_AMOUNT + CHAIN_RECLAIM_ONE_CENT_AMOUNT
+            directSourceAmount: IBAN_BRIDGE_EUR_AMOUNT + CHAIN_RECLAIM_ONE_CENT_AMOUNT
         });
 
         await runConsolidation();

--- a/tests/consolidation-tests/src/scenarios/iban-bridge-chain-transfer.test.ts
+++ b/tests/consolidation-tests/src/scenarios/iban-bridge-chain-transfer.test.ts
@@ -1,0 +1,76 @@
+import { TransactionConsolidationTypeEnum } from '@budgie/contracts';
+import { describe, expect, it } from 'vitest';
+
+import {
+    expectRevertRestoresSources,
+    fetchLedgerEntry,
+    fetchMovedSourceIds,
+    fetchSingleCanonicalId,
+    revertSingleCanonical
+} from '../harness/consolidation-revert-audit';
+import {
+    IBAN_BRIDGE_EUR_AMOUNT,
+    IBAN_BRIDGE_UAH_AMOUNT,
+    seedIbanBridgeLegs,
+    seedIbanBridgeSourceExpense,
+    seedIbanBridgeTargetIncome,
+    seedIbanBridgeTopology
+} from '../harness/iban-bridge-topology';
+import { runConsolidation } from '../harness/run-consolidation';
+
+const byTransactionId = (left: number, right: number): number => left - right;
+
+const seedIbanBridgeChainFixture = () => {
+    const topology = seedIbanBridgeTopology();
+
+    return {
+        ...topology,
+        ...seedIbanBridgeLegs(topology.bridgeAccount.id, topology.transferMccId),
+        sourceExpense: seedIbanBridgeSourceExpense(topology.sourceAccount.id, topology.transferMccId),
+        targetIncome: seedIbanBridgeTargetIncome(topology.targetAccount.id, topology.transferMccId)
+    };
+};
+
+const fetchChainCanonicalId = (): number => fetchSingleCanonicalId(TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER);
+
+const revertChainCanonical = (): Promise<number> => revertSingleCanonical(TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER);
+
+describe('consolidation/iban-bridge-chain-transfer', () => {
+    it('builds one canonical from the four legs of a bridged chain', async () => {
+        const { bridgeExpense, bridgeIncome, sourceAccount, sourceExpense, targetAccount, targetIncome } = seedIbanBridgeChainFixture();
+
+        const result = await runConsolidation();
+        const canonicalId = fetchChainCanonicalId();
+
+        expect(result.consolidated).toBe(1);
+        expect(fetchMovedSourceIds(canonicalId)).toEqual(
+            [sourceExpense.id, bridgeIncome.id, bridgeExpense.id, targetIncome.id].sort(byTransactionId)
+        );
+        expect(fetchLedgerEntry(canonicalId, sourceAccount.id).amount).toBe(IBAN_BRIDGE_EUR_AMOUNT);
+        expect(fetchLedgerEntry(canonicalId, targetAccount.id).amount).toBe(IBAN_BRIDGE_UAH_AMOUNT);
+    });
+
+    it('restores all four chain legs and account balances when the chain canonical is reverted', async () => {
+        const { bridgeAccount, bridgeExpense, bridgeIncome, sourceAccount, sourceExpense, targetAccount, targetIncome } =
+            seedIbanBridgeChainFixture();
+
+        await expectRevertRestoresSources({
+            accountIds: [sourceAccount.id, bridgeAccount.id, targetAccount.id],
+            consolidationType: TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER,
+            sourceTransactionIds: [sourceExpense.id, bridgeIncome.id, bridgeExpense.id, targetIncome.id]
+        });
+    });
+
+    it('rebuilds the same chain canonical shape after a revert', async () => {
+        const { sourceExpense, bridgeIncome, bridgeExpense, targetIncome } = seedIbanBridgeChainFixture();
+
+        await runConsolidation();
+        await revertChainCanonical();
+        const repeatedResult = await runConsolidation();
+
+        expect(repeatedResult.consolidated).toBe(1);
+        expect(fetchMovedSourceIds(fetchChainCanonicalId())).toEqual(
+            [sourceExpense.id, bridgeIncome.id, bridgeExpense.id, targetIncome.id].sort(byTransactionId)
+        );
+    });
+});

--- a/tests/consolidation-tests/src/scenarios/iban-bridge-transfer.test.ts
+++ b/tests/consolidation-tests/src/scenarios/iban-bridge-transfer.test.ts
@@ -1,0 +1,67 @@
+import { TransactionConsolidationTypeEnum } from '@budgie/contracts';
+import { describe, expect, it } from 'vitest';
+
+import {
+    expectConsolidationParent,
+    expectRevertRestoresSources,
+    fetchLedgerEntry,
+    fetchMovedSourceIds,
+    fetchSingleCanonicalId,
+    revertSingleCanonical
+} from '../harness/consolidation-revert-audit';
+import {
+    IBAN_BRIDGE_EUR_AMOUNT,
+    IBAN_BRIDGE_TARGET_IBAN,
+    IBAN_BRIDGE_UAH_AMOUNT,
+    seedIbanBridgeLegs,
+    seedIbanBridgeTopology
+} from '../harness/iban-bridge-topology';
+import { runConsolidation } from '../harness/run-consolidation';
+
+const byTransactionId = (left: number, right: number): number => left - right;
+
+const seedIbanBridgeTransferFixture = () => {
+    const topology = seedIbanBridgeTopology();
+
+    return { ...topology, ...seedIbanBridgeLegs(topology.bridgeAccount.id, topology.transferMccId) };
+};
+
+describe('consolidation/iban-bridge-transfer', () => {
+    it('builds a source to target canonical from two bridge legs', async () => {
+        const { bridgeExpense, bridgeIncome, sourceAccount, targetAccount } = seedIbanBridgeTransferFixture();
+
+        const result = await runConsolidation();
+        const canonicalId = fetchSingleCanonicalId(TransactionConsolidationTypeEnum.IBAN_BRIDGE_TRANSFER);
+
+        expect(result.consolidated).toBe(1);
+        expectConsolidationParent(bridgeIncome.id, canonicalId);
+        expectConsolidationParent(bridgeExpense.id, canonicalId);
+        expect(fetchMovedSourceIds(canonicalId)).toEqual([bridgeIncome.id, bridgeExpense.id].sort(byTransactionId));
+        expect(fetchLedgerEntry(canonicalId, sourceAccount.id).amount).toBe(IBAN_BRIDGE_EUR_AMOUNT);
+        expect(fetchLedgerEntry(canonicalId, sourceAccount.id).toIban).toBe(IBAN_BRIDGE_TARGET_IBAN);
+        expect(fetchLedgerEntry(canonicalId, targetAccount.id).amount).toBe(IBAN_BRIDGE_UAH_AMOUNT);
+    });
+
+    it('restores both bridge legs and account balances when the bridge canonical is reverted', async () => {
+        const { bridgeAccount, bridgeExpense, bridgeIncome, sourceAccount, targetAccount } = seedIbanBridgeTransferFixture();
+
+        await expectRevertRestoresSources({
+            accountIds: [sourceAccount.id, bridgeAccount.id, targetAccount.id],
+            consolidationType: TransactionConsolidationTypeEnum.IBAN_BRIDGE_TRANSFER,
+            sourceTransactionIds: [bridgeIncome.id, bridgeExpense.id]
+        });
+    });
+
+    it('rebuilds the same bridge canonical shape after a revert', async () => {
+        const { bridgeExpense, bridgeIncome } = seedIbanBridgeTransferFixture();
+
+        await runConsolidation();
+        await revertSingleCanonical(TransactionConsolidationTypeEnum.IBAN_BRIDGE_TRANSFER);
+        const repeatedResult = await runConsolidation();
+
+        expect(repeatedResult.consolidated).toBe(1);
+        expect(fetchMovedSourceIds(fetchSingleCanonicalId(TransactionConsolidationTypeEnum.IBAN_BRIDGE_TRANSFER))).toEqual(
+            [bridgeIncome.id, bridgeExpense.id].sort(byTransactionId)
+        );
+    });
+});

--- a/tests/consolidation-tests/src/scenarios/same-bank-hinted-fee-transfer.test.ts
+++ b/tests/consolidation-tests/src/scenarios/same-bank-hinted-fee-transfer.test.ts
@@ -1,12 +1,15 @@
 import { ExternalSourceEnum, PRECISION, TransactionConsolidationTypeEnum } from '@budgie/contracts';
 import { describe, expect, it } from 'vitest';
 
+import { expectRevertRestoresSources } from '../harness/consolidation-revert-audit';
 import { runConsolidation } from '../harness/run-consolidation';
 import { testQueryService, testSeedService } from '../harness/test-context';
 
 const TRANSFER_AMOUNT = 10_000 * PRECISION;
-const TRANSFER_WITH_FEE_AMOUNT = 10_300 * PRECISION;
-const TOO_LARGE_FEE_AMOUNT = 10_600 * PRECISION;
+const TRANSFER_FEE_DELTA_AMOUNT = 300 * PRECISION;
+const TRANSFER_WITH_FEE_AMOUNT = TRANSFER_AMOUNT + TRANSFER_FEE_DELTA_AMOUNT;
+const TOO_LARGE_FEE_AMOUNT = TRANSFER_AMOUNT + 600 * PRECISION;
+const HINTED_FEE_OPERATED_AT = new Date('2026-05-14T11:30:00');
 const SOURCE_CARD_SUFFIX = '0356';
 const TARGET_CARD_SUFFIX = '5524';
 const PRIVATBANK_FAKE_IBAN_PREFIX = 'UA1111111';
@@ -17,10 +20,10 @@ const seedPrivatbankAccount = (suffix: string, externalSource: ExternalSourceEnu
 const seedPrivatbankFeeTransfer = (
     incomeTitle: string = `Зі своєї картки *${SOURCE_CARD_SUFFIX}`,
     expenseAmount: number = TRANSFER_WITH_FEE_AMOUNT,
-    incomeOperatedAt: Date = new Date(2026, 4, 14, 11, 30, 0),
+    incomeOperatedAt: Date = HINTED_FEE_OPERATED_AT,
     externalSource: ExternalSourceEnum | null = ExternalSourceEnum.PRIVATBANK
 ) => {
-    const operatedAt = new Date(2026, 4, 14, 11, 30, 0);
+    const operatedAt = HINTED_FEE_OPERATED_AT;
     const transferMcc = testQueryService.findMccByCode('4829');
     const sourceAccount = seedPrivatbankAccount(SOURCE_CARD_SUFFIX, externalSource);
     const targetAccount = seedPrivatbankAccount(TARGET_CARD_SUFFIX, externalSource);
@@ -68,7 +71,7 @@ const expectPrivatbankFeeTransferConsolidated = async (
     const { expense, income, sourceAccount, targetAccount } = seedPrivatbankFeeTransfer(
         `Зі своєї картки *${SOURCE_CARD_SUFFIX}`,
         TRANSFER_WITH_FEE_AMOUNT,
-        new Date(2026, 4, 14, 11, 30, 0),
+        HINTED_FEE_OPERATED_AT,
         externalSource
     );
 
@@ -84,6 +87,16 @@ describe('consolidation/same-bank-hinted-fee-transfer', () => {
 
     it('auto-consolidates legacy same-bank own-card transfers when account source is missing but IBAN bank prefix matches', async () => {
         await expectPrivatbankFeeTransferConsolidated(null);
+    });
+
+    it('restores both hinted fee transfer sides and account balances when the canonical is reverted', async () => {
+        const { expense, income, sourceAccount, targetAccount } = seedPrivatbankFeeTransfer();
+
+        await expectRevertRestoresSources({
+            accountIds: [sourceAccount.id, targetAccount.id],
+            consolidationType: TransactionConsolidationTypeEnum.SAME_BANK_HINTED_FEE_TRANSFER,
+            sourceTransactionIds: [expense.id, income.id]
+        });
     });
 
     it('leaves a hinted transfer unconsolidated when the reciprocal account hint does not match', async () => {
@@ -105,11 +118,10 @@ describe('consolidation/same-bank-hinted-fee-transfer', () => {
     });
 
     it('leaves a hinted transfer unconsolidated when the matching transactions are not close in time', async () => {
-        const operatedAt = new Date(2026, 4, 14, 11, 30, 0);
         const { expense, income } = seedPrivatbankFeeTransfer(
             `Зі своєї картки *${SOURCE_CARD_SUFFIX}`,
             TRANSFER_WITH_FEE_AMOUNT,
-            new Date(operatedAt.getTime() + 3 * 60 * 1000)
+            new Date(HINTED_FEE_OPERATED_AT.getTime() + 3 * 60 * 1000)
         );
 
         const result = await runConsolidation();

--- a/tests/consolidation-tests/src/scenarios/unconsolidate-nested-canonical.test.ts
+++ b/tests/consolidation-tests/src/scenarios/unconsolidate-nested-canonical.test.ts
@@ -1,0 +1,72 @@
+import { TransactionConsolidationTypeEnum } from '@budgie/contracts';
+import { describe, expect, it } from 'vitest';
+
+import { CHAIN_RECLAIM_STALE_RATE_MULTIPLIER, seedNestedChainReclaimFixture } from '../harness/chain-reclaim-fixture';
+import {
+    expectCanonicalDeleted,
+    expectRevertRemovedCanonical,
+    expectSourcesRestored,
+    fetchLedgerBalances,
+    fetchMovedSourceIds,
+    fetchOwnLedgerEntries,
+    fetchSingleCanonicalId
+} from '../harness/consolidation-revert-audit';
+import { IBAN_BRIDGE_SOURCE_IBAN, IBAN_BRIDGE_UAH_TO_EUR_RATE } from '../harness/iban-bridge-topology';
+import { runConsolidation } from '../harness/run-consolidation';
+import { testDb, testQueryService, unconsolidationService } from '../harness/test-context';
+
+const NESTED_PAIR_LEDGER_ENTRY_COUNT = 2;
+const STALE_DIRECT_TRANSFER = {
+    directExchangeRate: IBAN_BRIDGE_UAH_TO_EUR_RATE * CHAIN_RECLAIM_STALE_RATE_MULTIPLIER,
+    directToIban: IBAN_BRIDGE_SOURCE_IBAN
+};
+
+const byTransactionId = (left: number, right: number): number => left - right;
+
+const expectRestoredNestedPair = (pairTransactionId: number, childTransactionIds: number[]): void => {
+    const restoredPair = testQueryService.fetchTransactionById(pairTransactionId);
+
+    expect(restoredPair.consolidationParentTransactionId).toBeNull();
+    expect(restoredPair.deletedAt).toBeNull();
+    expect(restoredPair.consolidationType).toBe(TransactionConsolidationTypeEnum.TRANSFER_PAIR);
+    expect(fetchOwnLedgerEntries(pairTransactionId)).toHaveLength(NESTED_PAIR_LEDGER_ENTRY_COUNT);
+    expect(testQueryService.fetchChildTransactionIds(pairTransactionId).sort(byTransactionId)).toEqual(
+        [...childTransactionIds].sort(byTransactionId)
+    );
+    expect(fetchMovedSourceIds(pairTransactionId)).toEqual([...childTransactionIds].sort(byTransactionId));
+};
+
+describe('consolidation/unconsolidate-nested-canonical', () => {
+    it('restores the nested transfer pair with its own children when the rebuilt outer canonical is reverted', async () => {
+        const { bridgeExpense, bridgeIncome, directTransfer, sourceExpense, targetIncome } =
+            await seedNestedChainReclaimFixture(STALE_DIRECT_TRANSFER);
+
+        await runConsolidation();
+        const outerCanonicalId = fetchSingleCanonicalId(TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER);
+        await unconsolidationService.unconsolidateById(outerCanonicalId, testDb);
+
+        expect(outerCanonicalId).not.toBe(directTransfer.id);
+        expectCanonicalDeleted(outerCanonicalId);
+        expectRestoredNestedPair(directTransfer.id, [sourceExpense.id, targetIncome.id]);
+        expectSourcesRestored([bridgeIncome.id, bridgeExpense.id]);
+    });
+
+    it('restores the raw chain sources when the restored nested transfer pair is reverted in turn', async () => {
+        const { bridgeAccount, directTransfer, sourceAccount, sourceExpense, targetAccount, targetIncome } =
+            await seedNestedChainReclaimFixture(STALE_DIRECT_TRANSFER);
+        const accountIds = [sourceAccount.id, bridgeAccount.id, targetAccount.id];
+        const balancesBeforeConsolidation = await fetchLedgerBalances(accountIds);
+
+        await runConsolidation();
+        await unconsolidationService.unconsolidateById(
+            fetchSingleCanonicalId(TransactionConsolidationTypeEnum.IBAN_BRIDGE_CHAIN_TRANSFER),
+            testDb
+        );
+        expect(await fetchLedgerBalances(accountIds)).toEqual(balancesBeforeConsolidation);
+
+        await unconsolidationService.unconsolidateById(directTransfer.id, testDb);
+
+        expectRevertRemovedCanonical(directTransfer.id, [sourceExpense.id, targetIncome.id]);
+        expect(await fetchLedgerBalances(accountIds)).toEqual(balancesBeforeConsolidation);
+    });
+});

--- a/tests/consolidation-tests/src/scenarios/unconsolidate-refund-restores-sources.test.ts
+++ b/tests/consolidation-tests/src/scenarios/unconsolidate-refund-restores-sources.test.ts
@@ -1,6 +1,7 @@
 import { PRECISION, TransactionConsolidationTypeEnum } from '@budgie/contracts';
 import { describe, expect, it } from 'vitest';
 
+import { expectSourcesRestored, fetchLedgerBalances } from '../harness/consolidation-revert-audit';
 import {
     REJECTED_PAYMENT_EXPENSE_AMOUNT,
     REJECTED_PAYMENT_FEE_AMOUNT,
@@ -30,6 +31,28 @@ describe('consolidation/unconsolidate-refund-restores-sources', () => {
 
         const restoredRefund = testQueryService.fetchTransactionById(refunds[0].id);
         expect(restoredRefund.consolidationParentTransactionId).toBeNull();
+    });
+
+    it('keeps tags copied from the refund income on the expense after unconsolidating a refund', async () => {
+        const tag = testSeedService.tag('Refunded order');
+        const { account, expense, refunds } = await runRefundScenario({
+            beforeConsolidation: ({ refunds }) => {
+                testSeedService.transactionTag(refunds[0].id, tag.id);
+            },
+            expenseAmount: STANDALONE_REFUND_EXPENSE_AMOUNT_UAH * PRECISION,
+            externalIdPrefix: 'refund-tag-revert',
+            refundAmounts: [STANDALONE_REFUND_EXPENSE_AMOUNT_UAH * PRECISION]
+        });
+        const balancesAfterConsolidation = await fetchLedgerBalances([account.id]);
+
+        expect(testQueryService.fetchTransactionTagIds(expense.id)).toEqual([tag.id]);
+
+        await unconsolidationService.unconsolidateById(expense.id, testDb);
+
+        expectSourcesRestored([refunds[0].id]);
+        expect(testQueryService.fetchTransactionById(expense.id).consolidationType).toBeNull();
+        expect(testQueryService.fetchTransactionTagIds(expense.id)).toEqual([tag.id]);
+        expect(await fetchLedgerBalances([account.id])).toEqual(balancesAfterConsolidation);
     });
 
     it('restores both refund incomes and their original DEBIT entries after unconsolidating a two-income rejected-payment expense', async () => {

--- a/tests/consolidation-tests/src/scenarios/unconsolidate-restores-sources.test.ts
+++ b/tests/consolidation-tests/src/scenarios/unconsolidate-restores-sources.test.ts
@@ -1,34 +1,55 @@
 import { PRECISION, TransactionConsolidationTypeEnum } from '@budgie/contracts';
 import { describe, expect, it } from 'vitest';
 
+import {
+    expectRevertRemovedCanonical,
+    fetchLedgerBalances,
+    fetchSingleCanonicalId,
+    revertSingleCanonical
+} from '../harness/consolidation-revert-audit';
 import { runConsolidation } from '../harness/run-consolidation';
-import { testDb, testQueryService, testSeedService, unconsolidationService } from '../harness/test-context';
+import { testQueryService, testSeedService } from '../harness/test-context';
+
+const TRANSFER_PAIR_AMOUNT = 250 * PRECISION;
 
 describe('consolidation/unconsolidate-restores-sources', () => {
     it('deletes the canonical transfer and restores source ledger entries', async () => {
         const transferMcc = testQueryService.findMccByCode('4829');
-        const { expense, income } = testSeedService.amountTransferPair(250 * PRECISION, transferMcc.id);
+        const { expense, income } = testSeedService.amountTransferPair(TRANSFER_PAIR_AMOUNT, transferMcc.id);
 
         const result = await runConsolidation();
         expect(result.consolidated).toBe(1);
 
-        const canonical = testQueryService.fetchCanonicalsOfType(TransactionConsolidationTypeEnum.TRANSFER_PAIR)[0];
-        expect(canonical).toBeDefined();
+        const canonicalId = await revertSingleCanonical(TransactionConsolidationTypeEnum.TRANSFER_PAIR);
 
-        await unconsolidationService.unconsolidateById(canonical.id, testDb);
-
-        expect(testQueryService.fetchCanonicalsOfType(TransactionConsolidationTypeEnum.TRANSFER_PAIR)).toHaveLength(0);
-        expect(testQueryService.fetchTransactionById(expense.id).consolidationParentTransactionId).toBeNull();
-        expect(testQueryService.fetchTransactionById(income.id).consolidationParentTransactionId).toBeNull();
-
-        const expenseEntry = testQueryService.fetchEntryByExternalId('tx-expense');
-        const incomeEntry = testQueryService.fetchEntryByExternalId('tx-income');
-        expect(expenseEntry.transactionId).toBe(expense.id);
-        expect(expenseEntry.originalTransactionId).toBeNull();
-        expect(incomeEntry.transactionId).toBe(income.id);
-        expect(incomeEntry.originalTransactionId).toBeNull();
+        expectRevertRemovedCanonical(canonicalId, [expense.id, income.id]);
+        expect(testQueryService.fetchEntryByExternalId('tx-expense').transactionId).toBe(expense.id);
+        expect(testQueryService.fetchEntryByExternalId('tx-income').transactionId).toBe(income.id);
 
         const secondResult = await runConsolidation();
         expect(secondResult.consolidated).toBe(1);
+    });
+
+    it('keeps source tags on the sources and restores account balances when the canonical transfer is reverted', async () => {
+        const { expense, fromAccount, income, toAccount } = testSeedService.amountTransferPair(
+            TRANSFER_PAIR_AMOUNT,
+            testQueryService.findMccByCode('4829').id
+        );
+        const tag = testSeedService.tag('Travel');
+        const accountIds = [fromAccount.id, toAccount.id];
+
+        testSeedService.transactionTag(expense.id, tag.id);
+        const balancesBeforeConsolidation = await fetchLedgerBalances(accountIds);
+
+        await runConsolidation();
+        const canonicalId = fetchSingleCanonicalId(TransactionConsolidationTypeEnum.TRANSFER_PAIR);
+
+        expect(testQueryService.fetchTransactionTagIds(canonicalId)).toEqual([]);
+
+        await revertSingleCanonical(TransactionConsolidationTypeEnum.TRANSFER_PAIR);
+
+        expectRevertRemovedCanonical(canonicalId, [expense.id, income.id]);
+        expect(testQueryService.fetchTransactionTagIds(expense.id)).toEqual([tag.id]);
+        expect(await fetchLedgerBalances(accountIds)).toEqual(balancesBeforeConsolidation);
     });
 });

--- a/tests/test-kit/src/query/service/test-query.service.ts
+++ b/tests/test-kit/src/query/service/test-query.service.ts
@@ -23,13 +23,28 @@ export class TestQueryService {
     }
 
     fetchTransactionById(id: number): TransactionEntityInterface {
-        const row = this.database.select().from(TransactionEntityTable).where(eq(TransactionEntityTable.id, id)).all()[0];
+        const row = this.findTransactionById(id);
 
         if (!isDefined(row)) {
             throw new Error(`Transaction ${id} not found`);
         }
 
         return row;
+    }
+
+    findTransactionById(id: number): TransactionEntityInterface | undefined {
+        const [row] = this.database.select().from(TransactionEntityTable).where(eq(TransactionEntityTable.id, id)).all();
+
+        return row;
+    }
+
+    fetchChildTransactionIds(parentTransactionId: number): number[] {
+        return this.database
+            .select({ id: TransactionEntityTable.id })
+            .from(TransactionEntityTable)
+            .where(eq(TransactionEntityTable.consolidationParentTransactionId, parentTransactionId))
+            .all()
+            .map(row => row.id);
     }
 
     fetchEntriesByTransactionId(transactionId: number): TransactionEntryEntityInterface[] {
@@ -41,11 +56,11 @@ export class TestQueryService {
     }
 
     fetchEntryByExternalId(externalId: string): TransactionEntryEntityInterface {
-        const row = this.database
+        const [row] = this.database
             .select()
             .from(TransactionEntryEntityTable)
             .where(eq(TransactionEntryEntityTable.externalId, externalId))
-            .all()[0];
+            .all();
 
         if (!isDefined(row)) {
             throw new Error(`Transaction entry ${externalId} not found`);
@@ -64,7 +79,7 @@ export class TestQueryService {
     }
 
     findMccByCode(mcc: string): Pick<MccCategoryEntityInterface, 'id' | 'mccGroupId'> {
-        const row = this.database.select().from(MccCategoryEntityTable).where(eq(MccCategoryEntityTable.mcc, mcc)).all()[0];
+        const [row] = this.database.select().from(MccCategoryEntityTable).where(eq(MccCategoryEntityTable.mcc, mcc)).all();
 
         if (!isDefined(row)) {
             throw new Error(`MCC ${mcc} not found`);

--- a/tests/test-kit/src/seed/service/test-seed.service.ts
+++ b/tests/test-kit/src/seed/service/test-seed.service.ts
@@ -380,6 +380,10 @@ export class TestSeedService {
         return this.requireInserted(rows, 'transactions');
     }
 
+    feeEntry(transactionId: number, externalId: string | null, entry: SeedBankPairEntryInputType): void {
+        this.insertEntry(transactionId, TransactionEntryTypeEnum.FEE, externalId, entry);
+    }
+
     private expenseTransaction(
         transaction: Pick<TransactionCreateEntityInterface, 'externalId' | 'operatedAt' | 'title'>,
         entry: SeedBankPairEntryInputType


### PR DESCRIPTION
## What / Why

P0 of the approved #609 spec: every consolidation family now has a reversibility test asserting that `consolidate → unconsolidateById` restores its sources cleanly (rows unparented and undeleted, entries back on their original transactions with `original_transaction_id IS NULL`, canonical deleted or preserved per family semantics, tags per family semantics) plus **account balances back to the pre-consolidate snapshot**, computed through the production ledger SQL (`AccountBalanceRepository.getNewTransactionEntriesDeltas`, which reuses `accountBalanceLedgerSqlBuilder`) rather than a test-local reimplementation.

Tests only. No schema, app, or product-code changes.

## Coverage matrix

Families enumerated from `packages/consolidation/src/auto/service/consolidation-family-registry.service.ts` (registry order).

| # | Family | Forward before | Forward after | Revert before | Revert after |
| --- | --- | --- | --- | --- | --- |
| 1 | `IBAN_BRIDGE_CHAIN_TRANSFER` | none (bank-sync-tests only) | `iban-bridge-chain-transfer.test.ts` | **none** | ✅ + idempotence rebuild |
| 2 | `EXISTING_TRANSFER_BRIDGE` | **none** | `existing-transfer-bridge.test.ts` | **none** | ✅ (pre-existing transfer preserved) |
| 3 | `EXISTING_TRANSFER_CHAIN_RECLAIM` | yes (2 files) | unchanged + strengthened | yes (fast path + rebuild) | ✅ strengthened (balances, absorbed-pair deletion pinned) |
| 4 | `IBAN_BRIDGE_CANONICAL_DUPLICATE` | **none** | `iban-bridge-canonical-duplicate.test.ts` | **none** | ✅ |
| 5 | `IBAN_BRIDGE_TRANSFER` | negative assertions only | `iban-bridge-transfer.test.ts` | **none** | ✅ + idempotence rebuild |
| 6 | `EXISTING_TRANSFER_INCOME_DUPLICATE` | **none** | `existing-transfer-income-duplicate.test.ts` | **none** | ⚠️ current behavior pinned — see finding 1 |
| 7 | `TRANSFER_PAIR` | yes (9 files) | unchanged | yes | ✅ + tags + balances |
| 7b | `SAME_BANK_HINTED_FEE_TRANSFER` variant | yes | unchanged | **none** | ✅ |
| 8 | `ATM_CASH_WITHDRAWAL` | none (bank-sync-tests only) | `atm-cash-withdrawal.test.ts` (incl. fee entry) | **none** | ✅ (cash balance cleared, fee entry restored) |
| 9 | `REFUND` | yes (13 files) | unchanged | yes | ✅ + tags — see finding 3 |
| — | Nested canonical (#651) | partial | `unconsolidate-nested-canonical.test.ts` | **none** | ✅ two-level revert |

Suite: **27 files / 76 tests → 34 files / 95 tests**, all green, zero regressions.
`tests/bank-sync-tests` (touched `tests/test-kit`): 54 files / 188 tests ✅. `tests/budget-tests`: 6 / 10 ✅.

## Nested-canonical case from #651

`unconsolidate-nested-canonical.test.ts` seeds a generated `TRANSFER_PAIR` that already owns two children (source expense + target income), makes its ledger diverge so chain reclaim takes the **rebuild** path, and asserts:

1. reverting the **outer** `IBAN_BRIDGE_CHAIN_TRANSFER` canonical deletes only the outer row and restores the inner `TRANSFER_PAIR` as a live canonical — `consolidation_type = TRANSFER_PAIR`, unparented, its own 2 ledger entries back, and **still parenting its original legs** (`fetchChildTransactionIds` + `fetchMovedSourceIds` both assert the two grandchildren, so children are provably not leaves);
2. a second `unconsolidateById` on the restored inner pair then deletes it and restores the raw sources fully;
3. account balances equal the pre-consolidate snapshot after **both** revert levels.

## Findings for the P1 repair work (#654)

### 1. `EXISTING_TRANSFER_INCOME_DUPLICATE` revert destroys the pre-existing transfer and corrupts balances

`ConsolidationRepairExecutorService.consolidateExistingTransferIncomeDuplicateInner` absorbs the duplicate income **in place**: it mutates the pre-existing transfer (`exchangeRate`, `toAccountId`, target entry `accountId`/`amount`/`exchangeRate`), retypes it to `TRANSFER_PAIR`, and parents the income under it. `UnconsolidationService.unconsolidateById` then treats that row as a generated canonical (it is not `REFUND`), so it deletes the ledger and **hard-deletes the user's transfer**; the in-place mutations are never reversed.

Evidence — `existing-transfer-income-duplicate.test.ts`, `deletes the pre-existing transfer instead of restoring it when the absorbed income duplicate is reverted`, pinning current behavior:

```
before consolidate: [[source, -500e6], [target, +1000e6]]
after revert:       [[source,     0],  [target,  +500e6]]   // transfer row gone
```

The SQL admits `existing_transfer.consolidation_type IS NULL`, i.e. **hand-created transfers are eligible**, so this is user-data loss, not just an engine-generated row. Reachable from `transactionService.unconsolidateById` (Revert button), `transactionService.deleteById` on a consolidated transaction, `resyncBankSyncService` bulk unconsolidation, and account deletion.

### 2. Absorb-in-place families cannot revert one level

`EXISTING_TRANSFER_CHAIN_RECLAIM` fast path retypes the existing `TRANSFER_PAIR` to `IBAN_BRIDGE_CHAIN_TRANSFER` in place. Reverting that canonical therefore unwinds **two** consolidation levels at once and deletes the absorbed pair — the opposite of the rebuild path, whose revert restores the pair (invariant asserted in #651). Pinned by `unwinds both consolidation levels and deletes the absorbed transfer pair when a fast-path reclaim is reverted`. Balances *are* restored here (the pair's ledger and its children's entries carry identical amounts), so this is an entity-identity loss rather than a balance bug. `IBAN_BRIDGE_CANONICAL_DUPLICATE` shares the shape: revert returns everything to the fully-raw state, discarding the earlier bridge consolidation.

Related and unfixed: `transactionRepository.setConsolidationType` is a no-op on parented rows (`WHERE id = ? AND consolidation_parent_transaction_id IS NULL`), so a repair that wants to retype a nested canonical must clear its parent first — this is exactly why the in-place retype above cannot be undone by a type write.

### 3. `REFUND` revert leaves copied tags on the expense

`consolidateRefundInner` copies the refund incomes' tags onto the expense; `unconsolidateById` returns early for `REFUND` **before** `transactionTagsRepository.deleteByTransactionId`, so the copies survive the revert. Blanket-deleting is not the fix (the expense is a real user transaction with its own tags) — the copies need to be identifiable. Pinned by `keeps tags copied from the refund income on the expense after unconsolidating a refund`. Transfer-like families copy no tags and leave source tags untouched, asserted in `unconsolidate-restores-sources.test.ts`.

### 4. Verified clean

`TRANSFER_PAIR`, `SAME_BANK_HINTED_FEE_TRANSFER`, `IBAN_BRIDGE_TRANSFER`, `IBAN_BRIDGE_CHAIN_TRANSFER`, `ATM_CASH_WITHDRAWAL`, `EXISTING_TRANSFER_BRIDGE` (nests and then restores a hand-created transfer with `consolidation_type` still `NULL` and its own 2-entry ledger), `IBAN_BRIDGE_CANONICAL_DUPLICATE`, and both reclaim revert paths all restore sources, entries, and balances. The canonical-duplicate forward test additionally pins the repair value: balances go from the double-counted `[-2×EUR, 0, +2×UAH]` to the correct `[-EUR, 0, +UAH]`.

## Harness

Shared audit primitives live in `tests/consolidation-tests/src/harness/consolidation-revert-audit.ts` (`expectRevertRestoresSources`, `expectRevertRemovedCanonical`, `expectSourcesRestored`, `expectCanonicalDeleted`, `fetchOwnLedgerEntries`/`fetchMovedSourceIds` ledger partition promoted out of the chain-reclaim fixture, `fetchLedgerBalances`, `revertSingleCanonical`, `fetchSingleCanonicalId`). The IBAN-bridge account/leg topology shared by five fixtures moved to `harness/iban-bridge-topology.ts`; `chain-reclaim-fixture.ts` now composes it and gained a nested rebuild variant. Family-specific seeds stay in their single consumer scenario per repo rule 52, and only generic, multi-suite capabilities went into `tests/test-kit` (`TestQueryService.findTransactionById` / `fetchChildTransactionIds`, `TestSeedService.feeEntry`).

`yarn cpd` reports 0 clones: the repeated revert body is the single `expectRevertRestoresSources` helper rather than copies per scenario.

## Validation

`yarn format && yarn ts && yarn lint && yarn deadcode && yarn cpd` — all clean, 0 clones, no new eslint-disables. Two pre-existing lint violations in files this PR touches were fixed in passing (`no-magic-numbers` in `same-bank-hinted-fee-transfer.test.ts`, `prefer-destructuring` in `test-query.service.ts`); `TRANSFER_WITH_FEE_AMOUNT` / `TOO_LARGE_FEE_AMOUNT` keep their original values (10 300 / 10 600) expressed as deltas over `TRANSFER_AMOUNT`.

Fixes #653
Part of epic #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for consolidating and reverting ATM cash withdrawals, IBAN bridge transfers, duplicate transfers, chained transfers, and nested canonical transactions.
  - Verified canonical transaction creation, parent relationships, ledger values, source restoration, balance preservation, repeatability, and cleanup after reversion.
  - Added regression coverage for refund metadata, hinted fees, stale exchange rates, and existing-transfer scenarios.
  - Improved shared test utilities for transaction lookup, child discovery, fee entries, topology setup, and consolidation-revert auditing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->