### PR TITLE
chore: add t3 project file with the app icon

### DIFF
--- a/t3.json
+++ b/t3.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://t3.codes/schema/t3.json",
+    "iconPath": "packages/app/assets/icons/ios-light.png"
+}


### PR DESCRIPTION
Adds a root t3.json pointing iconPath at the existing iOS app icon so tooling that reads the project file shows the Budgie icon instead of a generic folder glyph.